### PR TITLE
Change currency unit to TPC

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -7,7 +7,7 @@
 
 #include <tinyformat.h>
 
-const std::string CURRENCY_UNIT = "BTC";
+const std::string CURRENCY_UNIT = "TPC";
 
 CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nBytes_)
 {


### PR DESCRIPTION
RPC help document still includes "BTC". This PR changes it to "TPC".