### PR TITLE
snap: make sure /var/tmp is writable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,17 @@ apps:
     daemon: simple
     restart-condition: always
 
+layout:
+  # Make sure /var/tmp is writable by mounting as tmpfs.
+  #
+  # Berkeley DB sometimes creates temporary backing files under /var/tmp.
+  # BDB should respect TMPDIR environment variable to determine where to create
+  # such temporary files, however curiously, it sometimes ignores the
+  # environment variable. Unwritable temporary directory will prevent wallet
+  # database files from reloading.
+  /var/tmp:
+    type: tmpfs
+
 parts:
   tapyrus-core:
     plugin: autotools


### PR DESCRIPTION
Make sure /var/tmp is writable by mounting as tmpfs.

Berkeley DB sometimes creates temporary backing files under /var/tmp. BDB should respect TMPDIR environment variable to determine where to create such temporary files, however curiously, it sometimes ignores the environment variable. Unwritable temporary directory will prevent wallet database files from reloading.

----

snapパッケージはアプリケーションをサンドボックス環境で実行します。このため、ユーザーのホームディレクトリなどの限られたいくつかのディレクトリ以外はsnapアプリケーションからアクセスすることができません。

ウォレットを読み込む際に、BDBが一時ファイルを `/var/tmp` に作成しようとしますが、権限がないため一時ファイルを作成できず以下のようなエラーを出力して最終的に読み込みを諦めます。

```
2020-12-07T06:20:59Z tapyrus-core.service[100938]: BDB1586 temporary open: /var/tmp/BDB00938: Permission denied
2020-12-07T06:20:59Z tapyrus-core.service[100938]: BDB3014 unable to create temporary backing file
2020-12-07T06:20:59Z tapyrus-core.service[100938]: BDB3018 unknown: unwritable page 188 remaining in the cache after error 13
```

本来、BDBが一時ファイルを作成する先のパスは`TMPDIR`等の環境変数によって制御されますが、なぜかこれを無視して `/var/tmp` に作成する場合があるので、snapアプリケーションのサンドボックス内で `/var/tmp`を tmpfs としてすることで書き込めるようにしてこの問題を回避します。