### PR TITLE
Stop to use deprecated property in CI.

### DIFF
--- a/.github/workflows/ci_on_pullrequest.yml
+++ b/.github/workflows/ci_on_pullrequest.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python 3.7 for awscli
         uses: actions/setup-python@v1
         with:
-          version: '3.7'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install awscli
         run: pip install --upgrade pip awscli

--- a/.github/workflows/create_release_docker_image.yml
+++ b/.github/workflows/create_release_docker_image.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python 3.7 for awscli
         uses: actions/setup-python@v1
         with:
-          version: '3.7'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install awscli
         run: pip install --upgrade pip awscli

--- a/.github/workflows/update_docker_master_image.yml
+++ b/.github/workflows/update_docker_master_image.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python 3.7 for awscli
         uses: actions/setup-python@v1
         with:
-          version: '3.7'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install awscli
         run: pip install --upgrade pip awscli


### PR DESCRIPTION
"version" property is deprecated in setup-python action. So, we should use the new property "python-version".

I changed according to this.