### PR TITLE
Fix extra blocks directory bug

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -930,7 +930,7 @@ bool AppInitParameterInteraction()
 
     // also see: InitParameterInteraction()
 
-    if (!fs::is_directory(GetBlocksDir(false))) {
+    if (!fs::is_directory(GetBlocksDir())) {
         return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist."), gArgs.GetArg("-blocksdir", "").c_str()));
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -680,7 +680,6 @@ fs::path GetDefaultDataDir()
 #endif
 }
 
-static fs::path g_blocks_path_cached;
 static fs::path g_blocks_path_cache_net_specific;
 static fs::path pathCached;
 static fs::path pathCachedNetSpecific;
@@ -692,12 +691,12 @@ std::string GetDataDirNameFromNetworkId(const int networkId)
     return TAPYRUS_MODES::GetChainName(gArgs.GetChainMode()) + (strNetworkId.size() ? "-" + strNetworkId : "");
 }
 
-const fs::path &GetBlocksDir(bool fNetSpecific)
+const fs::path &GetBlocksDir()
 {
 
     LOCK(csPathCached);
 
-    fs::path &path = fNetSpecific ? g_blocks_path_cache_net_specific : g_blocks_path_cached;
+    fs::path &path = g_blocks_path_cache_net_specific;
 
     // This can be called during exceptions by LogPrintf(), so we cache the
     // value so we don't have to do memory allocations after that.
@@ -713,8 +712,8 @@ const fs::path &GetBlocksDir(bool fNetSpecific)
     } else {
         path = GetDataDir(false);
     }
-    if (fNetSpecific)
-        path /= GetDataDirNameFromNetworkId(gArgs.GetArg("-networkid", TAPYRUS_MODES::GetDefaultNetworkId(gArgs.GetChainMode())));
+
+    path /= GetDataDirNameFromNetworkId(gArgs.GetArg("-networkid", TAPYRUS_MODES::GetDefaultNetworkId(gArgs.GetChainMode())));
 
     path /= "blocks";
     fs::create_directories(path);
@@ -759,7 +758,6 @@ void ClearDatadirCache()
 
     pathCached = fs::path();
     pathCachedNetSpecific = fs::path();
-    g_blocks_path_cached = fs::path();
     g_blocks_path_cache_net_specific = fs::path();
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -93,7 +93,7 @@ fs::path GetDefaultDataDir();
  * Helper function to create data directory name using network mode and network id
 */
 std::string GetDataDirNameFromNetworkId(const int networkID);
-const fs::path &GetBlocksDir(bool fNetSpecific = true);
+const fs::path &GetBlocksDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string& confPath);


### PR DESCRIPTION
#140 -  always fetch blocks dir path based on network id. extra directory is created only when it is fetched without network id.