### PR TITLE
Fix parsing version messages which is received from network.

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -344,7 +344,12 @@ public:
         int nVersion = s.GetVersion();
         if (s.GetType() & SER_DISK)
             READWRITE(nVersion);
-        if (!(s.GetType() & SER_GETHASH))
+
+        // For network serialization, ADDR message includes nTime but VERSION message doesn't include it.
+        // To ensure it is VERSION message, checking `nVersion > INIT_PROTO_VERSION` because nVersion is not set actual
+        // value when parsing VERSION message payload. nVersion is initialized with INIT_PROTO_VERSION at that time.
+        if ((s.GetType() & SER_DISK) ||
+             ((s.GetType() & SER_NETWORK) && nVersion > INIT_PROTO_VERSION))
             READWRITE(nTime);
         uint64_t nServicesInt = nServices;
         READWRITE(nServicesInt);

--- a/src/version.h
+++ b/src/version.h
@@ -22,7 +22,7 @@
 static const int PROTOCOL_VERSION = 10000;
 
 //! initial proto version, to be increased after version/verack negotiation
-static const int INIT_PROTO_VERSION = 10000;
+static const int INIT_PROTO_VERSION = 1227;
 
 //! disconnect from peers older than this proto version
 static const int MIN_PEER_PROTO_VERSION = PROTOCOL_VERSION;

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -924,11 +924,11 @@ class msg_version():
         self.nServices = struct.unpack("<Q", f.read(8))[0]
         self.nTime = struct.unpack("<q", f.read(8))[0]
         self.addrTo = CAddress()
-        self.addrTo.deserialize(f, True)
+        self.addrTo.deserialize(f, False)
 
         if self.nVersion >= 106:
             self.addrFrom = CAddress()
-            self.addrFrom.deserialize(f, True)
+            self.addrFrom.deserialize(f, False)
             self.nNonce = struct.unpack("<Q", f.read(8))[0]
             self.strSubVer = deser_string(f)
         else:
@@ -956,8 +956,8 @@ class msg_version():
         r += struct.pack("<i", self.nVersion)
         r += struct.pack("<Q", self.nServices)
         r += struct.pack("<q", self.nTime)
-        r += self.addrTo.serialize(True)
-        r += self.addrFrom.serialize(True)
+        r += self.addrTo.serialize(False)
+        r += self.addrFrom.serialize(False)
         r += struct.pack("<Q", self.nNonce)
         r += ser_string(self.strSubVer)
         r += struct.pack("<i", self.nStartingHeight)


### PR DESCRIPTION
The version message from network doesn't have time field.

It seems like this bug came from a change for Tapyrus. So, I put it back to bitcoin's way.