### PR TITLE
Added coloured coin transaction 

### DIFF
--- a/.github/workflows/push_tapyrus-builder_image.yml
+++ b/.github/workflows/push_tapyrus-builder_image.yml
@@ -27,16 +27,6 @@ jobs:
         id: prep
         run: |
           DOCKER_IMAGE=tapyrus/tapyrus-builder
-          VERSION=noop
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          fi
-          echo ::set-output name=version::${VERSION}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
       - name: Set up QEMU
@@ -57,17 +47,17 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: depends
-          file: ./Dockerfile
+          file: ./depends/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: ${{ github.event.inputs.tag }}
           labels: |
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
-            org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}
+            org.opencontainers.image.description="Base image to build the tapyrusd (Tapyrus Core) image. "
             org.opencontainers.image.url=${{ fromJson(steps.repo.outputs.result).html_url }}
             org.opencontainers.image.source=${{ fromJson(steps.repo.outputs.result).clone_url }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.version=${{ github.event.inputs.tag }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ fromJson(steps.repo.outputs.result).license.spdx_id }}

--- a/.github/workflows/push_tapyrus-builder_image.yml
+++ b/.github/workflows/push_tapyrus-builder_image.yml
@@ -26,7 +26,11 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=tapyrus/tapyrus-builder
+          DOCKER_IMAGE=tapyrus/builder
+          VERSION=${{ github.event.inputs.tag }}
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
       - name: Set up QEMU
@@ -51,13 +55,13 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: ${{ github.event.inputs.tag }}
+          tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
             org.opencontainers.image.description="Base image to build the tapyrusd (Tapyrus Core) image. "
             org.opencontainers.image.url=${{ fromJson(steps.repo.outputs.result).html_url }}
             org.opencontainers.image.source=${{ fromJson(steps.repo.outputs.result).clone_url }}
-            org.opencontainers.image.version=${{ github.event.inputs.tag }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ fromJson(steps.repo.outputs.result).license.spdx_id }}

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -76,6 +76,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         spend_102_1_id = self.nodes[0].sendrawtransaction(spend_102_1_raw)
 
         self.sync_all()
+        
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, timelock_tx_id})
         
         for node in self.nodes:
@@ -90,10 +91,12 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
             node.invalidateblock(new_blocks[0])
 
         self.sync_all()
+        # create a coloured coin transaction 
         color_txid=create_colored_transaction(2, 1000, self.nodes[0])['txid'] 
         color_txid_1= create_colored_transaction(3, 1, self.nodes[0])['txid']
         new_blocks.extend(self.nodes[1].generate(1, self.signblockprivkey_wif))
