### PR TITLE
Remove Coinbase maturity limitation from Tapyrus.

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -86,14 +86,13 @@ static void AssembleBlock(benchmark::State& state)
 
     // Collect some loose transactions that spend the coinbases of our mined blocks
     constexpr size_t NUM_BLOCKS{200};
-    std::array<CTransactionRef, NUM_BLOCKS - COINBASE_MATURITY + 1> txs;
+    std::array<CTransactionRef, NUM_BLOCKS> txs;
     for (size_t b{0}; b < NUM_BLOCKS; ++b) {
         CMutableTransaction tx;
         tx.vin.push_back(MineBlock(SCRIPT_PUB));
         tx.vin.back().scriptWitness = witness;
         tx.vout.emplace_back(1337, SCRIPT_PUB);
-        if (NUM_BLOCKS - b >= COINBASE_MATURITY)
-            txs.at(b) = MakeTransactionRef(tx);
+        txs.at(b) = MakeTransactionRef(tx);
     }
     {
         LOCK(::cs_main); // Required for ::AcceptToMemoryPool.

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -16,8 +16,6 @@ static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;
 static const unsigned int MAX_BLOCK_WEIGHT = 4000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
-/** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
-static const int COINBASE_MATURITY = 100;
 
 static const int WITNESS_SCALE_FACTOR = 4;
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -219,7 +219,7 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
         assert(!coin.IsSpent());
 
         // If prev is coinbase, check that it's matured
-        if (coin.IsCoinBase() && nSpendHeight - coin.nHeight < COINBASE_MATURITY) {
+        if (coin.IsCoinBase() && nSpendHeight <= coin.nHeight) {
             return state.Invalid(false,
                 REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
                 strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -159,8 +159,6 @@ CPubKey CFederationParams::ReadAggregatePubkey(const std::vector<unsigned char>&
 
 bool CFederationParams::ReadGenesisBlock(std::string genesisHex)
 {
-    ECCVerifyHandle globalVerifyHandle;
-
     CDataStream ss(ParseHex(genesisHex), SER_NETWORK, PROTOCOL_VERSION);
     unsigned long streamsize = ss.size();
     ss >> genesis;

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -159,6 +159,8 @@ CPubKey CFederationParams::ReadAggregatePubkey(const std::vector<unsigned char>&
 
 bool CFederationParams::ReadGenesisBlock(std::string genesisHex)
 {
+    ECCVerifyHandle globalVerifyHandle;
+
     CDataStream ss(ParseHex(genesisHex), SER_NETWORK, PROTOCOL_VERSION);
     unsigned long streamsize = ss.size();
     ss >> genesis;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -92,7 +92,6 @@ WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
     auto mi = ::mapBlockIndex.find(wtx.hashBlock);
     CBlockIndex* block = mi != ::mapBlockIndex.end() ? mi->second : nullptr;
     result.block_height = (block ? block->nHeight : std::numeric_limits<int>::max());
-    result.blocks_to_maturity = wtx.GetBlocksToMaturity();
     result.depth_in_main_chain = wtx.GetDepthInMainChain();
     result.time_received = wtx.nTimeReceived;
     result.lock_time = wtx.tx->nLockTime;
@@ -336,12 +335,10 @@ public:
         WalletBalances result;
         result.balance = m_wallet.GetBalance();
         result.unconfirmed_balance = m_wallet.GetUnconfirmedBalance();
-        result.immature_balance = m_wallet.GetImmatureBalance();
         result.have_watch_only = m_wallet.HaveWatchOnly();
         if (result.have_watch_only) {
             result.watch_only_balance = m_wallet.GetBalance(ISMINE_WATCH_ONLY);
             result.unconfirmed_watch_only_balance = m_wallet.GetUnconfirmedWatchOnlyBalance();
-            result.immature_watch_only_balance = m_wallet.GetImmatureWatchOnlyBalance();
         }
         return result;
     }

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -315,14 +315,12 @@ struct WalletBalances
     bool have_watch_only = false;
     CAmount watch_only_balance = 0;
     CAmount unconfirmed_watch_only_balance = 0;
-    CAmount immature_watch_only_balance = 0;
 
     bool balanceChanged(const WalletBalances& prev) const
     {
         return balance != prev.balance || unconfirmed_balance != prev.unconfirmed_balance ||
                watch_only_balance != prev.watch_only_balance ||
-               unconfirmed_watch_only_balance != prev.unconfirmed_watch_only_balance ||
-               immature_watch_only_balance != prev.immature_watch_only_balance;
+               unconfirmed_watch_only_balance != prev.unconfirmed_watch_only_balance;
     }
 };
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -312,7 +312,6 @@ struct WalletBalances
 {
     CAmount balance = 0;
     CAmount unconfirmed_balance = 0;
-    CAmount immature_balance = 0;
     bool have_watch_only = false;
     CAmount watch_only_balance = 0;
     CAmount unconfirmed_watch_only_balance = 0;
@@ -321,7 +320,7 @@ struct WalletBalances
     bool balanceChanged(const WalletBalances& prev) const
     {
         return balance != prev.balance || unconfirmed_balance != prev.unconfirmed_balance ||
-               immature_balance != prev.immature_balance || watch_only_balance != prev.watch_only_balance ||
+               watch_only_balance != prev.watch_only_balance ||
                unconfirmed_watch_only_balance != prev.unconfirmed_watch_only_balance ||
                immature_watch_only_balance != prev.immature_watch_only_balance;
     }
@@ -347,7 +346,6 @@ struct WalletTx
 struct WalletTxStatus
 {
     int block_height;
-    int blocks_to_maturity;
     int depth_in_main_chain;
     unsigned int time_received;
     uint32_t lock_time;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -166,15 +166,7 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
     ui->labelTotal->setText(BitcoinUnits::formatWithUnit(unit, balances.balance + balances.unconfirmed_balance, false, BitcoinUnits::separatorAlways));
     ui->labelWatchAvailable->setText(BitcoinUnits::formatWithUnit(unit, balances.watch_only_balance, false, BitcoinUnits::separatorAlways));
     ui->labelWatchPending->setText(BitcoinUnits::formatWithUnit(unit, balances.unconfirmed_watch_only_balance, false, BitcoinUnits::separatorAlways));
-    ui->labelWatchImmature->setText(BitcoinUnits::formatWithUnit(unit, balances.immature_watch_only_balance, false, BitcoinUnits::separatorAlways));
-    ui->labelWatchTotal->setText(BitcoinUnits::formatWithUnit(unit, balances.watch_only_balance + balances.unconfirmed_watch_only_balance + balances.immature_watch_only_balance, false, BitcoinUnits::separatorAlways));
-
-    // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
-    // for the non-mining users
-    bool showWatchOnlyImmature = balances.immature_watch_only_balance != 0;
-
-    // for symmetry reasons also show immature label when the watch-only one is shown
-    ui->labelWatchImmature->setVisible(showWatchOnlyImmature); // show watch-only immature balance
+    ui->labelWatchTotal->setText(BitcoinUnits::formatWithUnit(unit, balances.watch_only_balance + balances.unconfirmed_watch_only_balance, false, BitcoinUnits::separatorAlways));
 }
 
 // show/hide watch-only labels

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -163,8 +163,7 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
     m_balances = balances;
     ui->labelBalance->setText(BitcoinUnits::formatWithUnit(unit, balances.balance, false, BitcoinUnits::separatorAlways));
     ui->labelUnconfirmed->setText(BitcoinUnits::formatWithUnit(unit, balances.unconfirmed_balance, false, BitcoinUnits::separatorAlways));
-    ui->labelImmature->setText(BitcoinUnits::formatWithUnit(unit, balances.immature_balance, false, BitcoinUnits::separatorAlways));
-    ui->labelTotal->setText(BitcoinUnits::formatWithUnit(unit, balances.balance + balances.unconfirmed_balance + balances.immature_balance, false, BitcoinUnits::separatorAlways));
+    ui->labelTotal->setText(BitcoinUnits::formatWithUnit(unit, balances.balance + balances.unconfirmed_balance, false, BitcoinUnits::separatorAlways));
     ui->labelWatchAvailable->setText(BitcoinUnits::formatWithUnit(unit, balances.watch_only_balance, false, BitcoinUnits::separatorAlways));
     ui->labelWatchPending->setText(BitcoinUnits::formatWithUnit(unit, balances.unconfirmed_watch_only_balance, false, BitcoinUnits::separatorAlways));
     ui->labelWatchImmature->setText(BitcoinUnits::formatWithUnit(unit, balances.immature_watch_only_balance, false, BitcoinUnits::separatorAlways));
@@ -172,12 +171,9 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
 
     // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
     // for the non-mining users
-    bool showImmature = balances.immature_balance != 0;
     bool showWatchOnlyImmature = balances.immature_watch_only_balance != 0;
 
     // for symmetry reasons also show immature label when the watch-only one is shown
-    ui->labelImmature->setVisible(showImmature || showWatchOnlyImmature);
-    ui->labelImmatureText->setVisible(showImmature || showWatchOnlyImmature);
     ui->labelWatchImmature->setVisible(showWatchOnlyImmature); // show watch-only immature balance
 }
 

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -58,7 +58,7 @@ void EditAddressAndSubmit(
  */
 void TestAddAddressesToSendBook()
 {
-    TestChain100Setup test;
+    TestChainSetup test;
     std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>("mock", WalletDatabase::CreateMock());
     bool firstRun;
     wallet->LoadWallet(firstRun);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -166,10 +166,10 @@ void TestGUI()
 
     // Send two transactions, and verify they are added to transaction list.
     TransactionTableModel* transactionTableModel = walletModel.getTransactionTableModel();
-    QCOMPARE(transactionTableModel->rowCount({}), 105);
+    QCOMPARE(transactionTableModel->rowCount({}), 10);
     uint256 txid1 = SendCoins(*wallet.get(), sendCoinsDialog, CKeyID(), 5 * COIN, false /* rbf */);
     uint256 txid2 = SendCoins(*wallet.get(), sendCoinsDialog, CKeyID(), 10 * COIN, true /* rbf */);
-    QCOMPARE(transactionTableModel->rowCount({}), 107);
+    QCOMPARE(transactionTableModel->rowCount({}), 12);
     QVERIFY(FindTx(*transactionTableModel, txid1).isValid());
     QVERIFY(FindTx(*transactionTableModel, txid2).isValid());
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -132,7 +132,7 @@ void BumpFee(TransactionView& view, const uint256& txid, bool expectDisabled, st
 void TestGUI()
 {
     // Set up wallet and chain with 105 blocks (5 mature blocks for spending).
-    TestChain100Setup test;
+    TestChainSetup test;
     for (int i = 0; i < 5; ++i) {
         test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
     }

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -137,7 +137,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             nUnmatured += wallet.getCredit(txout, ISMINE_ALL);
         strHTML += "<b>" + tr("Credit") + ":</b> ";
         if (status.is_in_main_chain)
-            strHTML += BitcoinUnits::formatHtmlWithUnit(unit, nUnmatured)
+            strHTML += BitcoinUnits::formatHtmlWithUnit(unit, nUnmatured);
         else
             strHTML += "(" + tr("not accepted") + ")";
         strHTML += "<br>";

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -137,7 +137,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             nUnmatured += wallet.getCredit(txout, ISMINE_ALL);
         strHTML += "<b>" + tr("Credit") + ":</b> ";
         if (status.is_in_main_chain)
-            strHTML += BitcoinUnits::formatHtmlWithUnit(unit, nUnmatured)+ " (" + tr("matures in %n more block(s)", "", status.blocks_to_maturity) + ")";
+            strHTML += BitcoinUnits::formatHtmlWithUnit(unit, nUnmatured)
         else
             strHTML += "(" + tr("not accepted") + ")";
         strHTML += "<br>";
@@ -270,12 +270,6 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             if (req.getMerchant(PaymentServer::getCertStore(), merchant))
                 strHTML += "<b>" + tr("Merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";
         }
-    }
-
-    if (wtx.is_coinbase)
-    {
-        quint32 numBlocksToMaturity = COINBASE_MATURITY +  1;
-        strHTML += "<br>" + tr("Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to \"not accepted\" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.").arg(QString::number(numBlocksToMaturity)) + "<br>";
     }
 
     //

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -168,7 +168,7 @@ void TransactionRecord::updateStatus(const interfaces::WalletTxStatus& wtx, int 
         wtx.is_coinbase ? 1 : 0,
         wtx.time_received,
         idx);
-    status.countsForBalance = wtx.is_trusted && !(wtx.blocks_to_maturity > 0);
+    status.countsForBalance = wtx.is_trusted;
     status.depth = wtx.depth_in_main_chain;
     status.cur_num_blocks = numBlocks;
 
@@ -188,22 +188,13 @@ void TransactionRecord::updateStatus(const interfaces::WalletTxStatus& wtx, int 
     // For generated transactions, determine maturity
     else if(type == TransactionRecord::Generated)
     {
-        if (wtx.blocks_to_maturity > 0)
+        if (wtx.is_in_main_chain)
         {
-            status.status = TransactionStatus::Immature;
-
-            if (wtx.is_in_main_chain)
-            {
-                status.matures_in = wtx.blocks_to_maturity;
-            }
-            else
-            {
-                status.status = TransactionStatus::NotAccepted;
-            }
+            status.status = TransactionStatus::Confirmed;
         }
         else
         {
-            status.status = TransactionStatus::Confirmed;
+            status.status = TransactionStatus::NotAccepted;
         }
     }
     else

--- a/src/test/chainparams_tests.cpp
+++ b/src/test/chainparams_tests.cpp
@@ -16,10 +16,11 @@ extern void noui_connect();
 
 struct ChainParamsTestingSetup {
 
+    ECCVerifyHandle globalVerifyHandle;
+
     explicit ChainParamsTestingSetup(const std::string& chainName= TAPYRUS_MODES::PROD)
         : m_path_root(fs::temp_directory_path() / "test_tapyrus" / strprintf("%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30))))
     {
-        ECCVerifyHandle globalVerifyHandle;
         SHA256AutoDetect();
         RandomInit();
         ECC_Start();
@@ -109,8 +110,6 @@ BOOST_AUTO_TEST_CASE(custom_networkid_dev)
 
 BOOST_AUTO_TEST_CASE(default_base_params_tests)
 {
-    ECCVerifyHandle globalVerifyHandle;
-
     //prod net
     gArgs.ForceSetArg("-networkid", "1");
     writeTestGenesisBlockToFile(GetDataDir(), "genesis.1");
@@ -137,8 +136,6 @@ BOOST_AUTO_TEST_CASE(default_base_params_tests)
 
 BOOST_AUTO_TEST_CASE(custom_networkId_test)
 {
-    ECCVerifyHandle globalVerifyHandle;
-
     gArgs.ForceSetArg("-networkid", "2");
     writeTestGenesisBlockToFile(GetDataDir(), "genesis.2");
 

--- a/src/test/chainparams_tests.cpp
+++ b/src/test/chainparams_tests.cpp
@@ -19,6 +19,7 @@ struct ChainParamsTestingSetup {
     explicit ChainParamsTestingSetup(const std::string& chainName= TAPYRUS_MODES::PROD)
         : m_path_root(fs::temp_directory_path() / "test_tapyrus" / strprintf("%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30))))
     {
+        ECCVerifyHandle globalVerifyHandle;
         SHA256AutoDetect();
         RandomInit();
         ECC_Start();
@@ -108,6 +109,8 @@ BOOST_AUTO_TEST_CASE(custom_networkid_dev)
 
 BOOST_AUTO_TEST_CASE(default_base_params_tests)
 {
+    ECCVerifyHandle globalVerifyHandle;
+
     //prod net
     gArgs.ForceSetArg("-networkid", "1");
     writeTestGenesisBlockToFile(GetDataDir(), "genesis.1");
@@ -134,6 +137,8 @@ BOOST_AUTO_TEST_CASE(default_base_params_tests)
 
 BOOST_AUTO_TEST_CASE(custom_networkId_test)
 {
+    ECCVerifyHandle globalVerifyHandle;
+
     gArgs.ForceSetArg("-networkid", "2");
     writeTestGenesisBlockToFile(GetDataDir(), "genesis.2");
 

--- a/src/test/federationparams_tests.cpp
+++ b/src/test/federationparams_tests.cpp
@@ -15,10 +15,12 @@ extern void noui_connect();
 
 struct FederationParamsTestingSetup {
 
+    ECCVerifyHandle globalVerifyHandle;
+
     explicit FederationParamsTestingSetup(const std::string& chainName = TAPYRUS_MODES::PROD)
         : m_path_root(fs::temp_directory_path() / "test_tapyrus" / strprintf("%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30))))
     {
-        ECCVerifyHandle globalVerifyHandle;
+
         SHA256AutoDetect();
         RandomInit();
         ECC_Start();
@@ -98,9 +100,6 @@ BOOST_AUTO_TEST_CASE(parse_pubkey_string_invalid)
 
 BOOST_AUTO_TEST_CASE(create_genesis_block)
 {
-    // This is for using CPubKey.verify().
-    ECCVerifyHandle globalVerifyHandle;
-
     BOOST_CHECK_NO_THROW(SelectFederationParams(TAPYRUS_OP_MODE::PROD));
 
     CKey key;
@@ -115,9 +114,6 @@ BOOST_AUTO_TEST_CASE(create_genesis_block)
 
 BOOST_AUTO_TEST_CASE(create_genesis_block_one_publickey)
 {
-    // This is for using CPubKey.verify().
-    ECCVerifyHandle globalVerifyHandle;
-
     CKey aggregateKey;
     aggregateKey.Set(validAggPrivateKey, validAggPrivateKey + 32, true);
     CPubKey aggPubkey = aggregateKey.GetPubKey();

--- a/src/test/federationparams_tests.cpp
+++ b/src/test/federationparams_tests.cpp
@@ -18,6 +18,7 @@ struct FederationParamsTestingSetup {
     explicit FederationParamsTestingSetup(const std::string& chainName = TAPYRUS_MODES::PROD)
         : m_path_root(fs::temp_directory_path() / "test_tapyrus" / strprintf("%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30))))
     {
+        ECCVerifyHandle globalVerifyHandle;
         SHA256AutoDetect();
         RandomInit();
         ECC_Start();
@@ -114,6 +115,9 @@ BOOST_AUTO_TEST_CASE(create_genesis_block)
 
 BOOST_AUTO_TEST_CASE(create_genesis_block_one_publickey)
 {
+    // This is for using CPubKey.verify().
+    ECCVerifyHandle globalVerifyHandle;
+
     CKey aggregateKey;
     aggregateKey.Set(validAggPrivateKey, validAggPrivateKey + 32, true);
     CPubKey aggPubkey = aggregateKey.GetPubKey();

--- a/src/test/test_tapyrus.cpp
+++ b/src/test/test_tapyrus.cpp
@@ -11,6 +11,7 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <validation.h>
+#include <miner.h>
 #include <net_processing.h>
 #include <ui_interface.h>
 #include <streams.h>

--- a/src/test/test_tapyrus.cpp
+++ b/src/test/test_tapyrus.cpp
@@ -11,7 +11,6 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <validation.h>
-#include <miner.h>
 #include <net_processing.h>
 #include <ui_interface.h>
 #include <streams.h>
@@ -147,13 +146,13 @@ void createSignedBlockProof(CBlock &block, std::vector<unsigned char>& blockProo
     return;
 }
 
-TestChain100Setup::TestChain100Setup() : TestingSetup(TAPYRUS_MODES::DEV)
+TestChainSetup::TestChainSetup() : TestingSetup(TAPYRUS_MODES::DEV)
 {
     // CreateAndProcessBlock() does not support building SegWit blocks, so don't activate in these tests.
-    // Generate a 100-block chain:
+    // Generate a block chain with '5' blocks:
     coinbaseKey.MakeNewKey(true);
     CScript scriptPubKey = CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
-    for (int i = 0; i < COINBASE_MATURITY; i++)
+    for (int i = 0; i < 5; i++)
     {
         std::vector<CMutableTransaction> noTxns;
         CBlock b = CreateAndProcessBlock(noTxns, scriptPubKey);
@@ -167,7 +166,7 @@ TestChain100Setup::TestChain100Setup() : TestingSetup(TAPYRUS_MODES::DEV)
 // scriptPubKey, and try to add it to the current chain.
 //
 CBlock
-TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey)
+TestChainSetup::CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
     std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
@@ -192,10 +191,6 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
 
     CBlock result = block;
     return result;
-}
-
-TestChain100Setup::~TestChain100Setup()
-{
 }
 
 

--- a/src/test/test_tapyrus.h
+++ b/src/test/test_tapyrus.h
@@ -15,6 +15,7 @@
 #include <scheduler.h>
 #include <txdb.h>
 #include <txmempool.h>
+#include <consensus/consensus.h>
 
 #include <memory>
 
@@ -39,6 +40,16 @@ static inline uint256 InsecureRand256() { return insecure_rand_ctx.rand256(); }
 static inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.randbits(bits); }
 static inline uint64_t InsecureRandRange(uint64_t range) { return insecure_rand_ctx.randrange(range); }
 static inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
+
+//utility functions
+CBlock getBlock();
+std::string getSignedTestBlock();
+std::string getTestGenesisBlockHex(const CPubKey& aggregatePubkey,
+                                   const CKey& aggregatePrivkey);
+void writeTestGenesisBlockToFile(fs::path genesisPath, std::string genesisFileName="");
+void createSignedBlockProof(CBlock &block, std::vector<unsigned char>& blockProof);
+// define an implicit conversion here so that uint256 may be used directly in BOOST_CHECK_*
+std::ostream& operator<<(std::ostream& os, const uint256& num);
 
 /** Basic testing setup.
  * This just configures logging and chain parameters.
@@ -82,17 +93,16 @@ class CScript;
 
 //
 // Testing fixture that pre-creates a
-// 100-block REGTEST-mode block chain
+// 5-block REGTEST-mode block chain
 //
-struct TestChain100Setup : public TestingSetup {
-    TestChain100Setup();
+struct TestChainSetup : public TestingSetup {
+    TestChainSetup();
 
     // Create a new block with just given transactions, coinbase paying to
     // scriptPubKey, and try to add it to the current chain.
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns,
                                  const CScript& scriptPubKey);
-
-    ~TestChain100Setup();
+    ~TestChainSetup(){}
 
     std::vector<CTransactionRef> m_coinbase_txns; // For convenience, coinbase transactions
     CKey coinbaseKey; // private/public key needed to spend coinbase transactions
@@ -124,14 +134,5 @@ struct TestMemPoolEntryHelper
     TestMemPoolEntryHelper &SpendsCoinbase(bool _flag) { spendsCoinbase = _flag; return *this; }
     TestMemPoolEntryHelper &SigOpsCost(unsigned int _sigopsCost) { sigOpCost = _sigopsCost; return *this; }
 };
-
-CBlock getBlock();
-std::string getSignedTestBlock();
-std::string getTestGenesisBlockHex(const CPubKey& aggregatePubkey,
-                                   const CKey& aggregatePrivkey);
-void writeTestGenesisBlockToFile(fs::path genesisPath, std::string genesisFileName="");
-void createSignedBlockProof(CBlock &block, std::vector<unsigned char>& blockProof);
-// define an implicit conversion here so that uint256 may be used directly in BOOST_CHECK_*
-std::ostream& operator<<(std::ostream& os, const uint256& num);
 
 #endif //TAPYRUS_TEST_TEST_TAPYRUS_H

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -14,7 +14,7 @@
 
 BOOST_AUTO_TEST_SUITE(txindex_tests)
 
-BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChainSetup)
 {
     TxIndex txindex(1 << 20, true);
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_SUITE(txvalidation_tests)
 /**
  * Ensure that the mempool won't accept coinbase transactions.
  */
-BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChainSetup)
 {
     CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
     CMutableTransaction coinbaseTx;

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -34,7 +34,7 @@ ToMemPool(const CMutableTransaction& tx)
                               nullptr /* plTxnReplaced */, true /* bypass_limits */, 0 /* nAbsurdFee */);
 }
 
-BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChainSetup)
 {
     // Make sure skipping validation of transactions that were
     // validated going into the memory pool does not allow
@@ -154,7 +154,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, uint32_t fail
     }
 }
 
-BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChainSetup)
 {
     // Test that passing CheckInputs with one set of script flags doesn't imply
     // that we would pass again with a different set of flags.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -518,7 +518,7 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
                     continue;
                 const Coin &coin = pcoins->AccessCoin(txin.prevout);
                 if (nCheckFrequency != 0) assert(!coin.IsSpent());
-                if (coin.IsSpent() || (coin.IsCoinBase() && ((signed long)nMemPoolHeight) - coin.nHeight < COINBASE_MATURITY)) {
+                if (coin.IsSpent()) {
                     txToRemove.insert(it);
                     break;
                 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1852,8 +1852,6 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const
                 {
                     if (wtx.GetDepthInMainChain() < 1)
                         entry.pushKV("category", "orphan");
-                    else if (wtx.GetBlocksToMaturity() > 0)
-                        entry.pushKV("category", "immature");
                     else
                         entry.pushKV("category", "generate");
                 }
@@ -2148,7 +2146,7 @@ static UniValue listaccounts(const JSONRPCRequest& request)
         std::list<COutputEntry> listReceived;
         std::list<COutputEntry> listSent;
         int nDepth = wtx.GetDepthInMainChain();
-        if (wtx.GetBlocksToMaturity() > 0 || nDepth < 0)
+        if (nDepth < 0)
             continue;
         wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, includeWatchonly);
         mapAccountBalances[strSentAccount] -= nFee;
@@ -3007,7 +3005,6 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"walletversion\": xxxxx,            (numeric) the wallet version\n"
             "  \"balance\": xxxxxxx,                (numeric) the total confirmed balance of the wallet in " + CURRENCY_UNIT + "\n"
             "  \"unconfirmed_balance\": xxx,        (numeric) the total unconfirmed balance of the wallet in " + CURRENCY_UNIT + "\n"
-            "  \"immature_balance\": xxxxxx,        (numeric) the total immature balance of the wallet in " + CURRENCY_UNIT + "\n"
             "  \"txcount\": xxxxxxx,                (numeric) the total number of transactions in the wallet\n"
             "  \"keypoololdest\": xxxxxx,           (numeric) the timestamp (seconds since Unix epoch) of the oldest pre-generated key in the key pool\n"
             "  \"keypoolsize\": xxxx,               (numeric) how many new keys are pre-generated (only counts external keys)\n"
@@ -3036,7 +3033,6 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.pushKV("walletversion", pwallet->GetVersion());
     obj.pushKV("balance",       ValueFromAmount(pwallet->GetBalance()));
     obj.pushKV("unconfirmed_balance", ValueFromAmount(pwallet->GetUnconfirmedBalance()));
-    obj.pushKV("immature_balance",    ValueFromAmount(pwallet->GetImmatureBalance()));
     obj.pushKV("txcount",       (int)pwallet->mapWallet.size());
     obj.pushKV("keypoololdest", pwallet->GetOldestKeyPoolTime());
     obj.pushKV("keypoolsize", (int64_t)kpExternalSize);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -267,7 +267,6 @@ public:
      */
     int GetDepthInMainChain() const;
     bool IsInMainChain() const { return GetDepthInMainChain() > 0; }
-    int GetBlocksToMaturity() const;
     bool hashUnset() const { return (hashBlock.IsNull() || hashBlock == ABANDON_HASH); }
     bool isAbandoned() const { return (hashBlock == ABANDON_HASH); }
     void setAbandoned() { hashBlock = ABANDON_HASH; }
@@ -341,21 +340,17 @@ public:
     // memory only
     mutable bool fDebitCached;
     mutable bool fCreditCached;
-    mutable bool fImmatureCreditCached;
     mutable bool fAvailableCreditCached;
     mutable bool fWatchDebitCached;
     mutable bool fWatchCreditCached;
-    mutable bool fImmatureWatchCreditCached;
     mutable bool fAvailableWatchCreditCached;
     mutable bool fChangeCached;
     mutable bool fInMempool;
     mutable CAmount nDebitCached;
     mutable CAmount nCreditCached;
-    mutable CAmount nImmatureCreditCached;
     mutable CAmount nAvailableCreditCached;
     mutable CAmount nWatchDebitCached;
     mutable CAmount nWatchCreditCached;
-    mutable CAmount nImmatureWatchCreditCached;
     mutable CAmount nAvailableWatchCreditCached;
     mutable CAmount nChangeCached;
 
@@ -376,22 +371,18 @@ public:
         strFromAccount.clear();
         fDebitCached = false;
         fCreditCached = false;
-        fImmatureCreditCached = false;
         fAvailableCreditCached = false;
         fWatchDebitCached = false;
         fWatchCreditCached = false;
-        fImmatureWatchCreditCached = false;
         fAvailableWatchCreditCached = false;
         fChangeCached = false;
         fInMempool = false;
         nDebitCached = 0;
         nCreditCached = 0;
-        nImmatureCreditCached = 0;
         nAvailableCreditCached = 0;
         nWatchDebitCached = 0;
         nWatchCreditCached = 0;
         nAvailableWatchCreditCached = 0;
-        nImmatureWatchCreditCached = 0;
         nChangeCached = 0;
         nOrderPos = -1;
     }
@@ -438,11 +429,9 @@ public:
     {
         fCreditCached = false;
         fAvailableCreditCached = false;
-        fImmatureCreditCached = false;
         fWatchDebitCached = false;
         fWatchCreditCached = false;
         fAvailableWatchCreditCached = false;
-        fImmatureWatchCreditCached = false;
         fDebitCached = false;
         fChangeCached = false;
     }
@@ -456,9 +445,7 @@ public:
     //! filter decides which addresses will count towards the debit
     CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
-    CAmount GetImmatureCredit(bool fUseCache=true) const;
     CAmount GetAvailableCredit(bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE) const;
-    CAmount GetImmatureWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetChange() const;
 
     // Get the marginal bytes if spending the specified output from this transaction
@@ -953,9 +940,7 @@ public:
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
     CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
     CAmount GetUnconfirmedBalance() const;
-    CAmount GetImmatureBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
-    CAmount GetImmatureWatchOnlyBalance() const;
     CAmount GetLegacyBalance(const isminefilter& filter, int minDepth, const std::string* account) const;
     CAmount GetAvailableBalance(const CCoinControl* coinControl = nullptr) const;
 

--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -11,7 +11,7 @@ import itertools
 import os
 import re
 import sys
-from .util import NetworkDirName
+from test_framework.util import NetworkDirName
 
 # Matches on the date format at the start of the log event
 TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z")

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -29,7 +29,7 @@ class BIP68Test(BitcoinTestFramework):
         self.relayfee = self.nodes[0].getnetworkinfo()["relayfee"]
 
         # Generate some coins
-        self.nodes[0].generate(110, self.signblockprivkey)
+        self.nodes[0].generate(11, self.signblockprivkey)
 
         self.log.info("Running test disable flag")
         self.test_disable_flag()

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -49,7 +49,7 @@ class MaxUploadTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(old_time)
 
         # Generate some old blocks
-        self.nodes[0].generate(130, self.signblockprivkey)
+        self.nodes[0].generate(31, self.signblockprivkey)
 
         # p2p_conns[0] will only request old blocks
         # p2p_conns[1] will only request new blocks

--- a/test/functional/feature_serialization.py
+++ b/test/functional/feature_serialization.py
@@ -50,7 +50,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_raises_rpc_error, assert_equal, bytes_to_hex_str, hex_str_to_bytes, wait_until
 from test_framework.key import CECKey
 
-CHAIN_HEIGHT = 111
+CHAIN_HEIGHT = 11
 REJECT_INVALID = 16
 
 def unDERify(tx):

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -49,9 +49,9 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]
 
-        self.log.info('Start with empty mempool, and 200 blocks')
+        self.log.info('Start with empty mempool, and 100 blocks')
         self.mempool_size = 0
-        wait_until(lambda: node.getblockcount() == 200, timeout=300)
+        wait_until(lambda: node.getblockcount() == 100, timeout=300)
         assert_equal(node.getmempoolinfo()['size'], self.mempool_size)
 
         self.log.info('Should not accept garbage to testmempoolaccept')

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -36,7 +36,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
     def run_test(self):
         ''' Mine some blocks and have them mature. '''
-        self.nodes[0].generate(101, self.signblockprivkey)
+        self.nodes[0].generate(2, self.signblockprivkey)
         utxo = self.nodes[0].listunspent(10)
         txid = utxo[0]['txid']
         vout = utxo[0]['vout']

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -50,7 +50,7 @@ class MempoolPersistTest(BitcoinTestFramework):
 
     def run_test(self):
         chain_height = self.nodes[0].getblockcount()
-        assert_equal(chain_height, 200)
+        assert_equal(chain_height, 100)
 
         self.log.debug("Mine a single block to get out of IBD")
         self.nodes[0].generate(1, self.signblockprivkey)

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -21,8 +21,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
     alert_filename = None  # Set by setup_network
 
     def run_test(self):
-        # Start with a 200 block chain
-        assert_equal(self.nodes[0].getblockcount(), 200)
+        # Start with a 100 block chain
+        assert_equal(self.nodes[0].getblockcount(), 100)
 
         # Mine four blocks. After this, nodes[0] blocks
         # 101, 102, and 103 are spend-able.
@@ -38,7 +38,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # 3. Indirect (coinbase and child both in chain) : spend_103 and spend_103_1
         # Use invalidatblock to make all of the above coinbase spends invalid (immature coinbase),
         # and make sure the mempool code behaves correctly.
-        b = [ self.nodes[0].getblockhash(n) for n in range(101, 105) ]
+        b = [ self.nodes[0].getblockhash(n) for n in range(1, 5) ]
         coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
         spend_101_raw = create_raw_transaction(self.nodes[0], coinbase_txids[1], node1_address, amount=49.99)
         spend_102_raw = create_raw_transaction(self.nodes[0], coinbase_txids[2], node0_address, amount=49.99)
@@ -92,7 +92,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.sync_all()
 
         # mempool should be empty.
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
+        assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_id, spend_102_1_id, spend_103_id, spend_103_1_id})
 
 if __name__ == '__main__':
     MempoolCoinbaseTest().main()

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -24,20 +24,20 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
     def run_test(self):
         chain_height = self.nodes[0].getblockcount()
-        assert_equal(chain_height, 200)
+        assert_equal(chain_height, 100)
         node0_address = self.nodes[0].getnewaddress()
 
         # Coinbase at height chain_height-100+1 ok in mempool, should
         # get mined. Coinbase at height chain_height-100+2 is
         # is too immature to spend.
-        b = [self.nodes[0].getblockhash(n) for n in range(101, 103)]
+        b = [self.nodes[0].getblockhash(n) for n in range(1, 3)]
         coinbase_txids = [self.nodes[0].getblock(h)['tx'][0] for h in b]
         spends_raw = [create_raw_transaction(self.nodes[0], txid, node0_address, amount=49.99) for txid in coinbase_txids]
 
         spend_101_id = self.nodes[0].sendrawtransaction(spends_raw[0])
 
         # coinbase at height 102 should be too immature to spend
-        assert_raises_rpc_error(-26,"bad-txns-premature-spend-of-coinbase", self.nodes[0].sendrawtransaction, spends_raw[1])
+        #assert_raises_rpc_error(-26,"bad-txns-premature-spend-of-coinbase", self.nodes[0].sendrawtransaction, spends_raw[1])
 
         # mempool should have just spend_101:
         assert_equal(self.nodes[0].getrawmempool(), [ spend_101_id ])

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -117,7 +117,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block = self.build_block_on_tip(self.nodes[0])
         self.test_node.send_and_ping(msg_block(block))
         assert(int(self.nodes[0].getbestblockhash(), 16) == block.sha256)
-        self.nodes[0].generate(100, self.signblockprivkey)
+        self.nodes[0].generate(10, self.signblockprivkey)
         sync_blocks(self.nodes[0:1], wait=150)
 
         total_value = block.vtx[0].vout[0].nValue

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -46,7 +46,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         node.p2p.send_blocks_and_test([block1], node, True)
 
         self.log.info("Mature the block.")
-        node.generate(100, self.signblockprivkey)
+        node.generate(1, self.signblockprivkey)
 
         best_block = node.getblock(node.getbestblockhash())
         tip = int(node.getbestblockhash(), 16)

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -18,7 +18,7 @@ class InvalidLocatorTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node
-        node.generate(1, self.signblockprivkey)  # Get node out of IBD
+        node.generate(16, self.signblockprivkey)  # Get node out of IBD
 
         self.log.info('Test max locator size')
         block_count = node.getblockcount()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -71,9 +71,6 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         tip = block.sha256
         node.p2p.send_blocks_and_test([block], node, success=True)
 
-        self.log.info("Mature the block.")
-        self.nodes[0].generate(100, self.signblockprivkey)
-
         # b'\x64' is OP_NOTIF
         # Transaction will be rejected with code 16 (REJECT_INVALID)
         self.log.info('Test a transaction that is rejected')

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -314,8 +314,6 @@ class SegWitTest(BitcoinTestFramework):
         self.test_node.sync_with_ping()  # make sure the block was processed
         txid = block.vtx[0].malfixsha256
 
-        self.nodes[0].generate(99, self.signblockprivkey)  # let the block mature
-
         # Create a transaction that spends the coinbase
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(txid, 0), b""))
@@ -1430,8 +1428,6 @@ class SegWitTest(BitcoinTestFramework):
         spend_tx.rehash()
 
         # Now test a premature spend.
-        self.nodes[0].generate(98, self.signblockprivkey)
-        sync_blocks(self.nodes)
         block2 = self.build_next_block()
         self.update_witness_block_with_transactions(block2, [spend_tx])
         test_witness_block(self.nodes[0].rpc, self.test_node, block2, with_witness=True,accepted=False)

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -23,34 +23,34 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
     def run_test(self):
         node0,node1,node2 = self.nodes
 
-        # 50 BTC each, rest will be 25 BTC each
-        node0.generate(149, self.signblockprivkey)
+        # 50 BTC starting balance
+        node0.generate(1, self.signblockprivkey)
         self.sync_all()
 
         self.moved = 0
+        self.output_type = "legacy"
         for self.nkeys in [3,5]:
             for self.nsigs in [2,3]:
-                for self.output_type in ["legacy"]:
-                    self.get_keys()
-                    self.do_multisig()
+                self.get_keys()
+                self.do_multisig()
 
         self.checkbalances()
 
     def checkbalances(self):
         node0,node1,node2 = self.nodes
-        node0.generate(100, self.signblockprivkey)
-        self.sync_all()
 
         bal0 = node0.getbalance()
         bal1 = node1.getbalance()
         bal2 = node2.getbalance()
 
         height = node0.getblockchaininfo()["blocks"]
-        assert 150 < height < 350
-        total = 149*50 + (height-149-100)*25
+        assert height == 9 # initial 1 + 8 blocks mined
+        assert bal0+bal1+bal2 == 9*50
+
+        # bal0 is initial 50 + total_block_rewards - self.moved - fee paid (total_block_rewards - 400)
+        assert bal0 == 450 - self.moved
         assert bal1 == 0
         assert bal2 == self.moved
-        assert bal0+bal1+bal2 == total
 
     def do_multisig(self):
         node0,node1,node2 = self.nodes

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -55,7 +55,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         self.nodes[2].generate(1, self.signblockprivkey)
         self.sync_all()
-        self.nodes[0].generate(121, self.signblockprivkey)
+        self.nodes[0].generate(5, self.signblockprivkey)
         self.sync_all()
 
         # ensure that setting changePosition in fundraw with an exact match is handled properly
@@ -86,6 +86,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ###############
         # simple test #
         ###############
+        self.log.info("simple test.")
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 1.0 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
@@ -145,6 +146,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################################
         # test a fundrawtransaction with a VIN greater than the required amount #
         #########################################################################
+        self.log.info("fundrawtransaction tests.")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
@@ -347,6 +349,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-4, "Insufficient funds", self.nodes[2].fundrawtransaction, rawtx)
 
+        self.log.info("transaction fee tests.")
         ############################################################
         #compare fee of a standard pubkeyhash transaction
         inputs = []
@@ -458,7 +461,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].generate(1, self.signblockprivkey)
         self.sync_all()
 
-        oldBalance = self.nodes[1].getbalance()
+        self.log.info("block reward tests.")
+        oldBalance0 = self.nodes[0].getbalance()
+        oldBalance1 = self.nodes[1].getbalance()
+        oldBalance2 = self.nodes[2].getbalance()
+
         inputs = []
         outputs = {self.nodes[1].getnewaddress():1.1}
         rawtx = self.nodes[2].createrawtransaction(inputs, outputs)
@@ -467,11 +474,19 @@ class RawTransactionsTest(BitcoinTestFramework):
         signedTx = self.nodes[2].signrawtransactionwithwallet(fundedTx['hex'], [], "ALL", self.options.scheme)
         txId = self.nodes[2].sendrawtransaction(signedTx['hex'])
         self.sync_all()
-        self.nodes[1].generate(1, self.signblockprivkey)
+        new_block = self.nodes[1].generate(1, self.signblockprivkey)[0]
         self.sync_all()
 
+        #get its block reward
+        blockData = self.nodes[1].getblock(new_block)
+        blockReward = self.nodes[1].gettransaction(blockData['tx'][0])['amount']
+
+        # no change in node0
+        assert_equal(oldBalance0, self.nodes[0].getbalance())
         # make sure funds are received at node1
-        assert_equal(oldBalance+Decimal('1.10000000'), self.nodes[1].getbalance())
+        assert_equal(oldBalance1 + blockReward + Decimal('1.10000000'), self.nodes[1].getbalance())
+        # make sure fee is paid by node2
+        assert_equal(oldBalance2 - (blockReward - 50) - Decimal('1.10000000'), self.nodes[2].getbalance())
 
         ############################################################
         # locked wallet test
@@ -512,7 +527,8 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-13, "walletpassphrase", self.nodes[1].sendtoaddress, self.nodes[0].getnewaddress(), 1.2)
 
-        oldBalance = self.nodes[0].getbalance()
+        oldBalance0 = self.nodes[0].getbalance()
+        oldBalance1 = self.nodes[1].getbalance()
 
         inputs = []
         outputs = {self.nodes[0].getnewaddress():1.1}
@@ -526,8 +542,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].generate(1, self.signblockprivkey)
         self.sync_all()
 
-        # make sure funds are received at node1
-        assert_equal(oldBalance+Decimal('51.10000000'), self.nodes[0].getbalance())
+        # make sure funds are received at node0
+        assert_equal(oldBalance0 + Decimal('1.10000000'), self.nodes[0].getbalance())
+        # block reward is only 50 because transaction fee is paid by and received by the same node
+        assert_equal(oldBalance1 - Decimal('1.10000000') + 50, self.nodes[1].getbalance())
 
 
         ###############################################
@@ -576,7 +594,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         #fund a tx with ~20 small inputs
-        oldBalance = self.nodes[0].getbalance()
+        oldBalance0 = self.nodes[0].getbalance()
+        oldBalance1 = self.nodes[1].getbalance()
 
         inputs = []
         outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
@@ -585,14 +604,22 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedAndSignedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'], [], "ALL", self.options.scheme)
         txId = self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
         self.sync_all()
-        self.nodes[0].generate(1, self.signblockprivkey)
+        new_block = self.nodes[0].generate(1, self.signblockprivkey)[0]
         self.sync_all()
-        assert_equal(oldBalance+Decimal('50.19000000'), self.nodes[0].getbalance()) #0.19+block reward
+
+        #get its block reward
+        blockData = self.nodes[0].getblock(new_block)
+        blockReward = self.nodes[0].gettransaction(blockData['tx'][0])['amount']
+
+        # make sure funds are received at node0
+        assert_equal(oldBalance0 + Decimal('0.19000000') + blockReward, self.nodes[0].getbalance())
+        # make sure fee are paid at node1
+        assert_equal(oldBalance1 - Decimal('0.19000000') - (blockReward - 50), self.nodes[1].getbalance())
 
         #####################################################
         # test fundrawtransaction with OP_RETURN and no vin #
         #####################################################
-
+        self.log.info("more fundrawtransaction tests.")
         rawtx   = "0100000000010000000000000000066a047465737400000000"
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
@@ -651,7 +678,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #######################
         # Test feeRate option #
         #######################
-
+        self.log.info("feeRate tests.")
         # Make sure there is exactly one input so coin selection can't skew the result
         assert_equal(len(self.nodes[3].listunspent(1)), 1)
 
@@ -683,7 +710,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ######################################
         # Test subtractFeeFromOutputs option #
         ######################################
-
+        self.log.info("subtractFeeFromOutputs tests.")
         # Make sure there is exactly one input so coin selection can't skew the result
         assert_equal(len(self.nodes[3].listunspent(1)), 1)
 

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -67,7 +67,7 @@ class GetblockstatsTest(BitcoinTestFramework):
         return [self.nodes[0].getblockstats(hash_or_height=self.start_height + i) for i in range(self.max_stat_pos+1)]
 
     def generate_test_data(self, filename):
-        self.nodes[0].generate(101, self.signblockprivkey)
+        self.nodes[0].generate(1, self.signblockprivkey)
 
         self.nodes[0].sendtoaddress(address=self.nodes[1].getnewaddress(), amount=10, subtractfeefromamount=True)
         self.nodes[0].generate(1, self.signblockprivkey)

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -22,7 +22,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         tips = self.nodes[0].getchaintips ()
         assert_equal (len (tips), 1)
         assert_equal (tips[0]['branchlen'], 0)
-        assert_equal (tips[0]['height'], 200)
+        assert_equal (tips[0]['height'], 100)
         assert_equal (tips[0]['status'], 'active')
 
         # Split the network and build two chains of different lengths.
@@ -35,14 +35,14 @@ class GetChainTipsTest (BitcoinTestFramework):
         assert_equal (len (tips), 1)
         shortTip = tips[0]
         assert_equal (shortTip['branchlen'], 0)
-        assert_equal (shortTip['height'], 210)
+        assert_equal (shortTip['height'], 110)
         assert_equal (tips[0]['status'], 'active')
 
         tips = self.nodes[3].getchaintips ()
         assert_equal (len (tips), 1)
         longTip = tips[0]
         assert_equal (longTip['branchlen'], 0)
-        assert_equal (longTip['height'], 220)
+        assert_equal (longTip['height'], 120)
         assert_equal (tips[0]['status'], 'active')
 
         # Join the network halves and check that we now have two tips

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -53,13 +53,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.log.info('prepare some coins for multiple *rawtransaction commands')
         self.nodes[2].generate(1, self.signblockprivkey)
         self.sync_all()
-        self.nodes[0].generate(101, self.signblockprivkey)
+        #generate one block that matures immediately for spending
+        self.nodes[0].generate(1, self.signblockprivkey)
         self.sync_all()
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0)
-        self.sync_all()
-        self.nodes[0].generate(5, self.signblockprivkey)
         self.sync_all()
 
         self.log.info('Test getrawtransaction on genesis block coinbase returns an error')
@@ -294,9 +293,14 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[2].sendrawtransaction(rawTxSigned['hex'])
         rawTx = self.nodes[0].decoderawtransaction(rawTxSigned['hex'])
         self.sync_all()
-        self.nodes[0].generate(1, self.signblockprivkey)
+        new_block = self.nodes[0].generate(1, self.signblockprivkey)[0]
         self.sync_all()
-        assert_equal(self.nodes[0].getbalance(), bal+Decimal('50.00000000')+Decimal('2.19000000')) #block reward + tx
+
+        #get block reward
+        blockData = self.nodes[0].getblock(new_block)
+        blockReward = self.nodes[0].gettransaction(blockData['tx'][0])['amount']
+
+        assert_equal(self.nodes[0].getbalance(), bal+blockReward+Decimal('2.19000000')) #block reward + tx
 
         # 2of2 test for combining transactions
         bal = self.nodes[2].getbalance()
@@ -343,9 +347,14 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[2].sendrawtransaction(rawTxComb)
         rawTx2 = self.nodes[0].decoderawtransaction(rawTxComb)
         self.sync_all()
-        self.nodes[0].generate(1, self.signblockprivkey)
+        new_block = self.nodes[0].generate(1, self.signblockprivkey)[0]
         self.sync_all()
-        assert_equal(self.nodes[0].getbalance(), bal+Decimal('50.00000000')+Decimal('2.19000000')) #block reward + tx
+
+        #get block reward
+        blockData = self.nodes[0].getblock(new_block)
+        blockReward = self.nodes[0].gettransaction(blockData['tx'][0])['amount']
+
+        assert_equal(self.nodes[0].getbalance(), bal+blockReward+Decimal('2.19000000')) #block reward + tx
 
         # decoderawtransaction tests
         # witness transaction

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -17,7 +17,7 @@ class ScantxoutsetTest(BitcoinTestFramework):
         self.setup_clean_chain = True
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(110, self.signblockprivkey)
+        self.nodes[0].generate(1, self.signblockprivkey)
 
         assert_raises_rpc_error(-5, "Unknown address type 'p2sh-segwit'",  self.nodes[0].getnewaddress, "", "p2sh-segwit")
         assert_raises_rpc_error(-5, "Unknown address type 'bech32'",  self.nodes[0].getnewaddress, "", "bech32")
@@ -54,7 +54,7 @@ class ScantxoutsetTest(BitcoinTestFramework):
         if(os.path.exists(os.path.join(self.nodes[0].datadir, NetworkDirName(), 'wallets'))):
             shutil.rmtree(os.path.join(self.nodes[0].datadir, NetworkDirName(), 'wallets'))
         self.start_node(0)
-        self.nodes[0].generate(110, self.signblockprivkey)
+        self.nodes[0].generate(1, self.signblockprivkey)
 
         self.restart_node(0, ['-nowallet'])
         self.log.info("Test if we have found the non HD unspent outputs.")

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -26,11 +26,11 @@ class MerkleBlockTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(105, self.signblockprivkey)
+        self.nodes[0].generate(2, self.signblockprivkey)
         self.sync_all()
 
         chain_height = self.nodes[1].getblockcount()
-        assert_equal(chain_height, 105)
+        assert_equal(chain_height, 2)
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -440,22 +440,21 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             for node in self.nodes:
                 node.wait_for_rpc_connection()
 
-            # Create a 200-block-long chain; each of the 4 first nodes
-            # gets 25 mature blocks and 25 immature.
+            # Create a 100 block-block-long chain; each of the 4 first nodes
+            # gets 25 mature blocks.
             # Note: To preserve compatibility with older versions of
             # initialize_chain, only 4 nodes will generate coins.
             #
             # blocks are created with timestamps 10 minutes apart
             # starting from 2010 minutes in the past
             block_time = self.mocktime - (201 * 10 * 60)
-            for i in range(2):
-                for peer in range(4):
-                    for j in range(25):
-                        set_node_times(self.nodes, block_time)
-                        self.nodes[peer].generate(1, self.signblockprivkey)
-                        block_time += 10 * 60
-                    # Must sync before next peer starts generating blocks
-                    sync_blocks(self.nodes)
+            for peer in range(4):
+                for j in range(25):
+                    set_node_times(self.nodes, block_time)
+                    self.nodes[peer].generate(1, self.signblockprivkey)
+                    block_time += 10 * 60
+                # Must sync before next peer starts generating blocks
+                sync_blocks(self.nodes)
 
             # Shut them down, and clean up cache directories:
             self.stop_nodes()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -490,7 +490,7 @@ class TestHandler:
             time.sleep(.5)
             for job in self.jobs:
                 (name, start_time, proc, testdir, log_out, log_err) = job
-                if os.getenv('TRAVIS') == 'true' and int(time.time() - start_time) > TRAVIS_TIMEOUT_DURATION:
+                if int(time.time() - start_time) > TRAVIS_TIMEOUT_DURATION:
                     # In travis, timeout individual tests (to stop tests hanging and not providing useful output).
                     proc.send_signal(signal.SIGINT)
                 if proc.poll() is not None:

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -22,7 +22,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         self.extra_args = [["-minrelaytxfee=0.00001"], []]
 
     def run_test(self):
-        self.nodes[1].generate(100, self.signblockprivkey)
+        self.nodes[1].generate(1, self.signblockprivkey)
         sync_blocks(self.nodes)
         balance = self.nodes[0].getbalance()
         txA = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -100,9 +100,9 @@ class AddressTypeTest(BitcoinTestFramework):
         self.test_address(node_sender, change_addresses[0], multisig=False, typ=expected_type)
 
     def run_test(self):
-        # Mine 101 blocks on node5 to bring nodes out of IBD and make sure that
+        # Mine 1 block on node5 to bring nodes out of IBD and make sure that
         # no coinbases are maturing for the nodes-under-test during the test
-        self.nodes[2].generate(101, self.signblockprivkey)
+        self.nodes[2].generate(1, self.signblockprivkey)
         sync_blocks(self.nodes)
 
         uncompressed_1 = "0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee"

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -18,7 +18,7 @@ and the miner mining one block.
 Wallets are backed up using dumpwallet/backupwallet.
 Then 5 more iterations of transactions and mining a block.
 
-Miner then generates 101 more blocks, so any
+Miner then generates 1 more blocks, so any
 transaction fees paid mature.
 
 Sanity check:
@@ -105,13 +105,13 @@ class WalletBackupTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
         self.nodes[2].generate(1, self.signblockprivkey)
         sync_blocks(self.nodes)
-        self.nodes[3].generate(100, self.signblockprivkey)
+        self.nodes[3].generate(1, self.signblockprivkey)
         sync_blocks(self.nodes)
 
         assert_equal(self.nodes[0].getbalance(), 50)
         assert_equal(self.nodes[1].getbalance(), 50)
         assert_equal(self.nodes[2].getbalance(), 50)
-        assert_equal(self.nodes[3].getbalance(), 0)
+        assert_equal(self.nodes[3].getbalance(), 50)
 
         self.log.info("Creating transactions")
         # Five rounds of sending each other transactions.
@@ -131,19 +131,15 @@ class WalletBackupTest(BitcoinTestFramework):
         for i in range(5):
             self.do_one_round()
 
-        # Generate 101 more blocks, so any fees paid mature
-        self.nodes[3].generate(101, self.signblockprivkey)
-        self.sync_all()
-
         balance0 = self.nodes[0].getbalance()
         balance1 = self.nodes[1].getbalance()
         balance2 = self.nodes[2].getbalance()
         balance3 = self.nodes[3].getbalance()
         total = balance0 + balance1 + balance2 + balance3
 
-        # At this point, there are 214 blocks (103 for setup, then 10 rounds, then 101.)
-        # 114 are mature, so the sum of all wallets should be 114 * 50 = 5700.
-        assert_equal(total, 5700)
+        # At this point, there are 214 blocks (4 for setup, then 10 rounds.)
+        # 14 are mature, so the sum of all wallets should be 14 * 50 = 700.
+        assert_equal(total, 700)
 
         ##
         # Test restoring spender wallets from backups

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -192,14 +192,18 @@ class WalletTest(BitcoinTestFramework):
         fee_per_byte = Decimal('0.001') / 1000
         self.nodes[2].settxfee(fee_per_byte * 1000)
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", False)
-        self.nodes[2].generate(1, self.signblockprivkey)
+        # generate block on another node so that balance is not distorted by block reward
+        self.sync_all([self.nodes[0:3]])
+        self.nodes[1].generate(1, self.signblockprivkey)[0]
         self.sync_all([self.nodes[0:3]])
         node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), Decimal('84'), fee_per_byte, self.get_vsize(self.nodes[2].getrawtransaction(txid)))
         assert_equal(self.nodes[0].getbalance(), Decimal('10'))
 
         # Send 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", True)
-        self.nodes[2].generate(1, self.signblockprivkey)
+        # generate block on another node so that balance is not distorted by block reward
+        self.sync_all([self.nodes[0:3]])
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.sync_all([self.nodes[0:3]])
         node_2_bal -= Decimal('10')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
@@ -207,7 +211,9 @@ class WalletTest(BitcoinTestFramework):
 
         # Sendmany 10 BTC
         txid = self.nodes[2].sendmany('', {address: 10}, 0, "", [])
-        self.nodes[2].generate(1, self.signblockprivkey)
+        # generate block on another node so that balance is not distorted by block reward
+        self.sync_all([self.nodes[0:3]])
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.sync_all([self.nodes[0:3]])
         node_0_bal += Decimal('10')
         node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), node_2_bal - Decimal('10'), fee_per_byte, self.get_vsize(self.nodes[2].getrawtransaction(txid)))
@@ -215,7 +221,9 @@ class WalletTest(BitcoinTestFramework):
 
         # Sendmany 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendmany('', {address: 10}, 0, "", [address])
-        self.nodes[2].generate(1, self.signblockprivkey)
+        # generate block on another node so that balance is not distorted by block reward
+        self.sync_all([self.nodes[0:3]])
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.sync_all([self.nodes[0:3]])
         node_2_bal -= Decimal('10')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
@@ -229,7 +237,14 @@ class WalletTest(BitcoinTestFramework):
         txid2 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         sync_mempools(self.nodes[0:2])
 
+        self.stop_nodes()
         self.start_node(3, extra_args = ['-acceptnonstdtxn=1'])
+        self.start_node(2, extra_args = ['-acceptnonstdtxn=1'])
+        self.start_node(1, extra_args = ['-acceptnonstdtxn=1'])
+        self.start_node(0, extra_args = ['-acceptnonstdtxn=1'])
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 1, 2)
+        connect_nodes_bi(self.nodes, 0, 2)
         connect_nodes_bi(self.nodes, 0, 3)
         sync_blocks(self.nodes)
 
@@ -256,7 +271,7 @@ class WalletTest(BitcoinTestFramework):
         signed_raw_tx = self.nodes[1].signrawtransactionwithwallet(raw_tx, [], "ALL", self.options.scheme)
         decoded_raw_tx = self.nodes[1].decoderawtransaction(signed_raw_tx['hex'])
         zero_value_txid = decoded_raw_tx['txid']
-        self.nodes[1].sendrawtransaction(signed_raw_tx['hex'])
+        self.nodes[1].sendrawtransaction(signed_raw_tx['hex'], True)
 
         self.sync_all()
         self.nodes[1].generate(1, self.signblockprivkey)  # mine a block
@@ -424,8 +439,8 @@ class WalletTest(BitcoinTestFramework):
         # Get all non-zero utxos together
         chain_addrs = [self.nodes[0].getnewaddress(), self.nodes[0].getnewaddress()]
         singletxid = self.nodes[0].sendtoaddress(chain_addrs[0], self.nodes[0].getbalance(), "", "", True)
-        self.nodes[0].generate(1, self.signblockprivkey)
         node0_balance = self.nodes[0].getbalance()
+        self.nodes[0].generate(1, self.signblockprivkey)
         # Split into two chains
         rawtx = self.nodes[0].createrawtransaction([{"txid": singletxid, "vout": 0}], {chain_addrs[0]: node0_balance / 2 - Decimal('0.01'), chain_addrs[1]: node0_balance / 2 - Decimal('0.01')})
         signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx, [], "ALL", self.options.scheme)
@@ -438,10 +453,10 @@ class WalletTest(BitcoinTestFramework):
         # So we should be able to generate exactly chainlimit txs for each original output
         sending_addr = self.nodes[1].getnewaddress()
         txid_list = []
-        for i in range(chainlimit * 2):
+        for i in range(chainlimit * 4): #including 2 block rewards its 4
             txid_list.append(self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001')))
-        assert_equal(self.nodes[0].getmempoolinfo()['size'], chainlimit * 2)
-        assert_equal(len(txid_list), chainlimit * 2)
+        assert_equal(self.nodes[0].getmempoolinfo()['size'], chainlimit * 4)
+        assert_equal(len(txid_list), chainlimit * 4)
 
         # Without walletrejectlongchains, we will still generate a txid
         # The tx will be stored in the wallet but not accepted to the mempool
@@ -458,10 +473,10 @@ class WalletTest(BitcoinTestFramework):
 
         # wait for loadmempool
         timeout = 10
-        while (timeout > 0 and len(self.nodes[0].getrawmempool()) < chainlimit * 2):
+        while (timeout > 0 and len(self.nodes[0].getrawmempool()) < chainlimit * 4):
             time.sleep(0.5)
             timeout -= 0.5
-        assert_equal(len(self.nodes[0].getrawmempool()), chainlimit * 2)
+        assert_equal(len(self.nodes[0].getrawmempool()), chainlimit * 4)
 
         node0_balance = self.nodes[0].getbalance()
         # With walletrejectlongchains we will not create the tx and store it in our wallet.

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -26,9 +26,9 @@ class WalletTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.add_nodes(4)
-        self.start_node(0, extra_args = ['-acceptnonstdtxn=1'])
-        self.start_node(1, extra_args = ['-acceptnonstdtxn=1'])
-        self.start_node(2, extra_args = ['-acceptnonstdtxn=1'])
+        self.start_node(0) 
+        self.start_node(1) 
+        self.start_node(2)
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
         connect_nodes_bi(self.nodes, 0, 2)
@@ -54,11 +54,10 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[0].generate(1, self.signblockprivkey)
 
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['immature_balance'], 50)
-        assert_equal(walletinfo['balance'], 0)
+        assert_equal(walletinfo['balance'], 50)
 
         self.sync_all([self.nodes[0:3]])
-        self.nodes[1].generate(101, self.signblockprivkey)
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.sync_all([self.nodes[0:3]])
 
         assert_equal(self.nodes[0].getbalance(), 50)
@@ -116,7 +115,7 @@ class WalletTest(BitcoinTestFramework):
         balance = self.nodes[0].getbalance()
         assert_equal(set([txout1['value'], txout2['value']]), set([10, balance]))
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['immature_balance'], 0)
+        assert_equal(walletinfo['balance'], balance)
 
         # Have node0 mine a block, thus it will collect its own fee.
         self.nodes[0].generate(1, self.signblockprivkey)
@@ -148,8 +147,8 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[1].sendrawtransaction(tx)
         assert_equal(len(self.nodes[1].listlockunspent()), 0)
 
-        # Have node1 generate 100 blocks (so node0 can recover the fee)
-        self.nodes[1].generate(100, self.signblockprivkey)
+        # Have node1 generate 1 block (so node0 can recover the fee)
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.sync_all([self.nodes[0:3]])
 
         # node0 should end up with 100 btc in block rewards plus fees, but

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -51,7 +51,7 @@ class BumpFeeTest(BitcoinTestFramework):
 
         # fund rbf node with 10 coins of 0.001 btc (100,000 satoshis)
         self.log.info("Mining blocks...")
-        peer_node.generate(110, self.signblockprivkey)
+        peer_node.generate(11, self.signblockprivkey)
         self.sync_all()
         for i in range(25):
             peer_node.sendtoaddress(rbf_node_address, 0.001)

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -116,7 +116,7 @@ class WalletDumpTest(BitcoinTestFramework):
             read_dump(wallet_unenc_dump, addrs, script_addrs, None)
         assert_equal(found_addr, test_addr_count)  # all keys must be in the dump
         assert_equal(found_script_addr, 1)  # all scripts must be in the dump
-        assert_equal(found_addr_chg, 50)  # 50 blocks where mined
+        assert_equal(found_addr_chg, 25)  # 25 blocks where mined
         assert_equal(found_addr_rsv, 90*2) # 90 keys plus 100% internal keys
         assert_equal(witness_addr_ret, None) # p2sh-p2wsh address added to the first key
 
@@ -132,7 +132,7 @@ class WalletDumpTest(BitcoinTestFramework):
             read_dump(wallet_enc_dump, addrs, script_addrs, hd_master_addr_unenc)
         assert_equal(found_addr, test_addr_count)
         assert_equal(found_script_addr, 1)
-        assert_equal(found_addr_chg, 90*2 + 50)  # old reserve keys are marked as change now
+        assert_equal(found_addr_chg, 90*2 + 25)  # old reserve keys are marked as change now
         assert_equal(found_addr_rsv, 90*2)
         assert_equal(witness_addr_ret, None)
 

--- a/test/functional/wallet_fallbackfee.py
+++ b/test/functional/wallet_fallbackfee.py
@@ -13,7 +13,7 @@ class WalletRBFTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        self.nodes[0].generate(101, self.signblockprivkey)
+        self.nodes[0].generate(1, self.signblockprivkey)
 
         # sending a transaction without fee estimations must be possible by default on regtest
         self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -26,7 +26,7 @@ class WalletGroupTest(BitcoinTestFramework):
 
     def run_test (self):
         # Mine some coins
-        self.nodes[0].generate(110, self.signblockprivkey)
+        self.nodes[0].generate(5, self.signblockprivkey)
 
         # Get some addresses from the two nodes
         addr1 = [self.nodes[1].getnewaddress() for i in range(3)]

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -50,7 +50,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Derive some HD addresses and remember the last
         # Also send funds to each add
-        self.nodes[0].generate(101, self.signblockprivkey)
+        self.nodes[0].generate(1, self.signblockprivkey)
         hd_add = None
         NUM_HD_ADDS = 10
         for i in range(NUM_HD_ADDS):

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -230,7 +230,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['pubkey'], sig_address_2['pubkey'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100, self.signblockprivkey)
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1, self.signblockprivkey)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -257,7 +257,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['pubkey'], sig_address_2['pubkey'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100, self.signblockprivkey)
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1, self.signblockprivkey)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -284,7 +284,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['pubkey'], sig_address_2['pubkey'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100, self.signblockprivkey)
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1, self.signblockprivkey)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -311,7 +311,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['pubkey'], sig_address_2['pubkey'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100, self.signblockprivkey)
+        self.nodes[1].generate(1, self.signblockprivkey)
         self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1, self.signblockprivkey)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -19,7 +19,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(101, self.signblockprivkey)
+        self.nodes[0].generate(1, self.signblockprivkey)
 
         self.sync_all()
 
@@ -38,7 +38,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.sync_all()
 
         # Node 1 sync test
-        assert_equal(self.nodes[1].getblockcount(), 101)
+        assert_equal(self.nodes[1].getblockcount(), 1)
 
         # Address Test - before import
         address_info = self.nodes[1].getaddressinfo(address1)

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -32,7 +32,7 @@ class KeypoolRestoreTest(BitcoinTestFramework):
     def run_test(self):
         wallet_path = os.path.join(self.nodes[1].datadir, NetworkDirName(), "wallets", "wallet.dat")
         wallet_backup_path = os.path.join(self.nodes[1].datadir, "wallet.bak")
-        self.nodes[0].generate(101, self.signblockprivkey)
+        self.nodes[0].generate(1, self.signblockprivkey)
 
         self.log.info("Make backup of wallet")
         self.stop_node(1)

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -45,8 +45,9 @@ class WalletLabelsTest(BitcoinTestFramework):
         # Note each time we call generate, all generated coins go into
         # the same address, so we call twice to get two addresses w/50 each
         node.generate(1, self.signblockprivkey)
-        node.generate(101, self.signblockprivkey)
+        node.generate(1, self.signblockprivkey)
         assert_equal(node.getbalance(), 100)
+        assert_equal(len(node.listunspent()), 2)
 
         # there should be 2 address groups
         # each with 1 address with a balance of 50 Bitcoins
@@ -140,13 +141,13 @@ class WalletLabelsTest(BitcoinTestFramework):
             if accounts_api:
                 node.move(label.name, "", node.getbalance(label.name))
             label.verify(node)
-        node.generate(101, self.signblockprivkey)
-        expected_account_balances = {"": 5200}
+        node.generate(3, self.signblockprivkey)
+        expected_account_balances = {"": 300}
         for label in labels:
             expected_account_balances[label.name] = 0
         if accounts_api:
             assert_equal(node.listaccounts(), expected_account_balances)
-            assert_equal(node.getbalance(""), 5200)
+            assert_equal(node.getbalance(""), 300)
 
         # Check that setlabel can assign a label to a new unused address.
         for label in labels:
@@ -170,7 +171,7 @@ class WalletLabelsTest(BitcoinTestFramework):
             label.verify(node)
             if accounts_api:
                 node.sendfrom("", multisig_address, 50)
-        node.generate(101, self.signblockprivkey)
+        node.generate(1, self.signblockprivkey)
         if accounts_api:
             for label in labels:
                 assert_equal(node.getbalance(label.name), 50)

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -14,7 +14,7 @@ class ListSinceBlockTest (BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        self.nodes[2].generate(101, self.signblockprivkey)
+        self.nodes[2].generate(2, self.signblockprivkey)
         self.sync_all()
 
         self.test_no_blockhash()

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -128,7 +128,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(set(node.listwallets()), {"w4", "w5"})
         w5 = wallet("w5")
         w5_info = w5.getwalletinfo()
-        assert(w5_info['balance'], 50)
+        assert_equal(w5_info['balance'], 50)
 
         competing_wallet_dir = os.path.join(self.options.tmpdir, 'competing_walletdir')
         os.mkdir(competing_wallet_dir)

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -128,7 +128,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(set(node.listwallets()), {"w4", "w5"})
         w5 = wallet("w5")
         w5_info = w5.getwalletinfo()
-        assert_equal(w5_info['immature_balance'], 50)
+        assert(w5_info['balance'], 50)
 
         competing_wallet_dir = os.path.join(self.options.tmpdir, 'competing_walletdir')
         os.mkdir(competing_wallet_dir)
@@ -145,7 +145,7 @@ class MultiWalletTest(BitcoinTestFramework):
         wallets[0].generate(1, self.signblockprivkey)
         for wallet_name, wallet in zip(wallet_names, wallets):
             info = wallet.getwalletinfo()
-            assert_equal(info['immature_balance'], 50 if wallet is wallets[0] else 0)
+            assert_equal(info['balance'], 50 if wallet is wallets[0] else 0)
             assert_equal(info['walletname'], wallet_name)
 
         # accessing invalid wallet fails
@@ -155,7 +155,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-19, "Wallet file not specified", node.getwalletinfo)
 
         w1, w2, w3, w4, *_ = wallets
-        w1.generate(101, self.signblockprivkey)
+        w1.generate(1, self.signblockprivkey)
         assert_equal(w1.getbalance(), 100)
         assert_equal(w2.getbalance(), 0)
         assert_equal(w3.getbalance(), 0)

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -29,6 +29,7 @@ class TxnMallTest(BitcoinTestFramework):
 
     def run_test(self):
         # All nodes should start with 1,250 BTC:
+        self.log.info("All nodes should start with initial balance 1250.")
         starting_balance = 1250
         for i in range(4):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
@@ -109,14 +110,21 @@ class TxnMallTest(BitcoinTestFramework):
         assert_equal(txid1, txid1_clone)
 
         # ... mine a block...
-        self.nodes[2].generate(1, self.signblockprivkey)
+        new_block = self.nodes[2].generate(1, self.signblockprivkey)[0]
+
+        #get its block reward
+        blockData = self.nodes[2].getblock(new_block)
+        blockReward = self.nodes[2].gettransaction(blockData['tx'][0])['amount']
 
         # Reconnect the split network, and sync chain:
         connect_nodes(self.nodes[1], 2)
         self.nodes[2].sendrawtransaction(node0_tx2["hex"])
         self.nodes[2].sendrawtransaction(tx2["hex"])
-        self.nodes[2].generate(1, self.signblockprivkey)  # Mine another block to make sure we sync
+        new_block = self.nodes[2].generate(1, self.signblockprivkey)[0]  # Mine another block to make sure we sync
         sync_blocks(self.nodes)
+
+        blockData = self.nodes[2].getblock(new_block)
+        blockReward += self.nodes[2].gettransaction(blockData['tx'][0])['amount']
 
         # Re-fetch transaction info:
         tx1 = self.nodes[0].gettransaction(txid1)
@@ -131,12 +139,18 @@ class TxnMallTest(BitcoinTestFramework):
         assert_equal(tx1_clone["confirmations"], 2)
         assert_equal(tx2["confirmations"], 1)
 
-        # Check node0's total balance; should be same as before the clone, + 100 BTC for 2 matured,
+        self.log.info("Check final node balances.")
+        # Check node0's total balance; should be same as before the clone
         # less possible orphaned matured subsidy
-        expected += 100
         if (self.options.mine_block):
             expected -= 50
         assert_equal(self.nodes[0].getbalance(), expected)
+        # node1 should have +60 from tx1["amount"] and tx2["amount"]
+        assert_equal(self.nodes[1].getbalance(), starting_balance + 60)
+        # node2 gets 100 block reward for last 2 blocks mined from it + block rewards.
+        assert_equal(self.nodes[2].getbalance(), starting_balance + blockReward)
+        # node2's balance is unaffected
+        assert_equal(self.nodes[3].getbalance(), starting_balance)
 
 if __name__ == '__main__':
     TxnMallTest().main()

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -31,8 +31,6 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.log.info("Mining blocks...")
         self.nodes[0].generate(1, self.signblockprivkey)
         self.sync_all()
-        self.nodes[1].generate(100, self.signblockprivkey)
-        self.sync_all()
 
         # This transaction will be confirmed
         txid1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 10)


### PR DESCRIPTION
Removed Coinbase maturity definition and usage from transaction validation code.
As a result tapyrus wallet does not need to remember immature balance. 
Updated unit tests to create chain of length "5" instead of 100. (some tests needed multiple outputs)
Removed all coinbase maturing code from functional tests i.e create only one block (not 100) to get a spendable coinbase output.
Updated wallet balances in some functional tests - as blocks rewards mature immediately there are tests where wallet balances had to take into account the transaction fee and block reward.