### PR TITLE
snap: decrale build-essential explicitly in build dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,7 @@ parts:
       - --disable-bench
       - --disable-tests
     build-packages:
+      - build-essential
       - bsdmainutils
       - pkg-config
       - libboost-system-dev


### PR DESCRIPTION
Formerly, some build dependencies such as build-essential are not
necessary however it became necessary at some point.

----

Same as chaintope/tapyrus-signer#136.