### PR TITLE
Fixed colored coin transaction reorg failure

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -89,11 +89,10 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool 
     bool fCoinbase = tx.IsCoinBase();
     const uint256& txid = tx.GetHashMalFix();
     for (size_t i = 0; i < tx.vout.size(); ++i) {
-        ColorIdentifier colorId(GetColorIdFromScript(tx.vout[i].scriptPubKey));
         bool overwrite = check ? cache.HaveCoin(COutPoint(txid, i)) : fCoinbase;
         // Always set the possible_overwrite flag to AddCoin for coinbase txn, in order to correctly
         // deal with the pre-BIP30 occurrences of duplicate coinbase transactions.
-        cache.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase, colorId.type), overwrite);
+        cache.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase), overwrite);
     }
 }
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -226,7 +226,8 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
         }
 
         // Check for negative or overflow input values
-        if(coin.type == TokenTypes::NONE)
+        ColorIdentifier cid = GetColorIdFromScript(coin.out.scriptPubKey);
+        if(cid.type == TokenTypes::NONE)
             nValueIn += coin.out.nValue;
         if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -555,7 +555,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
         for (const CCoin& coin : outs) {
             UniValue utxo(UniValue::VOBJ);
             utxo.pushKV("height", (int32_t)coin.nHeight);
-            ColorIdentifier colorId(std::move(GetColorIdFromScript(coin.out.scriptPubKey)));
+            ColorIdentifier colorId(GetColorIdFromScript(coin.out.scriptPubKey));
             utxo.pushKV("token", colorId.toHexString());
             utxo.pushKV("value", (colorId.type == TokenTypes::NONE ? ValueFromAmount(coin.out.nValue) : coin.out.nValue ));
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -853,7 +853,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
                 outputs.clear();
             }
             prevkey = key.hashMalFix;
-            outputs[key.n] = std::move(coin);
+            outputs.emplace(key.n, coin);
         } else {
             return error("%s: unable to read value", __func__);
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -843,8 +843,7 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
         }
         const CScript& prevPubKey = coin.out.scriptPubKey;
         const CAmount& amount = coin.out.nValue;
-        ColorIdentifier colorId = GetColorIdFromScript(coin.out.scriptPubKey);
-        inBalances[colorId] += amount;
+        inBalances[GetColorIdFromScript(coin.out.scriptPubKey)] += amount;
 
         SignatureData sigdata = DataFromTransaction(mtx, i, coin.out);
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
@@ -854,8 +853,9 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
 
         UpdateInput(txin, sigdata);
 
+        ColorIdentifier tempColorId;
         ScriptError serror = SCRIPT_ERR_OK;
-        if (!VerifyScript(txin.scriptSig, prevPubKey, nullptr, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&txConst, i, amount), colorId, &serror)) {
+        if (!VerifyScript(txin.scriptSig, prevPubKey, nullptr, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&txConst, i, amount), tempColorId, &serror)) {
             if (serror == SCRIPT_ERR_INVALID_STACK_OPERATION) {
                 // Unable to sign input and verification failed (possible attempt to partially sign).
                 TxInErrorToJSON(txin, vErrors, "Unable to sign input, invalid stack size (possibly missing key)");

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
             // Update the expected result to know about the new output coins
             assert(tx.vout.size() == 1);
             const COutPoint outpoint(tx.GetHashMalFix(), 0);
-            result[outpoint] = Coin(tx.vout[0], height, CTransaction(tx).IsCoinBase(), TokenTypes::NONE);
+            result[outpoint] = Coin(tx.vout[0], height, CTransaction(tx).IsCoinBase());
 
             // Call UpdateCoins on the top cache
             CTxUndo undo;
@@ -479,33 +479,30 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 BOOST_AUTO_TEST_CASE(ccoins_serialization)
 {
     // Good example  - ColorID = 00
-    CDataStream ss0(ParseHex("97f23c835800816115944e077fe7c803cfa57f29b36bf87c1d3500"), SER_DISK, CLIENT_VERSION);
+    CDataStream ss0(ParseHex("97f23c835800816115944e077fe7c803cfa57f29b36bf87c1d35"), SER_DISK, CLIENT_VERSION);
     Coin cc1;
     ss0 >> cc1;
     BOOST_CHECK_EQUAL(cc1.fCoinBase, false);
     BOOST_CHECK_EQUAL(cc1.nHeight, 203998U);
     BOOST_CHECK_EQUAL(cc1.out.nValue, CAmount{60000000000});
     BOOST_CHECK_EQUAL(HexStr(cc1.out.scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))))));
-    BOOST_CHECK_EQUAL(TokenToUint(cc1.type), 0);
 
     // Good example - ColorID = 01
-    CDataStream ss1(ParseHex("97f23c835800816115944e077fe7c803cfa57f29b36bf87c1d3501"), SER_DISK, CLIENT_VERSION);
+    CDataStream ss1(ParseHex("97f23c835800816115944e077fe7c803cfa57f29b36bf87c1d35"), SER_DISK, CLIENT_VERSION);
     ss1 >> cc1;
     BOOST_CHECK_EQUAL(cc1.fCoinBase, false);
     BOOST_CHECK_EQUAL(cc1.nHeight, 203998U);
     BOOST_CHECK_EQUAL(cc1.out.nValue, CAmount{60000000000});
     BOOST_CHECK_EQUAL(HexStr(cc1.out.scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))))));
-    BOOST_CHECK_EQUAL(TokenToUint(cc1.type), 0);
 
     // Good example
