### PR TITLE
snap: set restart-condition to always

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ apps:
     environment:
       HOME: $SNAP_USER_COMMON
     daemon: simple
+    restart-condition: always
 
 parts:
   tapyrus-core:


### PR DESCRIPTION
tapyrus-core daemon service will automatically restart after unexpected
crash. This should make tapyrus service more robust.

ref. https://snapcraft.io/docs/services-and-daemons
ref. https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=