### PR TITLE
Fix color id size check in colored custom script

### DIFF
--- a/src/coloridentifier.h
+++ b/src/coloridentifier.h
@@ -9,6 +9,9 @@
 #include <version.h>
 #include <amount.h>
 
+// Size of color identifier data in bytes
+static const unsigned int COLOR_IDENTIFIER_SIZE = 33;
+
 enum class TokenTypes
 {
     NONE = 0x00, //TPC
@@ -73,11 +76,11 @@ struct ColorIdentifier
     }
 
     bool operator==(const ColorIdentifier& colorId) const {
-        return this->type == colorId.type && (memcmp(&this->payload[0], &colorId.payload[0], 32) == 0);
+        return this->type == colorId.type && (memcmp(&this->payload[0], &colorId.payload[0], COLOR_IDENTIFIER_SIZE - 1) == 0);
     }
 
     bool operator<(const ColorIdentifier& colorId) const {
-        return memcmp(this, &colorId, 33) < 0;
+        return memcmp(this, &colorId, COLOR_IDENTIFIER_SIZE) < 0;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -117,7 +120,7 @@ struct ColorIdentifierCompare
 {
     bool operator()(const ColorIdentifier& c1, const ColorIdentifier& c2) const
     {
-        return memcmp(&c1, &c2, 33) < 0;
+        return memcmp(&c1, &c2, COLOR_IDENTIFIER_SIZE) < 0;
     }
 };
 

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -410,7 +410,7 @@ bool MatchCustomColoredScript(const CScript& script, std::vector<unsigned char>&
     if(iterOpColor == script.end())
         return false;
 
-    if(iterColorId1 != script.end() && std::distance(iterColorId1 + 1, iterOpColor - 1) == 33 &&
+    if(iterColorId1 != script.end() && std::distance(iterColorId1 + 1, iterOpColor - 1) == COLOR_IDENTIFIER_SIZE &&
       (*(iterColorId1 + 1) == TokenToUint(TokenTypes::REISSUABLE) ||
        *(iterColorId1 + 1) == TokenToUint(TokenTypes::NON_REISSUABLE) ||
        *(iterColorId1 + 1) == TokenToUint(TokenTypes::NFT)))

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -410,7 +410,7 @@ bool MatchCustomColoredScript(const CScript& script, std::vector<unsigned char>&
     if(iterOpColor == script.end())
         return false;
 
-    if(iterColorId1 != script.end() && std::distance(iterColorId1, iterOpColor) == 34 &&
+    if(iterColorId1 != script.end() && std::distance(iterColorId1 + 1, iterOpColor - 1) == 33 &&
       (*(iterColorId1 + 1) == TokenToUint(TokenTypes::REISSUABLE) ||
        *(iterColorId1 + 1) == TokenToUint(TokenTypes::NON_REISSUABLE) ||
        *(iterColorId1 + 1) == TokenToUint(TokenTypes::NFT)))

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -2513,6 +2513,13 @@ BOOST_AUTO_TEST_CASE(coloredScripts)
     BOOST_CHECK(MatchColoredPayToPubkeyHash(ColoredPayToScriptHash2, data, colorId));
     BOOST_CHECK(!ColoredPayToScriptHash2.IsColoredPayToScriptHash());
     BOOST_CHECK(GetColorIdFromScript(ColoredPayToScriptHash2).type == TokenTypes::REISSUABLE);
+
+    // Custom script
+    CScript ColoredCustomScript = CScript() << ParseHex("c11863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") << OP_COLOR << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(MatchCustomColoredScript(ColoredPayToScriptHash2, colorId));
+    BOOST_CHECK(!ColoredCustomScript.IsColoredPayToScriptHash());
+    BOOST_CHECK(ColoredCustomScript.IsColoredScript());
+    BOOST_CHECK(GetColorIdFromScript(ColoredCustomScript).type == TokenTypes::REISSUABLE);
 }
 
 #endif

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -2514,12 +2514,28 @@ BOOST_AUTO_TEST_CASE(coloredScripts)
     BOOST_CHECK(!ColoredPayToScriptHash2.IsColoredPayToScriptHash());
     BOOST_CHECK(GetColorIdFromScript(ColoredPayToScriptHash2).type == TokenTypes::REISSUABLE);
 
-    // Custom script
+    // Custom script:
     CScript ColoredCustomScript = CScript() << ParseHex("c11863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") << OP_COLOR << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
     BOOST_CHECK(MatchCustomColoredScript(ColoredPayToScriptHash2, colorId));
     BOOST_CHECK(!ColoredCustomScript.IsColoredPayToScriptHash());
     BOOST_CHECK(ColoredCustomScript.IsColoredScript());
     BOOST_CHECK(GetColorIdFromScript(ColoredCustomScript).type == TokenTypes::REISSUABLE);
+
+    // In a case of 32 bytes colored identifier
+    CScript InvalidColoredCustomScript1 = CScript() << ParseHex("c11863143c14c5166804bd19203356da136c985678cd4d27a1b8c63296049032") << OP_COLOR << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(!MatchCustomColoredScript(InvalidColoredCustomScript1, colorId));
+    // In a case of 34 bytes of colored identifier
+    CScript InvalidColoredCustomScript2 = CScript() << ParseHex("c11863143c14c5166804bd19203356da136c985678cd4d27a1b8c632960490326200") << OP_COLOR << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(!MatchCustomColoredScript(InvalidColoredCustomScript2, colorId));
+    // In a case of OP_COLOR is putted at before colord identifier
+    CScript InvalidColoredCustomScript3 = CScript() << OP_COLOR << ParseHex("c11863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(!MatchCustomColoredScript(InvalidColoredCustomScript3, colorId));
+    // In a case of there is not OP_COLOR
+    CScript InvalidColoredCustomScript4 = CScript() << ParseHex("c11863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(!MatchCustomColoredScript(InvalidColoredCustomScript4, colorId));
+    // In a case of the script that drops colored identifier before evaluating OP_COLOR
+    CScript InvalidColoredCustomScript5 = CScript() << ParseHex("c11863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") << OP_DROP << OP_COLOR << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(!MatchCustomColoredScript(InvalidColoredCustomScript5, colorId));
 }
 
 #endif


### PR DESCRIPTION
The length of color ids is fixed 33 bytes. But the `MatchCustomColoredScript()` expected length 34bytes.

I guess the condition didn't consider that results of `std::distance()` include last item too. 