-    CDataStream ss2(ParseHex("8ddf77bbd123008c988f1a4a4de2161e0f50aac7f17e7f9555caa4c1"), SER_DISK, CLIENT_VERSION);
+    CDataStream ss2(ParseHex("8ddf77bbd123008c988f1a4a4de2161e0f50aac7f17e7f9555caa4"), SER_DISK, CLIENT_VERSION);
     Coin cc2;
     ss2 >> cc2;
     BOOST_CHECK_EQUAL(cc2.fCoinBase, true);
     BOOST_CHECK_EQUAL(cc2.nHeight, 120891U);
     BOOST_CHECK_EQUAL(cc2.out.nValue, 110397);
     BOOST_CHECK_EQUAL(HexStr(cc2.out.scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
-    BOOST_CHECK_EQUAL(TokenToUint(cc2.type), 0xc1);
 
     // Smallest possible example
     CDataStream ss3(ParseHex("000006c2"), SER_DISK, CLIENT_VERSION);
@@ -515,7 +512,6 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     BOOST_CHECK_EQUAL(cc3.nHeight, 0U);
     BOOST_CHECK_EQUAL(cc3.out.nValue, 0);
     BOOST_CHECK_EQUAL(cc3.out.scriptPubKey.size(), 0U);
-    BOOST_CHECK_EQUAL(TokenToUint(cc3.type), 0xc2);
 
     // scriptPubKey that ends beyond the end of the stream
     CDataStream ss4(ParseHex("000007"), SER_DISK, CLIENT_VERSION);
@@ -731,7 +727,7 @@ static void CheckAddCoinBase(CAmount base_value, CAmount cache_value, CAmount mo
     try {
         CTxOut output;
         output.nValue = modify_value;
-        test.cache.AddCoin(OUTPOINT, Coin(std::move(output), 1, coinbase, TokenTypes::NONE), coinbase);
+        test.cache.AddCoin(OUTPOINT, Coin(std::move(output), 1, coinbase), coinbase);
         test.cache.SelfTest();
         GetCoinsMapEntry(test.cache.map(), result_value, result_flags);
     } catch (std::logic_error& e) {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -388,8 +388,7 @@ bool CCoinsViewDB::Upgrade() {
             COutPoint outpoint(key.second, 0);
             for (size_t i = 0; i < old_coins.vout.size(); ++i) {
                 if (!old_coins.vout[i].IsNull() && !old_coins.vout[i].scriptPubKey.IsUnspendable()) {
-                    ColorIdentifier colorId(GetColorIdFromScript(old_coins.vout[i].scriptPubKey));
-                    Coin newcoin(std::move(old_coins.vout[i]), old_coins.nHeight, old_coins.fCoinBase, colorId.type);
+                    Coin newcoin(std::move(old_coins.vout[i]), old_coins.nHeight, old_coins.fCoinBase);
                     outpoint.n = i;
                     CoinEntry entry(&outpoint);
                     batch.Write(entry, newcoin);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -890,8 +890,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     CTransactionRef ptx = mempool.get(outpoint.hashMalFix);
     if (ptx) {
         if (outpoint.n < ptx->vout.size()) {
-            ColorIdentifier colorId(GetColorIdFromScript(ptx->vout[outpoint.n].scriptPubKey));
-            coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false, colorId.type);
+            coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);
             return true;
         } else {
             return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -587,7 +587,8 @@ bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& stat
             const Coin& coin = inputs.AccessCoin(txin.prevout);
             ColorIdentifier coinColorId;
 
-            switch(coin.type)
+            ColorIdentifier cid = GetColorIdFromScript(coin.out.scriptPubKey);
+            switch(cid.type)
             {
                 // when the coin is TPC this is a token issue tx. 
                 // colorid is hash(coin's scriptpubkey) or prevout
@@ -1736,9 +1737,11 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
         for (size_t o = 0; o < tx.vout.size(); o++) {
             if (!tx.vout[o].scriptPubKey.IsUnspendable()) {
                 COutPoint out(hash, o);
+                ColorIdentifier cid = GetColorIdFromScript(tx.vout[o].scriptPubKey);
                 Coin coin;
                 bool is_spent = view.SpendCoin(out, &coin);
-                if (!is_spent || tx.vout[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.fCoinBase) {
+                ColorIdentifier coincid = GetColorIdFromScript(coin.out.scriptPubKey);
+                if (!is_spent || tx.vout[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.fCoinBase || cid != coincid ) {
                     fClean = false; // transaction output mismatch
                 }
             }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2422,16 +2422,12 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
 
     TxColoredCoinBalancesMap walletbalances = pwallet->GetBalance();
     for (auto const& wb : walletbalances) {
-        if (wb.first.type == TokenTypes::NONE) {
-            balances.pushKV(CURRENCY_UNIT.c_str(), ValueFromAmount(wb.second));
-        } else {
-            balances.pushKV(wb.first.toHexString(), wb.second);
-        }
+        balances.pushKV(wb.first.toHexString(), wb.first.type == TokenTypes::NONE ? ValueFromAmount(wb.second) : wb.second);
     };
 
     TxColoredCoinBalancesMap walletunconfirmedbalances = pwallet->GetUnconfirmedBalance();
     for (auto const& uwb : walletunconfirmedbalances) {
-        unconfirmBalancesObj.pushKV(uwb.first.toHexString(), ValueFromAmount(uwb.second));
+        unconfirmBalancesObj.pushKV(uwb.first.toHexString(), uwb.first.type == TokenTypes::NONE ? ValueFromAmount(uwb.second) : uwb.second);
     };
 
     size_t kpExternalSize = pwallet->KeypoolCountExternalKeys();


### PR DESCRIPTION
Removed token type stored in Coin class. As this is not stored in CTxUndo correctly token issue transactions were getting dropped from mempool after reorg.
It is not needed in cache a it can be accessed from the scriptpubkey inside Coin class.