### PR TITLE
Issue/77 fixed size color identifier

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -44,6 +44,7 @@ BITCOIN_TESTS =\
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \
+  test/coloridentifier_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \

--- a/src/coloridentifier.cpp
+++ b/src/coloridentifier.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <primitives/transaction.h>
+#include <coloridentifier.h>
+#include <script/script.h>
+#include <script/standard.h>
+
+ColorIdentifier GetColorIdFromScript(const CScript& script)
+{
+    if(!script.IsColoredScript())
+        return ColorIdentifier();
+
+    std::vector<unsigned char> pubkeyhash, colorId;
+    if( MatchColoredPayToPubkeyHash(script, pubkeyhash, colorId))
+        return ColorIdentifier(colorId);
+
+    if(script.IsColoredPayToScriptHash())
+    {
+        colorId.assign(script.begin()+1, script.begin()+34);
+        return ColorIdentifier(colorId);
+    }
+
+    if(MatchCustomColoredScript(script, colorId))
+        return ColorIdentifier(colorId);
+
+    return ColorIdentifier();
+}

--- a/src/coloridentifier.h
+++ b/src/coloridentifier.h
@@ -94,7 +94,7 @@ struct ColorIdentifier
             const uint8_t xtype = TokenToUint(type);
             s.write((const char *)&xtype, 1);
         }
-        if(type != TokenTypes::NONE)
+        if(type > TokenTypes::NONE && type <= TokenTypes::TOKENTYPE_MAX)
             READWRITE(this->payload);
     }
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1172,10 +1172,8 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     if(colorId->type <= TokenTypes::NONE || colorId->type > TokenTypes::TOKENTYPE_MAX)
                         return set_error(serror, SCRIPT_ERR_OP_COLORID_INVALID);
 
-                    //COLOR identifier consists of one byte of TYPE and 32 or 36 bytes of PAYLOAD.
-                    if((stacktop(-1).size() == 33 && colorId->type == TokenTypes::REISSUABLE)
-                     ||(stacktop(-1).size() == 37 
-                            && (colorId->type == TokenTypes::NON_REISSUABLE || colorId->type == TokenTypes::NFT)))
+                    //COLOR identifier consists of one byte of TYPE and 32 of PAYLOAD.
+                    if(stacktop(-1).size() == 33 && (colorId->type == TokenTypes::REISSUABLE || colorId->type == TokenTypes::NON_REISSUABLE || colorId->type == TokenTypes::NFT))
                     {
                         popstack(stack);
                     }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1609,7 +1609,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     }
 
     std::vector<std::vector<unsigned char> > stack, stackCopy;
-    ColorIdentifier colorId(TokenTypes::NONE);
+    ColorIdentifier colorId;
     if (!EvalScript(stack, scriptSig, flags, checker, SigVersion::BASE, &colorId, serror))
         // serror is set
         return false;

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -221,20 +221,13 @@ bool CScript::IsColoredScript() const
 bool CScript::IsColoredPayToScriptHash() const
 {
     // <COLOR identifier> OP_COLOR OP_HASH160 <H(redeem script)> OP_EQUAL
-    if(this->size() == 56) // <COLOR identifier> : TYPE = 1 and 32 PAYLOAD
+    if(this->size() == 58) // <COLOR identifier> : TYPE = 1 byte and 32 byte PAYLOAD
         return ((*this)[0] == 0x21 &&
-                (*this)[1] == 0x01 &&
-                (*this)[33] == OP_COLOR &&
-                (*this)[34] == OP_HASH160 &&
-                (*this)[35] == 0x14 &&
-                (*this)[55] == OP_EQUAL);
-    else if(this->size() == 60) // <COLOR identifier> : TYPE = 2/3 and 36 PAYLOAD
-        return ((*this)[0] == 0x25 &&
-                ((*this)[1] == 0x02 || (*this)[1] == 0x03 )&&
-                (*this)[37] == OP_COLOR &&
-                (*this)[38] == OP_HASH160 &&
-                (*this)[39] == 0x14 &&
-                (*this)[59] == OP_EQUAL);
+                ((*this)[1] == 0x01 || (*this)[1] == 0x02 || (*this)[1] == 0x03)&&
+                (*this)[34] == OP_COLOR &&
+                (*this)[35] == OP_HASH160 &&
+                (*this)[36] == 0x14 &&
+                (*this)[57] == OP_EQUAL);
     return false;
 }
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -11,6 +11,7 @@
 #include <script/script.h>
 #include <util.h>
 #include <utilstrencodings.h>
+#include <script/script.h>
 
 
 typedef std::vector<unsigned char> valtype;
