### PR TITLE
snap: set source-branch to release/v0.4.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,7 @@ parts:
   tapyrus-core:
     plugin: autotools
     source: https://github.com/chaintope/tapyrus-core.git
+    source-branch: release/v0.4.0
     configflags:
       - --disable-dependency-tracking
       - --enable-zmq


### PR DESCRIPTION
Snap packages for 0.4 tracks should be built from release/v0.4.0 branch.
Specify the target branch explicitly.

This change must not be merged into master.