### PR TITLE
snap: set source-branch exlicitly

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
   tapyrus-core:
     plugin: autotools
     source: https://github.com/chaintope/tapyrus-core.git
-    source-branch: v0.4
+    source-branch: master # KEEP THIS ALWAYS MATCH TO THE BRANCH
     configflags:
       - --disable-dependency-tracking
       - --enable-zmq


### PR DESCRIPTION
master snap packages (latest channel) should always be built from master
branch.