@@ -74,20 +75,41 @@ static bool MatchPayToPubkeyHash(const CScript& script, valtype& pubkeyhash)
 static bool MatchColoredPayToPubkeyHash(const CScript& script, valtype& pubkeyhash, valtype& colorid)
 {
     //<COLOR identifier> OP_COLOR OP_DUP OP_HASH160 <H(pubkey)> OP_EQUALVERIFY OP_CHECKSIG
-    // <COLOR identifier> : TYPE = 1 and 32 PAYLOAD
-    if (script.size() == 59 && script[0] ==0x21 && script[1] == 0x01 && script[34] == OP_DUP && script[35] == OP_HASH160 && script[36] == 20 && script[57] == OP_EQUALVERIFY && script[58] == OP_CHECKSIG)
+    // <COLOR identifier> : TYPE = 1 byte and 32 byte PAYLOAD
+    if (script.size() == 60 && script[0] == 0x21  && (script[1] == 0x01 || script[1] == 0x02 || script[1] == 0x03) && script[34] == OP_COLOR && script[35] == OP_DUP && script[36] == OP_HASH160 && script[37] == 20 && script[58] == OP_EQUALVERIFY && script[59] == OP_CHECKSIG)
     {
-        pubkeyhash = valtype(script.begin() + 37, script.begin() + 57);
+        pubkeyhash = valtype(script.begin() + 38, script.begin() + 58);
         colorid = valtype(script.begin() + 1, script.begin() + 34);
         return true;
     }
-    // <COLOR identifier> : TYPE = 2/3 and 36 PAYLOAD
-    else if (script.size() == 63 && script[0] ==0x25 && (script[1] == 0x02 || script[1] == 0x03) && script[38] == OP_DUP && script[39] == OP_HASH160 && script[40] == 20 && script[61] == OP_EQUALVERIFY && script[62] == OP_CHECKSIG)
+    return false;
+}
+
+bool MatchCustomColoredScript(const CScript& script, valtype& colorid)
+{
+    //search for colorid in the script
+    // pattern: 0x21<33 byte>OP_COLOR
+    std::vector<unsigned char> colorId;
+    CScript::const_iterator iterColorId1 = std::find(script.begin(), script.end(), 0x21);
+    CScript::const_iterator iterOpColor = script.begin();
+    opcodetype opcode;
+    while (iterOpColor < script.end())
     {
-        pubkeyhash = valtype(script.begin() + 41, script.begin() + 61);
-        colorid = valtype(script.begin() + 1, script.begin() + 38);
+        if (!script.GetOp(iterOpColor, opcode))
+            return false;
+        if (opcode == OP_COLOR)
+            break;
+    }
+
+    if(iterOpColor == script.end())
+        return false;
+
+    if(iterColorId1 != script.end() && std::distance(iterColorId1, iterOpColor) == 34)
+    {
+        colorId.assign(iterColorId1 + 1, iterColorId1 + 34);
         return true;
     }
+    
     return false;
 }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -62,6 +62,7 @@ add_test_to_suite(tapyrus test_tapyrus
 		checkdatasig_tests.cpp
 		checkqueue_tests.cpp
 		coins_tests.cpp
+		coloridentifier_tests.cpp
 		compress_tests.cpp
 		crypto_tests.cpp
 		cuckoocache_tests.cpp

--- a/src/test/checkdatasig_tests.cpp
+++ b/src/test/checkdatasig_tests.cpp
@@ -60,7 +60,7 @@ static void CheckError(uint32_t flags, const stacktype &original_stack,
     MutableTransactionSignatureChecker checker(&txCredit, 0, 0);
 
     stacktype stack{original_stack};
-    ColorIdentifier colorId(TokenTypes::NONE);
+    ColorIdentifier colorId;
     bool r = EvalScript(stack, script, flags, checker, SigVersion::BASE, &colorId, &err);
     BOOST_CHECK(!r);
     BOOST_CHECK_EQUAL(err, expected);
@@ -83,7 +83,7 @@ static void CheckPass(uint32_t flags, const stacktype &original_stack,
     MutableTransactionSignatureChecker checker(&txCredit, 0, 0);
 
     stacktype stack{original_stack};
-    ColorIdentifier colorId(TokenTypes::NONE);
+    ColorIdentifier colorId;
     bool r = EvalScript(stack, script, flags, checker, SigVersion::BASE, &colorId, &err);
     BOOST_CHECK(r);
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);

--- a/src/test/coloridentifier_tests.cpp
+++ b/src/test/coloridentifier_tests.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+#include <test/test_tapyrus.h>
+#include <map>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <coloridentifier.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(coloridentifier_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(coloridentifier_valid_unserialize)
+{
+    //type NONE
+    ColorIdentifier c0;
+    uint8_t str[32] = {};
+    CDataStream ss0(ParseHex("00"), SER_NETWORK, INIT_PROTO_VERSION);
+    ss0 >> c0;
+    BOOST_CHECK_EQUAL(TokenToUint(c0.type), TokenToUint(TokenTypes::NONE));
+    BOOST_CHECK(memcmp(&c0.payload[0], &str[0], 32) == 0);
+
+    try {
+        CDataStream ss00(ParseHex("0100"), SER_NETWORK, INIT_PROTO_VERSION);
+        ss00 >> c0;
+        BOOST_CHECK_MESSAGE(false, "We should have thrown");
+    } catch (const std::ios_base::failure& e) {
+    }
+
+    CDataStream ss00(ParseHex("038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508"), SER_NETWORK, INIT_PROTO_VERSION);
+    ss00 >> c0;
+
+    //type REISSUABLE
+    std::vector<unsigned char> scriptVector(ParseHex("038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508"));
+    uint8_t scripthash[CSHA256::OUTPUT_SIZE];
+    scriptVector.insert(scriptVector.begin(), 0x21);
+    CSHA256().Write(scriptVector.data(), scriptVector.size()).Finalize(scripthash);
+    
+    ColorIdentifier c1;
+    CDataStream ss1(ParseHex("01f55efb77e5a0e37c16d8f3484024558241c215a57aa991533152813f111482f6"), SER_NETWORK, INIT_PROTO_VERSION);
+    ss1 >> c1;
+    BOOST_CHECK_EQUAL(HexStr(&scripthash[0], &scripthash[32]), "f55efb77e5a0e37c16d8f3484024558241c215a57aa991533152813f111482f6");
+    BOOST_CHECK_EQUAL(HexStr(&c1.payload[0], &c1.payload[32]), "f55efb77e5a0e37c16d8f3484024558241c215a57aa991533152813f111482f6");
+    BOOST_CHECK_EQUAL(TokenToUint(c1.type), TokenToUint(TokenTypes::REISSUABLE));
+    BOOST_CHECK(memcmp(&c1.payload[0], &scripthash[0], 32) == 0);
+
+    //type NON_REISSUABLE
+    uint256 hashMalFix(ParseHex("485273f6703f038a234400edadb543eb44b4af5372e8b207990beebc386e7954"));
+    COutPoint out(hashMalFix, 0);
+    CDataStream s(SER_NETWORK, INIT_PROTO_VERSION);
+    s << out;
+    CSHA256().Write((const unsigned char *)s.data(), s.size()).Finalize(scripthash);
+
+    ColorIdentifier c2;
+    CDataStream ss2(ParseHex("029608951ee23595caa227e7668e39f9d3525a39e9dc30d7391f138576c07be84d"), SER_NETWORK, INIT_PROTO_VERSION);
+    ss2 >> c2;
+    BOOST_CHECK_EQUAL(HexStr(&scripthash[0], &scripthash[32]), "9608951ee23595caa227e7668e39f9d3525a39e9dc30d7391f138576c07be84d");
+    BOOST_CHECK_EQUAL(HexStr(&c2.payload[0], &c2.payload[32], false), "9608951ee23595caa227e7668e39f9d3525a39e9dc30d7391f138576c07be84d");
+    BOOST_CHECK_EQUAL(TokenToUint(c2.type), TokenToUint(TokenTypes::NON_REISSUABLE));
+    BOOST_CHECK(memcmp(&c2.payload[0], &scripthash[0], 32) == 0);
+
+}
+
+BOOST_AUTO_TEST_CASE(coloridentifier_valid_serialize)
+{
+    //type REISSUABLE
+    std::vector<unsigned char> scriptVector(ParseHex("038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508"));
+    ColorIdentifier c1(CScript() << scriptVector);
+    CDataStream ss1(SER_NETWORK, INIT_PROTO_VERSION);
+    ss1 << c1;
+    BOOST_CHECK_EQUAL(HexStr(ss1.begin(), ss1.end(), false), "01f55efb77e5a0e37c16d8f3484024558241c215a57aa991533152813f111482f6");
+
+    //type NON_REISSUABLE
+    uint256 hashMalFix(ParseHex("485273f6703f038a234400edadb543eb44b4af5372e8b207990beebc386e7954"));
+    COutPoint out(hashMalFix, 0);
+    ColorIdentifier c2(out, TokenTypes::NON_REISSUABLE);
+    CDataStream ss2(SER_NETWORK, INIT_PROTO_VERSION);
+    ss2 << c2;
+    BOOST_CHECK_EQUAL(HexStr(ss2.begin(), ss2.end()), "029608951ee23595caa227e7668e39f9d3525a39e9dc30d7391f138576c07be84d");
+}
+
+BOOST_AUTO_TEST_CASE(coloridentifier_compare)
+{
+    //type REISSUABLE
+    std::vector<unsigned char> scriptVector(ParseHex("038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508"));
+    ColorIdentifier c1(CScript() << scriptVector);
+
+    uint8_t scripthash[CSHA256::OUTPUT_SIZE];
+    scriptVector.insert(scriptVector.begin(), 0x21);
+    CSHA256().Write(scriptVector.data(), scriptVector.size()).Finalize(scripthash);
+    ColorIdentifier c2;
+    c2.type = TokenTypes::REISSUABLE;
+    memcpy(&c2.payload[0], &scripthash[0], 32);
+
+    BOOST_CHECK_EQUAL(HexStr(&scripthash[0], &scripthash[32]), "f55efb77e5a0e37c16d8f3484024558241c215a57aa991533152813f111482f6");
+    BOOST_CHECK_EQUAL(HexStr(&c1.payload[0], &c1.payload[32]), "f55efb77e5a0e37c16d8f3484024558241c215a57aa991533152813f111482f6");
+    BOOST_CHECK_EQUAL(HexStr(&c2.payload[0], &c2.payload[32]), "f55efb77e5a0e37c16d8f3484024558241c215a57aa991533152813f111482f6");
+    BOOST_CHECK(c1.operator==(c2));
+
+    //type NON_REISSUABLE
+    uint256 hashMalFix(ParseHex("485273f6703f038a234400edadb543eb44b4af5372e8b207990beebc386e7954"));
+    COutPoint out(hashMalFix, 0);
+    ColorIdentifier c3(out, TokenTypes::NON_REISSUABLE);
+
+    ColorIdentifier c4;
+    CDataStream s(SER_NETWORK, INIT_PROTO_VERSION);
+    s << out;
+    CSHA256().Write((const unsigned char *)s.data(), s.size()).Finalize(scripthash);
+    c4.type = TokenTypes::NON_REISSUABLE;
+    memcpy(&c4.payload[0], &scripthash[0], 32);
+
+    BOOST_CHECK(c3.operator==(c4));
+
+    BOOST_CHECK(!c1.operator==(c3));
+    BOOST_CHECK(!c2.operator==(c4));
+}
+
+BOOST_AUTO_TEST_CASE(coloridentifier_map_compare)
+{
+    //type REISSUABLE
+    std::vector<unsigned char> scriptVector(ParseHex("038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508"));
+    ColorIdentifier c1(CScript() << scriptVector);
+
+    uint8_t scripthash[CSHA256::OUTPUT_SIZE];
+    scriptVector.insert(scriptVector.begin(), 0x21);
+    CSHA256().Write(scriptVector.data(), scriptVector.size()).Finalize(scripthash);
+    ColorIdentifier c2;
+    c2.type = TokenTypes::REISSUABLE;
+    memcpy(&c2.payload[0], &scripthash[0], 32);
+
+    BOOST_CHECK_EQUAL(c1 < c2, false);
+
+    //type NON_REISSUABLE
+    uint256 hashMalFix(ParseHex("485273f6703f038a234400edadb543eb44b4af5372e8b207990beebc386e7954"));
+    COutPoint out(hashMalFix, 0);
+    ColorIdentifier c3(out, TokenTypes::NON_REISSUABLE);
+
+    ColorIdentifier c4;
+    CDataStream s(SER_NETWORK, INIT_PROTO_VERSION);
+    s << out;
+    CSHA256().Write((const unsigned char *)s.data(), s.size()).Finalize(scripthash);
+    c4.type = TokenTypes::NON_REISSUABLE;
+    memcpy(&c4.payload[0], &scripthash[0], 32);
+    BOOST_CHECK_EQUAL(c3 < c4, false);
+
+    BOOST_CHECK_EQUAL(c1 < c3, true);
+    BOOST_CHECK_EQUAL(c2 < c4, true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1718,7 +1718,7 @@ BOOST_AUTO_TEST_CASE(script_PushData)
     //verify the same same set of tests using SCRIPT_VERIFY_NONE, stdFlags and mndFlags
     ScriptError err;
     std::vector<std::vector<unsigned char>> directStack;
-    ColorIdentifier colorId(TokenTypes::NONE);
+    ColorIdentifier colorId;
     BOOST_CHECK(EvalScript(directStack, CScript(&direct[0], &direct[sizeof(direct)]), SCRIPT_VERIFY_NONE, BaseSignatureChecker(), SigVersion::BASE, &colorId, &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 


### PR DESCRIPTION
Changed ColorIdentifier to fixed size. payload is 32 bytes hash of scriptpubkey or utxo.
Updated tests.