-
+        
+        # Use inavalidate block to re-org
         for node in self.nodes:
             node.invalidateblock(new_blocks[2])
 

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -9,7 +9,7 @@ Test re-org scenarios with a mempool that contains transactions
 that spend (directly or indirectly) coinbase transactions.
 """
 
-from test_framework.blocktools import create_raw_transaction
+from test_framework.blocktools import create_raw_transaction, create_colored_transaction
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
@@ -59,6 +59,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.nodes[0].generate(1, self.signblockprivkey_wif)
         # Time-locked transaction is still too immature to spend
         assert_raises_rpc_error(-26, 'non-final', self.nodes[0].sendrawtransaction, timelock_tx)
+        print(spend_102_id)
+        print(spend_103_id)
 
         # Create 102_1 and 103_1:
         spend_102_1_raw = create_raw_transaction(self.nodes[0], spend_102_id, node1_address, amount=49.98)
@@ -77,12 +79,14 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.sync_all()
 
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, timelock_tx_id})
+        print(self.nodes[0].getrawmempool())
 
         for node in self.nodes:
             node.invalidateblock(last_block[0])
         # Time-locked transaction is now too immature and has been removed from the mempool
         # spend_103_1 has been re-orged out of the chain and is back in the mempool
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, spend_103_1_id})
+        print(self.nodes[0].getrawmempool())
 
         # Use invalidateblock to re-org back and make all those coinbase spends
         # immature/invalid:
@@ -90,9 +94,17 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
             node.invalidateblock(new_blocks[0])
 
         self.sync_all()
+        color_txid=create_colored_transaction(2, 1000, self.nodes[0])['txid'] 
+        color_txid_1= create_colored_transaction(3, 1, self.nodes[0])['txid']
+        print(color_txid)
+        new_blocks.extend(self.nodes[1].generate(1, self.signblockprivkey_wif))
+        #assert_equal(set(self.nodes[0].getrawmempool()), set())
+
+        for node in self.nodes:
+            node.invalidateblock(new_blocks[2])
 
         # mempool should be empty.
-        assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_id, spend_102_1_id, spend_103_id, spend_103_1_id})
+        assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_id, spend_102_1_id, spend_103_id, spend_103_1_id,color_txid,color_txid_1})
 
 if __name__ == '__main__':
     MempoolCoinbaseTest().main()

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -59,8 +59,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.nodes[0].generate(1, self.signblockprivkey_wif)
         # Time-locked transaction is still too immature to spend
         assert_raises_rpc_error(-26, 'non-final', self.nodes[0].sendrawtransaction, timelock_tx)
-        print(spend_102_id)
-        print(spend_103_id)
+        
 
         # Create 102_1 and 103_1:
         spend_102_1_raw = create_raw_transaction(self.nodes[0], spend_102_id, node1_address, amount=49.98)
@@ -77,16 +76,13 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         spend_102_1_id = self.nodes[0].sendrawtransaction(spend_102_1_raw)
 
         self.sync_all()
-
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, timelock_tx_id})
-        print(self.nodes[0].getrawmempool())
-
+        
         for node in self.nodes:
             node.invalidateblock(last_block[0])
         # Time-locked transaction is now too immature and has been removed from the mempool
         # spend_103_1 has been re-orged out of the chain and is back in the mempool
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, spend_103_1_id})
-        print(self.nodes[0].getrawmempool())
 
         # Use invalidateblock to re-org back and make all those coinbase spends
         # immature/invalid:
@@ -96,9 +92,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.sync_all()
         color_txid=create_colored_transaction(2, 1000, self.nodes[0])['txid'] 
         color_txid_1= create_colored_transaction(3, 1, self.nodes[0])['txid']
-        print(color_txid)
         new_blocks.extend(self.nodes[1].generate(1, self.signblockprivkey_wif))
-        #assert_equal(set(self.nodes[0].getrawmempool()), set())
 
         for node in self.nodes:
             node.invalidateblock(new_blocks[2])

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -5,7 +5,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test resurrection of mined transactions when the blockchain is re-organized."""
 
-from test_framework.blocktools import create_raw_transaction
+
+from test_framework.blocktools import create_raw_transaction, create_colored_transaction
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
@@ -60,6 +61,34 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # mempool should be empty, all txns confirmed
         assert_equal(set(self.nodes[0].getrawmempool()), set())
         for txid in spends1_id+spends2_id:
+            tx = self.nodes[0].gettransaction(txid)
+            assert(tx["confirmations"] > 0)
+        
+
+        blocks.extend(self.nodes[0].generate(1, self.signblockprivkey_wif))
+
+        color_txid=[create_colored_transaction(2, 1000, self.nodes[0])['txid'], create_colored_transaction(3, 1, self.nodes[0])['txid']]
+
+        blocks.extend(self.nodes[0].generate(1, self.signblockprivkey_wif))
+
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+        for txid in color_txid:
+            tx = self.nodes[0].gettransaction(txid)
+            assert(tx["confirmations"] > 0)
+        
+        for node in self.nodes:
+            node.invalidateblock(blocks[3])
+
+        assert_equal(set(self.nodes[0].getrawmempool()), set(color_txid))
+        for txid in color_txid:
+            tx = self.nodes[0].gettransaction(txid)
+            assert(tx["confirmations"] == 0)
+
+        
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+       
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+        for txid in color_txid:
             tx = self.nodes[0].gettransaction(txid)
             assert(tx["confirmations"] > 0)
 

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -50,9 +50,16 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         for node in self.nodes:
             node.invalidateblock(blocks[0])
 
+        color_txid=[create_colored_transaction(2, 1000, self.nodes[0])['txid'], create_colored_transaction(3, 1, self.nodes[0])['txid']]
+        blocks.extend(self.nodes[0].generate(1, self.signblockprivkey_wif))
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+
+        for node in self.nodes:
+            node.invalidateblock(blocks[2])
+
         # All txns should be back in mempool with 0 confirmations
-        assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id))
-        for txid in spends1_id+spends2_id:
+        assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id+color_txid))
+        for txid in spends1_id+spends2_id+color_txid:
             tx = self.nodes[0].gettransaction(txid)
             assert(tx["confirmations"] == 0)
 
@@ -60,35 +67,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.nodes[0].generate(1, self.signblockprivkey_wif)
         # mempool should be empty, all txns confirmed
         assert_equal(set(self.nodes[0].getrawmempool()), set())
