### PR TITLE
Ignore error raised by test framework when stop command cannot be sent to tapyrusd using cli

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -380,6 +380,9 @@ class TestNodeCLI():
             if match:
                 code, message = match.groups()
                 raise JSONRPCException(dict(code=int(code), message=message))
+            #if stop command could not be delivered its not an error.
+            if command == 'stop' and re.match(r'error: Could not connect to the server\n(.*)', cli_stderr):
+                return 0
             # Ignore cli_stdout, raise with cli_stderr
             raise subprocess.CalledProcessError(returncode, self.binary, output=cli_stderr)
         try:


### PR DESCRIPTION
do not raise exception when "stop" command cannot be delivered when Tapyrusd is stopping.

In the call stack below Tapyrus-cli was not able to send "Stop" command and raises the exception. 
```
    self.stop_node(i)
    self.nodes[i].stop_node(expected_stderr)
    self.stop()
    return self.cli.send_cli(self.command, *args, **kwargs)
    raise subprocess.CalledProcessError(returncode, self.binary, output=cli_stderr)
```
But logs show that the node has already stopped. 
```
node0 2021-10-26T06:17:48.395114Z BerkeleyBatch::Rewrite: Rewriting wallet.dat... 
5359
 test  2021-10-26T06:17:48.405000Z TestFramework.node0 (DEBUG): Stopping node 
5360
 test  2021-10-26T06:17:48.405000Z TestFramework.bitcoincli (DEBUG): Running tapyrus-cli command: stop 
5361
 node0 2021-10-26T06:17:48.408810Z Interrupting HTTP server 
5362
 node0 2021-10-26T06:17:48.408905Z Interrupting HTTP RPC server 
5363
 node0 2021-10-26T06:17:48.408919Z Interrupting RPC 
5364
 node0 2021-10-26T06:17:48.408939Z Shutdown: In progress... 
5365
 node0 2021-10-26T06:17:48.408957Z Stopping HTTP RPC server 
5366
 node0 2021-10-26T06:17:48.408988Z Unregistering HTTP handler for / (exactmatch 1) 
5367
 node0 2021-10-26T06:17:48.408999Z Unregistering HTTP handler for /wallet/ (exactmatch 0) 
5368
 node0 2021-10-26T06:17:48.409009Z Stopping RPC 
5369
 node0 2021-10-26T06:17:48.409010Z addcon thread exit 
5370
 node0 2021-10-26T06:17:48.409084Z RPC stopped. 
```

Re running the jobs usually fixes the error. This looks like a race condition that can be ignored in the test framework. 