### PR TITLE
Fix  getblockchaininfo

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1127,13 +1127,15 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
         }
     }
     //aggregate pubkey list with block height
-    UniValue aggPubkeyObj(UniValue::VOBJ);
+    UniValue aggPubkeyList(UniValue::VARR);
     const std::vector<aggPubkeyAndHeight>& aggregatePubkeyHeightList = FederationParams().GetAggregatePubkeyHeightList();
     for (auto& aggpubkeyPair : aggregatePubkeyHeightList)
     {
+        UniValue aggPubkeyObj(UniValue::VOBJ);
         aggPubkeyObj.pushKV(HexStr(aggpubkeyPair.aggpubkey.begin(), aggpubkeyPair.aggpubkey.end()), aggpubkeyPair.height);
+        aggPubkeyList.push_back(aggPubkeyObj);
     }
-    obj.pushKV("aggregatePubkeys", aggPubkeyObj);
+    obj.pushKV("aggregatePubkeys", aggPubkeyList);
     obj.pushKV("warnings", GetWarnings("statusbar"));
     return obj;
 }

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -76,7 +76,7 @@ class BlockchainTest(BitcoinTestFramework):
             'warnings',
         ]
         res = self.nodes[0].getblockchaininfo()
-        assert_equal(res['aggregatePubkeys'], {self.signblockpubkey:0})
+        assert_equal(res['aggregatePubkeys'], [{self.signblockpubkey:0}])
 
         # result should have these additional pruning keys if manual pruning is enabled
         assert_equal(sorted(res.keys()), sorted(['pruneheight', 'automatic_pruning'] + keys))


### PR DESCRIPTION
if the same aggpubkey appears in the federation params list more than once, first aggpubkey will be overwritten