-        for txid in spends1_id+spends2_id:
-            tx = self.nodes[0].gettransaction(txid)
-            assert(tx["confirmations"] > 0)
-        
-
-        blocks.extend(self.nodes[0].generate(1, self.signblockprivkey_wif))
-
-        color_txid=[create_colored_transaction(2, 1000, self.nodes[0])['txid'], create_colored_transaction(3, 1, self.nodes[0])['txid']]
-
-        blocks.extend(self.nodes[0].generate(1, self.signblockprivkey_wif))
-
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
-        for txid in color_txid:
-            tx = self.nodes[0].gettransaction(txid)
-            assert(tx["confirmations"] > 0)
-        
-        for node in self.nodes:
-            node.invalidateblock(blocks[3])
-
-        assert_equal(set(self.nodes[0].getrawmempool()), set(color_txid))
-        for txid in color_txid:
-            tx = self.nodes[0].gettransaction(txid)
-            assert(tx["confirmations"] == 0)
-
-        
-        self.nodes[0].generate(1, self.signblockprivkey_wif)
-       
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
-        for txid in color_txid:
+        for txid in spends1_id+spends2_id+color_txid:
             tx = self.nodes[0].gettransaction(txid)
             assert(tx["confirmations"] > 0)
 

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -50,16 +50,19 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         for node in self.nodes:
             node.invalidateblock(blocks[0])
 
-        color_txid=[create_colored_transaction(2, 1000, self.nodes[0])['txid'], create_colored_transaction(3, 1, self.nodes[0])['txid']]
+        color_id=[create_colored_transaction(2, 1000, self.nodes[0])['txid'], create_colored_transaction(3, 1, self.nodes[0])['txid']]
         blocks.extend(self.nodes[0].generate(1, self.signblockprivkey_wif))
+        
+        # mempool should be empty, all txns confirmed 
         assert_equal(set(self.nodes[0].getrawmempool()), set())
-
+        
+        # Use invalidate to re-org back 
         for node in self.nodes:
             node.invalidateblock(blocks[2])
 
         # All txns should be back in mempool with 0 confirmations
-        assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id+color_txid))
-        for txid in spends1_id+spends2_id+color_txid:
+        assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id+color_id))
+        for txid in spends1_id+spends2_id+color_id:
             tx = self.nodes[0].gettransaction(txid)
             assert(tx["confirmations"] == 0)
 
@@ -67,7 +70,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.nodes[0].generate(1, self.signblockprivkey_wif)
         # mempool should be empty, all txns confirmed
         assert_equal(set(self.nodes[0].getrawmempool()), set())
-        for txid in spends1_id+spends2_id+color_txid:
+        for txid in spends1_id+spends2_id+color_id:
             tx = self.nodes[0].gettransaction(txid)
             assert(tx["confirmations"] > 0)
 

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -14,7 +14,7 @@ but less mature coinbase spends are NOT.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.blocktools import create_raw_transaction,create_colored_transaction
+from test_framework.blocktools import create_raw_transaction
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
 
@@ -30,7 +30,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         # Coinbase at height chain_height-100+1 ok in mempool, should
         # get mined. Coinbase at height chain_height-100+2 is
         # is too immature to spend.
-        b = [self.nodes[0].getblockhash(n) for n in range(1, 4)]
+        b = [self.nodes[0].getblockhash(n) for n in range(1, 3)]
         coinbase_txids = [self.nodes[0].getblock(h)['tx'][0] for h in b]
         spends_raw = [create_raw_transaction(self.nodes[0], txid, node0_address, amount=49.99) for txid in coinbase_txids]
 
@@ -49,12 +49,6 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         # ... and now height 102 can be spent:
         spend_102_id = self.nodes[0].sendrawtransaction(spends_raw[1])
         assert_equal(self.nodes[0].getrawmempool(), [ spend_102_id ])
-
-        self.nodes[0].generate(1, self.signblockprivkey_wif)
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
-
-        color_txid=[create_colored_transaction(2, 1000, self.nodes[0])['txid'], create_colored_transaction(3, 1, self.nodes[0])['txid']]
-        assert_equal(self.nodes[0].getrawmempool(),  color_txid )
 
 if __name__ == '__main__':
     MempoolSpendCoinbaseTest().main()


### PR DESCRIPTION
coloured coin transactions is added to mempool along with raw transactions to test resurrect when the blockchain is reorganized
mempool_spent_coinbase is deleted as is is not relevant to tapyrus and  coinbase transactions don’t have a maturity period so they can be spent in the next block.