### PR TITLE
snap: fix build on arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,11 @@ confinement: strict
 license: MIT
 
 architectures:
-  - build-on: [amd64, arm64]
+  - build-on: amd64
+    run-on: amd64
+
+  - build-on: arm64
+    run-on: arm64
 
 apps:
   daemon:


### PR DESCRIPTION
The specification of arhchitectures was wrong. See Example 6 of [1]
for the correct one.

[1] https://snapcraft.io/docs/architectures