### PR TITLE
Fix tapyrus signer bound

### DIFF
--- a/doc/tapyrus/getting_started.md
+++ b/doc/tapyrus/getting_started.md
@@ -8,7 +8,7 @@ Tapyrus network has different kinds of nodes, this is a minimal list at the time
 
 | Node type |    How many? | Purpose |
 | :---: | :---: | :---: |
-|Tapyrus Signer | min 3, max 15  | A network of signers that collects Unapproved transactions from the Tapyrus network and creates a block. |
+|Tapyrus Signer | min 3, unbounded  | A network of signers that collects Unapproved transactions from the Tapyrus network and creates a block. |
 | Tapyrus Core  | min 1, unbounded  | Tapyrus full node implementation |
 | Tapyrus Seeder | min 1, unbounded  | DNS seeder for configuring Tapyrus network |
 


### PR DESCRIPTION
Until v0.2.0, ECDSA was used to sign blocks, requiring a threshold number of signatures. In this case, an upper limit was set because the signature size increased linearly with the increase in the threshold value.
Starting with v0.3.0, we introduced Schnorr's aggregate signature and implemented a t-of-n threshold signature scheme in tapyrus-signer. This removes the upper limit restriction.