### PR TITLE
Coloured coin support in tapyrus QT overview page

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -69,18 +69,27 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     WalletTx result;
     result.tx = wtx.tx;
     result.txin_is_mine.reserve(wtx.tx->vin.size());
+    result.txin_color_id.reserve(wtx.tx->vin.size());
+    result.txin_amount.reserve(wtx.tx->vin.size());
     for (const auto& txin : wtx.tx->vin) {
         result.txin_is_mine.emplace_back(wallet.IsMine(txin));
+        ColorIdentifier colorId;
+        CAmount val = wallet.GetDebit(txin, ISMINE_ALL, colorId);
+        result.txin_color_id.emplace_back(colorId.type != TokenTypes::NONE ? colorId.toHexString() : std::string());
+        result.txin_amount.emplace_back(val);
     }
     result.txout_is_mine.reserve(wtx.tx->vout.size());
     result.txout_address.reserve(wtx.tx->vout.size());
     result.txout_address_is_mine.reserve(wtx.tx->vout.size());
+    result.txout_color_id.reserve(wtx.tx->vout.size());
     for (const auto& txout : wtx.tx->vout) {
         result.txout_is_mine.emplace_back(wallet.IsMine(txout));
         result.txout_address.emplace_back();
         result.txout_address_is_mine.emplace_back(ExtractDestination(txout.scriptPubKey, result.txout_address.back()) ?
                                                       IsMine(wallet, result.txout_address.back()) :
                                                       ISMINE_NO);
+        ColorIdentifier cid = GetColorIdFromScript(txout.scriptPubKey);
+        result.txout_color_id.emplace_back(cid.type != TokenTypes::NONE ? cid.toHexString() : std::string());
     }
     result.credits = wallet.GetCredit(*wtx.tx, ISMINE_ALL);
     result.debits = wallet.GetDebit(*wtx.tx, ISMINE_ALL);
@@ -364,11 +373,7 @@ public:
         num_blocks = ::chainActive.Height();
         return true;
     }
-    CAmount getBalance() override { return m_wallet.GetBalance()[ColorIdentifier()]; }
-    CAmount getAvailableBalance(const CCoinControl& coin_control) override
-    {
-        return m_wallet.GetAvailableBalance(&coin_control)[ColorIdentifier()];
-    }
+    CAmount getBalance(ColorIdentifier colorId) override { return m_wallet.GetBalance()[colorId]; }
     CAmount getAvailableBalance(const CCoinControl& coin_control, const ColorIdentifier& colorId) override
     {
         return m_wallet.GetAvailableBalance(&coin_control)[colorId];

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -389,6 +389,7 @@ struct WalletBalances
 
     void prev()
     {
+        if (tokens.empty()) return;
         if(tokenIndex != tokens.begin())
             tokenIndex--;
         else
@@ -400,6 +401,7 @@ struct WalletBalances
 
     void next()
     {
+        if (tokens.empty()) return;
         if(tokenIndex != tokens.end())
         {
             tokenIndex++;
@@ -410,11 +412,13 @@ struct WalletBalances
 
     bool isToken()
     {
+        if (tokens.empty()) return false;
         return (*tokenIndex).type != TokenTypes::NONE;
     }
 
     std::string getTokenName()
     {
+        if (tokens.empty()) return "";
         return (*tokenIndex).toHexString();
     }
 };

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -200,11 +200,10 @@ public:
     virtual bool tryGetBalances(WalletBalances& balances, int& num_blocks) = 0;
 
     //! Get balance.
-    virtual CAmount getBalance() = 0;
+    virtual CAmount getBalance(ColorIdentifier colorId = ColorIdentifier()) = 0;
 
     //! Get available balance.
-    virtual CAmount getAvailableBalance(const CCoinControl& coin_control) = 0;
-    virtual CAmount getAvailableBalance(const CCoinControl& coin_control, const ColorIdentifier& colorId) = 0;
+    virtual CAmount getAvailableBalance(const CCoinControl& coin_control, const ColorIdentifier& colorId = ColorIdentifier()) = 0;
 
     //! Issue a new REISSUABLE token; generates address and script internally.
     virtual TokenIssuanceResult issueNewReissuableToken(CAmount value) = 0;
@@ -333,32 +332,35 @@ struct WalletBalances
     bool have_watch_only;
     TxColoredCoinBalancesMap watch_only_balances;
     TxColoredCoinBalancesMap unconfirmed_watch_only_balances;
+    std::set<ColorIdentifier> tokens;
+    std::set<ColorIdentifier>::iterator tokenIndex;
 
     WalletBalances(){
         have_watch_only = false;
+        tokenIndex = tokens.begin();
     }
 
-    CAmount getBalance(const ColorIdentifier& colorId = ColorIdentifier()) const
+    CAmount getBalance() const
     {
-        auto it = balances.find(colorId);
+        auto it = balances.find(*tokenIndex);
         return it != balances.end() ? it->second : 0;
     }
 
-    CAmount getUnconfirmedBalance(const ColorIdentifier& colorId = ColorIdentifier()) const
+    CAmount getUnconfirmedBalance() const
     {
-        auto it = unconfirmed_balances.find(colorId);
+        auto it = unconfirmed_balances.find(*tokenIndex);
         return it != unconfirmed_balances.end() ? it->second : 0;
     }
 
-    CAmount getWatchOnlyBalance(const ColorIdentifier& colorId = ColorIdentifier()) const
+    CAmount getWatchOnlyBalance() const
     {
-        auto it = watch_only_balances.find(colorId);
+        auto it = watch_only_balances.find(*tokenIndex);
         return it != watch_only_balances.end() ? it->second : 0;
     }
 
-    CAmount getUnconfirmedWatchOnlyBalance(const ColorIdentifier& colorId = ColorIdentifier()) const
+    CAmount getUnconfirmedWatchOnlyBalance() const
     {
-        auto it = unconfirmed_watch_only_balances.find(colorId);
+        auto it = unconfirmed_watch_only_balances.find(*tokenIndex);
         return it != unconfirmed_watch_only_balances.end() ? it->second : 0;
     }
 
@@ -367,6 +369,53 @@ struct WalletBalances
         return balances != prev.balances || unconfirmed_balances != prev.unconfirmed_balances ||
                watch_only_balances != prev.watch_only_balances ||
                unconfirmed_watch_only_balances != prev.unconfirmed_watch_only_balances;
+    }
+
+    //collect all tokens in the wallet from all the balance lists
+    void refreshTokens() {
+        tokens.clear();
+
+        for(auto pair:balances)
+            tokens.insert(pair.first);
+        for(auto pair:unconfirmed_balances)
+            tokens.insert(pair.first);
+        for(auto pair:watch_only_balances)
+            tokens.insert(pair.first);
+        for(auto pair:unconfirmed_watch_only_balances)
+            tokens.insert(pair.first);
+
+        tokenIndex = tokens.begin();
+    }
+
+    void prev()
+    {
+        if(tokenIndex != tokens.begin())
+            tokenIndex--;
+        else
+        {
+            tokenIndex = tokens.end();
+            tokenIndex--;
+        }
+    }
+
+    void next()
+    {
+        if(tokenIndex != tokens.end())
+        {
+            tokenIndex++;
+            if(tokenIndex == tokens.end())
+                tokenIndex = tokens.begin();
+        }
+    }
+
+    bool isToken()
+    {
+        return (*tokenIndex).type != TokenTypes::NONE;
+    }
+
+    std::string getTokenName()
+    {
+        return (*tokenIndex).toHexString();
     }
 };
 
@@ -378,6 +427,9 @@ struct WalletTx
     std::vector<isminetype> txout_is_mine;
     std::vector<CTxDestination> txout_address;
     std::vector<isminetype> txout_address_is_mine;
+    std::vector<std::string> txout_color_id; // hex color ID per output, empty string for TPC outputs
+    std::vector<std::string> txin_color_id;  // hex color ID per input's prev out (empty for TPC/unknown)
+    std::vector<CAmount> txin_amount;        // nValue per input's prev out (0 if not mine)
     TxColoredCoinBalancesMap credits;
     TxColoredCoinBalancesMap debits;
     TxColoredCoinBalancesMap changes;

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -212,3 +212,19 @@ bool IsValidDestinationString(const std::string& str)
 {
     return IsValidDestinationString(str, Params());
 }
+
+bool IsColoredDestination(const std::string& str, ColorIdentifier* colorId)
+{
+    CTxDestination dest = DecodeDestination(str, Params());
+    if (const CColorKeyID* p = std::get_if<CColorKeyID>(&dest)) {
+        if (colorId)
+            *colorId = p->color;
+        return true;
+    }
+    if (const CColorScriptID* p = std::get_if<CColorScriptID>(&dest)) {
+        if (colorId)
+            *colorId = p->color;
+        return true;
+    }
+    return false;
+}

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -7,6 +7,7 @@
 #define BITCOIN_KEY_IO_H
 
 #include <chainparams.h>
+#include <coloridentifier.h>
 #include <key.h>
 #include <pubkey.h>
 #include <script/standard.h>
@@ -25,5 +26,6 @@ std::string EncodeDestination(const CTxDestination& dest);
 CTxDestination DecodeDestination(const std::string& str);
 bool IsValidDestinationString(const std::string& str);
 bool IsValidDestinationString(const std::string& str, const CChainParams& params);
+bool IsColoredDestination(const std::string& str, ColorIdentifier* colorId = nullptr);
 
 #endif // BITCOIN_KEY_IO_H

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>596</width>
-    <height>342</height>
+    <width>900</width>
+    <height>420</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>820</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -36,8 +42,10 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
      <item>
+      <!-- Left column: TPC balance + Token balance -->
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
+        <!-- TPC Balance frame -->
         <widget class="QFrame" name="frame">
          <property name="frameShape">
           <enum>QFrame::StyledPanel</enum>
@@ -57,15 +65,12 @@
                </font>
               </property>
               <property name="text">
-               <string>Balances</string>
+               <string>TPC Balance</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QPushButton" name="labelWalletStatus">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
               <property name="maximumSize">
                <size>
                 <width>30</width>
@@ -114,149 +119,13 @@
             <property name="spacing">
              <number>12</number>
             </property>
-            <item row="2" column="2">
-             <widget class="QLabel" name="labelWatchPending">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
-              </property>
-              <property name="toolTip">
-               <string>Unconfirmed transactions to watch-only addresses</string>
-              </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="labelSpendable">
               <property name="text">
-               <string notr="true">0.000 000 00 TPC</string>
+               <string>Spendable:</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLabel" name="labelUnconfirmed">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
-              </property>
-              <property name="toolTip">
-               <string>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
-              </property>
-              <property name="text">
-               <string notr="true">0.000 000 00 TPC</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0" colspan="2">
-             <widget class="Line" name="line">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="2">
-             <widget class="Line" name="lineWatchBalance">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>140</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="labelTotalText">
-              <property name="text">
-               <string>Total:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="4" column="1">
-             <widget class="QLabel" name="labelTotal">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
-              </property>
-              <property name="toolTip">
-               <string>Your current total balance</string>
-              </property>
-              <property name="text">
-               <string notr="true">0.000 000 00 TPC</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="2">
-             <widget class="QLabel" name="labelWatchTotal">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
-              </property>
-              <property name="toolTip">
-               <string>Current total balance in watch-only addresses</string>
-              </property>
-              <property name="text">
-               <string notr="true">0.000 000 00 TPC</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -292,7 +161,7 @@
                <string>Your current spendable balance</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 TPC</string>
+               <string notr="true">0.000 000 00 TPC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -317,7 +186,7 @@
                <string>Your current balance in watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 TPC</string>
+               <string notr="true">0.000 000 00 TPC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -334,13 +203,314 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="labelSpendable">
+            <item row="2" column="1">
+             <widget class="QLabel" name="labelUnconfirmed">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
+              </property>
               <property name="text">
-               <string>Spendable:</string>
+               <string notr="true">0.000 000 00 TPC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="labelWatchPending">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Unconfirmed transactions to watch-only addresses</string>
+              </property>
+              <property name="text">
+               <string notr="true">0.000 000 00 TPC</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="3" column="0" colspan="2">
+             <widget class="Line" name="line">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <widget class="Line" name="lineWatchBalance">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="labelTotalText">
+              <property name="text">
+               <string>Total:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLabel" name="labelTotal">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Your current total balance</string>
+              </property>
+              <property name="text">
+               <string notr="true">0.000 000 00 TPC</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="QLabel" name="labelWatchTotal">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Current total balance in watch-only addresses</string>
+              </property>
+              <property name="text">
+               <string notr="true">0.000 000 00 TPC</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <!-- Token Balance frame -->
+        <widget class="QFrame" name="frameToken">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_token">
+          <property name="spacing">
+           <number>10</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="labelTokenHeader">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Token Balance</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboToken">
+            <property name="toolTip">
+             <string>Select a token to view its balance</string>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayoutToken">
+            <property name="spacing">
+             <number>12</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="labelTokenAvailableText">
+              <property name="text">
+               <string>Available:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="labelTokenBalance">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Confirmed token balance for the selected token</string>
+              </property>
+              <property name="text">
+               <string notr="true">0</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <spacer name="horizontalSpacer_token">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="labelTokenPendingText">
+              <property name="text">
+               <string>Pending:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="labelTokenUnconfirmed">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Unconfirmed token balance for the selected token</string>
+              </property>
+              <property name="text">
+               <string notr="true">0</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <widget class="Line" name="lineToken">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="labelTokenTotalText">
+              <property name="text">
+               <string>Total:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="labelTokenTotal">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Total token balance (confirmed + unconfirmed)</string>
+              </property>
+              <property name="text">
+               <string notr="true">0</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -365,6 +535,7 @@
       </layout>
      </item>
      <item>
+      <!-- Right column: Recent transactions -->
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QFrame" name="frame_2">

--- a/src/qt/issuetoken.cpp
+++ b/src/qt/issuetoken.cpp
@@ -97,10 +97,8 @@ void IssueTokenDialog::setModel(WalletModel *_model)
 {
     model = _model;
     if (model) {
-        refreshTokenTable();
-        connect(model, &WalletModel::balanceChanged,
-                this,  &IssueTokenDialog::refreshTokenTable);
-        connect(model, &WalletModel::tokenAddressBookChanged,
+        refreshTokenTable(model->getIssuedTokens());
+        connect(model, &WalletModel::tokenListChanged,
                 this,  &IssueTokenDialog::refreshTokenTable);
     }
 }
@@ -115,13 +113,12 @@ void IssueTokenDialog::clear()
 
 // ── Public slots ─────────────────────────────────────────────────────────────
 
-void IssueTokenDialog::refreshTokenTable()
+void IssueTokenDialog::refreshTokenTable(const QList<WalletModel::IssuedTokenRecord>& tokens)
 {
     if (!model)
         return;
 
-    // Rebuild m_tokens from the wallet address book (shared with RPC layer)
-    m_tokens = model->getIssuedTokens();
+    m_tokens = tokens;
 
     // Remember the currently selected colorId so we can restore it after the rebuild
     QString selectedColorId;
@@ -228,9 +225,7 @@ void IssueTokenDialog::on_issueButton_clicked()
     WalletModel::IssueTokenResult result = model->issueToken(tokenType, tokenValue, existingColorId);
 
     if (result.status == WalletModel::IssueTokenResult::OK) {
-        // Address book was updated by the wallet during issuance/reissuance;
-        // refresh the table from the wallet directly.
-        refreshTokenTable();
+        refreshTokenTable(model->getIssuedTokens());
 
         // Save label (if provided) to the colored address in the address book.
         // This applies equally to new issuance and reissue — both produce a
@@ -244,7 +239,7 @@ void IssueTokenDialog::on_issueButton_clicked()
                 }
             }
             // Refresh again so the table shows the saved label
-            refreshTokenTable();
+            refreshTokenTable(model->getIssuedTokens());
         }
 
         highlightTokenRow(result.color);
@@ -354,7 +349,7 @@ void IssueTokenDialog::on_burnButton_clicked()
 
     if (result.status == WalletModel::BurnTokenResult::OK) {
         ui->burnAmountEdit->clear();
-        refreshTokenTable(); // update balances
+        refreshTokenTable(model->getIssuedTokens());
         highlightTokenRow(colorId);
         Q_EMIT message(tr("Burn Token"),
                        tr("Tokens burned successfully.\nColor: %1").arg(colorId),

--- a/src/qt/issuetoken.h
+++ b/src/qt/issuetoken.h
@@ -44,7 +44,7 @@ public:
 
 public Q_SLOTS:
     void clear();
-    void refreshTokenTable();   // re-read tokens and balances from wallet
+    void refreshTokenTable(const QList<WalletModel::IssuedTokenRecord>& tokens);
 
 Q_SIGNALS:
     void message(const QString &title, const QString &message, unsigned int style);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -14,7 +14,6 @@
 #include <qt/transactionfilterproxy.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/walletmodel.h>
-
 #include <QAbstractItemDelegate>
 #include <QPainter>
 
@@ -31,7 +30,6 @@ public:
         QAbstractItemDelegate(parent), unit(TapyrusUnits::TPC),
         platformStyle(_platformStyle)
     {
-
     }
 
     inline void paint(QPainter *painter, const QStyleOptionViewItem &option,
@@ -52,8 +50,8 @@ public:
 
         QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
         QString address = index.data(Qt::DisplayRole).toString();
-        qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
         bool confirmed = index.data(TransactionTableModel::ConfirmedRole).toBool();
+        bool isToken = index.data(TransactionTableModel::IsTokenRole).toBool();
         QVariant value = index.data(Qt::ForegroundRole);
         QColor foreground = option.palette.color(QPalette::Text);
         if(value.canConvert<QBrush>())
@@ -73,7 +71,17 @@ public:
             iconWatchonly.paint(painter, watchonlyRect);
         }
 
-        if(amount < 0)
+        QString amountText;
+        qint64 netAmount;
+        if (isToken) {
+            netAmount = index.data(TransactionTableModel::TokenAmountRole).toLongLong();
+            amountText = TapyrusUnits::format(TapyrusUnits::TOKEN, netAmount, true, TapyrusUnits::separatorAlways);
+        } else {
+            netAmount = index.data(TransactionTableModel::AmountRole).toLongLong();
+            amountText = TapyrusUnits::formatWithUnit(unit, netAmount, true, TapyrusUnits::separatorAlways);
+        }
+
+        if(netAmount < 0)
         {
             foreground = COLOR_NEGATIVE;
         }
@@ -86,7 +94,6 @@ public:
             foreground = option.palette.color(QPalette::Text);
         }
         painter->setPen(foreground);
-        QString amountText = TapyrusUnits::formatWithUnit(unit, amount, true, TapyrusUnits::separatorAlways);
         if(!confirmed)
         {
             amountText = QString("[") + amountText + QString("]");
@@ -119,11 +126,9 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
 {
     ui->setupUi(this);
 
-    m_balances.balances[ColorIdentifier()] = -1;
-
     // use a SingleColorIcon for the "out of sync warning" icon
     QIcon icon = platformStyle->SingleColorIcon(":/icons/warning");
-    icon.addPixmap(icon.pixmap(QSize(64,64), QIcon::Normal), QIcon::Disabled); // also set the disabled icon because we are using a disabled QPushButton to work around missing HiDPI support of QLabel (https://bugreports.qt.io/browse/QTBUG-42503)
+    icon.addPixmap(icon.pixmap(QSize(64,64), QIcon::Normal), QIcon::Disabled);
     ui->labelTransactionsStatus->setIcon(icon);
     ui->labelWalletStatus->setIcon(icon);
 
@@ -134,6 +139,12 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
 
     connect(ui->listTransactions, &QAbstractItemView::clicked, this, &OverviewPage::handleTransactionClicked);
+
+    // Token box: hidden until a wallet with tokens is loaded
+    ui->frameToken->setVisible(false);
+
+    connect(ui->comboToken, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &OverviewPage::onTokenSelectionChanged);
 
     // start with displaying the "out of sync" warnings
     showOutOfSyncWarning(true);
@@ -157,33 +168,132 @@ OverviewPage::~OverviewPage()
     delete ui;
 }
 
-void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
+void OverviewPage::updateTpcBalances()
 {
-    int unit = walletModel->getOptionsModel()->getDisplayUnit();
-    m_balances = balances;
+    if (!walletModel || !walletModel->getOptionsModel())
+        return;
 
-    CAmount balance = balances.getBalance();
-    CAmount unconfirmed_balance = balances.getUnconfirmedBalance();
-    CAmount watch_only_balance = balances.getWatchOnlyBalance();
-    CAmount unconfirmed_watch_only_balance = balances.getUnconfirmedWatchOnlyBalance();
+    int unit = walletModel->getOptionsModel()->getDisplayUnit();
+    ColorIdentifier tpc; // default-constructed = NONE = TPC
+
+    auto conf_it = m_balances.balances.find(tpc);
+    CAmount balance = (conf_it != m_balances.balances.end()) ? conf_it->second : 0;
+
+    auto unconf_it = m_balances.unconfirmed_balances.find(tpc);
+    CAmount unconfirmed = (unconf_it != m_balances.unconfirmed_balances.end()) ? unconf_it->second : 0;
+
+    auto wo_it = m_balances.watch_only_balances.find(tpc);
+    CAmount watchOnly = (wo_it != m_balances.watch_only_balances.end()) ? wo_it->second : 0;
+
+    auto wou_it = m_balances.unconfirmed_watch_only_balances.find(tpc);
+    CAmount watchOnlyUnconf = (wou_it != m_balances.unconfirmed_watch_only_balances.end()) ? wou_it->second : 0;
 
     ui->labelBalance->setText(TapyrusUnits::formatWithUnit(unit, balance, false, TapyrusUnits::separatorAlways));
-    ui->labelUnconfirmed->setText(TapyrusUnits::formatWithUnit(unit, balance, false, TapyrusUnits::separatorAlways));
-    ui->labelTotal->setText(TapyrusUnits::formatWithUnit(unit, balance + unconfirmed_balance, false, TapyrusUnits::separatorAlways));
-    ui->labelWatchAvailable->setText(TapyrusUnits::formatWithUnit(unit, watch_only_balance, false, TapyrusUnits::separatorAlways));
-    ui->labelWatchPending->setText(TapyrusUnits::formatWithUnit(unit, unconfirmed_watch_only_balance, false, TapyrusUnits::separatorAlways));
-    ui->labelWatchTotal->setText(TapyrusUnits::formatWithUnit(unit, watch_only_balance + unconfirmed_watch_only_balance, false, TapyrusUnits::separatorAlways));
+    ui->labelUnconfirmed->setText(TapyrusUnits::formatWithUnit(unit, unconfirmed, false, TapyrusUnits::separatorAlways));
+    ui->labelTotal->setText(TapyrusUnits::formatWithUnit(unit, balance + unconfirmed, false, TapyrusUnits::separatorAlways));
+    ui->labelWatchAvailable->setText(TapyrusUnits::formatWithUnit(unit, watchOnly, false, TapyrusUnits::separatorAlways));
+    ui->labelWatchPending->setText(TapyrusUnits::formatWithUnit(unit, watchOnlyUnconf, false, TapyrusUnits::separatorAlways));
+    ui->labelWatchTotal->setText(TapyrusUnits::formatWithUnit(unit, watchOnly + watchOnlyUnconf, false, TapyrusUnits::separatorAlways));
+}
+
+void OverviewPage::refreshTokenList()
+{
+    if (!walletModel)
+        return;
+
+    // Remember the currently selected colorId so we can restore it after repopulating
+    QString selectedColorId;
+    int cur = ui->comboToken->currentIndex();
+    if (cur >= 0 && cur < m_tokenRecords.size())
+        selectedColorId = m_tokenRecords[cur].colorId;
+
+    // Fetch all issued tokens and keep only those with a non-zero total balance
+    m_tokenRecords.clear();
+    for (const WalletModel::IssuedTokenRecord& rec : walletModel->getIssuedTokens()) {
+        if (rec.balance + rec.unconfirmedBalance != 0)
+            m_tokenRecords.append(rec);
+    }
+
+    // Block signals while repopulating to avoid spurious onTokenSelectionChanged calls
+    ui->comboToken->blockSignals(true);
+    ui->comboToken->clear();
+
+    static const QMap<QString, QString> typeIcons = {
+        {"REISSUABLE",     ":/icons/token_reissuable"},
+        {"NON_REISSUABLE", ":/icons/token_nonreissuable"},
+        {"NFT",            ":/icons/token_nft"},
+    };
+
+    for (const WalletModel::IssuedTokenRecord& rec : m_tokenRecords) {
+        QIcon icon(typeIcons.value(rec.tokenType));
+        ui->comboToken->addItem(icon, rec.colorId, rec.colorId);
+        int idx = ui->comboToken->count() - 1;
+        ui->comboToken->setItemData(idx, rec.colorId, Qt::ToolTipRole);
+    }
+
+    ui->comboToken->blockSignals(false);
+
+    // Restore previous selection by colorId (stored as item data), else default to first item
+    int restoreIndex = 0;
+    if (!selectedColorId.isEmpty()) {
+        int found = ui->comboToken->findData(selectedColorId);
+        if (found >= 0)
+            restoreIndex = found;
+    }
+
+    bool hasTokens = ui->comboToken->count() > 0;
+    ui->frameToken->setVisible(hasTokens);
+
+    if (hasTokens) {
+        ui->comboToken->setCurrentIndex(restoreIndex);
+        updateTokenBalance(restoreIndex);
+    }
+}
+
+void OverviewPage::onTokenSelectionChanged(int index)
+{
+    updateTokenBalance(index);
+}
+
+void OverviewPage::updateTokenBalance(int index)
+{
+    if (index < 0 || index >= m_tokenRecords.size()) {
+        ui->labelTokenBalance->setText("0");
+        ui->labelTokenUnconfirmed->setText("0");
+        ui->labelTokenTotal->setText("0");
+        return;
+    }
+
+    const WalletModel::IssuedTokenRecord& rec = m_tokenRecords[index];
+
+    // Balance values
+    ui->labelTokenBalance->setText(TapyrusUnits::format(TapyrusUnits::TOKEN, rec.balance, false, TapyrusUnits::separatorAlways));
+    ui->labelTokenUnconfirmed->setText(TapyrusUnits::format(TapyrusUnits::TOKEN, rec.unconfirmedBalance, false, TapyrusUnits::separatorAlways));
+    ui->labelTokenTotal->setText(TapyrusUnits::format(TapyrusUnits::TOKEN, rec.balance + rec.unconfirmedBalance, false, TapyrusUnits::separatorAlways));
+
+    // Tooltips: append colorId to existing tooltip text
+    QString colorTip = QString("\nColor ID: %1").arg(rec.colorId);
+    ui->labelTokenBalance->setToolTip(tr("Confirmed token balance for the selected token") + colorTip);
+    ui->labelTokenUnconfirmed->setToolTip(tr("Unconfirmed token balance for the selected token") + colorTip);
+    ui->labelTokenTotal->setToolTip(tr("Total token balance (confirmed + unconfirmed)") + colorTip);
+}
+
+void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
+{
+    m_balances = balances;
+    updateTpcBalances();
+    refreshTokenList();
 }
 
 // show/hide watch-only labels
 void OverviewPage::updateWatchOnlyLabels(bool showWatchOnly)
 {
-    ui->labelSpendable->setVisible(showWatchOnly);      // show spendable label (only when watch-only is active)
-    ui->labelWatchonly->setVisible(showWatchOnly);      // show watch-only label
-    ui->lineWatchBalance->setVisible(showWatchOnly);    // show watch-only balance separator line
-    ui->labelWatchAvailable->setVisible(showWatchOnly); // show watch-only available balance
-    ui->labelWatchPending->setVisible(showWatchOnly);   // show watch-only pending balance
-    ui->labelWatchTotal->setVisible(showWatchOnly);     // show watch-only total balance
+    ui->labelSpendable->setVisible(showWatchOnly);
+    ui->labelWatchonly->setVisible(showWatchOnly);
+    ui->lineWatchBalance->setVisible(showWatchOnly);
+    ui->labelWatchAvailable->setVisible(showWatchOnly);
+    ui->labelWatchPending->setVisible(showWatchOnly);
+    ui->labelWatchTotal->setVisible(showWatchOnly);
 }
 
 void OverviewPage::setClientModel(ClientModel *model)
@@ -191,7 +301,6 @@ void OverviewPage::setClientModel(ClientModel *model)
     this->clientModel = model;
     if(model)
     {
-        // Show warning if this is a prerelease version
         connect(model, &ClientModel::alertsChanged, this, &OverviewPage::updateAlerts);
         updateAlerts(model->getStatusBarWarnings());
     }
@@ -219,6 +328,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         interfaces::WalletBalances balances = wallet.getBalances();
         setBalance(balances);
         connect(model, &WalletModel::balanceChanged, this, &OverviewPage::setBalance);
+        connect(model, &WalletModel::tokenListChanged, this, [this](const QList<WalletModel::IssuedTokenRecord>&){ refreshTokenList(); });
 
         connect(model->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &OverviewPage::updateDisplayUnit);
 
@@ -226,7 +336,6 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(model, &WalletModel::notifyWatchonlyChanged, this, &OverviewPage::updateWatchOnlyLabels);
     }
 
-    // update the display unit, to not use the default ("TPC")
     updateDisplayUnit();
 }
 
@@ -234,13 +343,8 @@ void OverviewPage::updateDisplayUnit()
 {
     if(walletModel && walletModel->getOptionsModel())
     {
-        if (m_balances.getBalance() != -1) {
-            setBalance(m_balances);
-        }
-
-        // Update txdelegate->unit with the current unit
+        updateTpcBalances();
         txdelegate->unit = walletModel->getOptionsModel()->getDisplayUnit();
-
         ui->listTransactions->update();
     }
 }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_OVERVIEWPAGE_H
 
 #include <interfaces/wallet.h>
+#include <qt/walletmodel.h>
 
 #include <QWidget>
 #include <memory>
@@ -47,12 +48,17 @@ private:
     ClientModel *clientModel;
     WalletModel *walletModel;
     interfaces::WalletBalances m_balances;
+    QList<WalletModel::IssuedTokenRecord> m_tokenRecords;
 
     TxViewDelegate *txdelegate;
     std::unique_ptr<TransactionFilterProxy> filter;
 
 private Q_SLOTS:
     void updateDisplayUnit();
+    void updateTpcBalances();
+    void refreshTokenList();
+    void onTokenSelectionChanged(int index);
+    void updateTokenBalance(int index);
     void handleTransactionClicked(const QModelIndex &index);
     void updateAlerts(const QString &warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -52,6 +52,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
     QAction *copyMessageAction = new QAction(tr("Copy message"), this);
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
+    QAction *copyColorIdAction = new QAction(tr("Copy color ID"), this);
 
     // context menu
     contextMenu = new QMenu(this);
@@ -59,6 +60,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyMessageAction);
     contextMenu->addAction(copyAmountAction);
+    contextMenu->addAction(copyColorIdAction);
 
     // context menu signals
     connect(ui->recentRequestsView, &QAbstractItemView::customContextMenuRequested, this, &ReceiveCoinsDialog::showMenu);
@@ -66,6 +68,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
     connect(copyLabelAction, &QAction::triggered, this, &ReceiveCoinsDialog::copyLabel);
     connect(copyMessageAction, &QAction::triggered, this, &ReceiveCoinsDialog::copyMessage);
     connect(copyAmountAction, &QAction::triggered, this, &ReceiveCoinsDialog::copyAmount);
+    connect(copyColorIdAction, &QAction::triggered, this, &ReceiveCoinsDialog::copyColorId);
 
     connect(ui->clearButton, &QPushButton::clicked, this, &ReceiveCoinsDialog::clear);
 }
@@ -113,7 +116,7 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
     {
         _model->getRecentRequestsTableModel()->sort(RecentRequestsTableModel::Date, Qt::DescendingOrder);
         connect(_model->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &ReceiveCoinsDialog::updateDisplayUnit);
-        connect(_model, &WalletModel::tokenAddressBookChanged, this, &ReceiveCoinsDialog::refreshTokenCombo);
+        connect(_model, &WalletModel::tokenListChanged, this, &ReceiveCoinsDialog::refreshTokenCombo);
         connect(ui->radioToken, &QRadioButton::toggled, this, &ReceiveCoinsDialog::on_radioToken_toggled);
         connect(ui->reqToken, QOverload<int>::of(&QComboBox::currentIndexChanged),
                 this, &ReceiveCoinsDialog::on_reqToken_currentIndexChanged);
@@ -391,4 +394,10 @@ void ReceiveCoinsDialog::copyMessage()
 void ReceiveCoinsDialog::copyAmount()
 {
     copyColumnToClipboard(RecentRequestsTableModel::Amount);
+}
+
+// context menu action: copy color ID
+void ReceiveCoinsDialog::copyColorId()
+{
+    copyColumnToClipboard(RecentRequestsTableModel::Token);
 }

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -81,6 +81,7 @@ private Q_SLOTS:
     void copyLabel();
     void copyMessage();
     void copyAmount();
+    void copyColorId();
 };
 
 #endif // BITCOIN_QT_RECEIVECOINSDIALOG_H

--- a/src/qt/tapyrusunits.cpp
+++ b/src/qt/tapyrusunits.cpp
@@ -200,12 +200,7 @@ bool TapyrusUnits::parse(int unit, const QString &value, CAmount *val_out)
 
 QString TapyrusUnits::getAmountColumnTitle(int unit)
 {
-    QString amountTitle = QObject::tr("Amount");
-    if (TapyrusUnits::valid(unit))
-    {
-        amountTitle += " ("+TapyrusUnits::shortName(unit) + ")";
-    }
-    return amountTitle;
+    return QObject::tr("Amount");
 }
 
 int TapyrusUnits::rowCount(const QModelIndex &parent) const

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -170,15 +170,28 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
                 strHTML += "<b>" + tr("From") + ":</b> " + tr("watch-only") + "<br>";
 
             //
-            // Debit
+            // Debit (TPC outputs only; token outputs handled in the token section below)
             //
             auto mine = wtx.txout_is_mine.begin();
-            for (const CTxOut& txout : wtx.tx->vout)
+            for (unsigned int i = 0; i < wtx.tx->vout.size(); i++)
             {
-                // Ignore change
-                isminetype toSelf = *(mine++);
-                if ((toSelf == ISMINE_SPENDABLE) && (fAllFromMe == ISMINE_SPENDABLE))
+                const CTxOut& txout = wtx.tx->vout[i];
+                isminetype toSelf = wtx.txout_is_mine[i];
+
+                // Skip colored outputs — shown in the token section below
+                if (!wtx.txout_color_id[i].empty())
+                {
+                    ++mine;
                     continue;
+                }
+
+                // Ignore TPC change
+                if ((toSelf == ISMINE_SPENDABLE) && (fAllFromMe == ISMINE_SPENDABLE))
+                {
+                    ++mine;
+                    continue;
+                }
+                ++mine;
 
                 if (!wtx.value_map.count("to") || wtx.value_map["to"].empty())
                 {
@@ -213,10 +226,6 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
                 strHTML += "<b>" + tr("Total debit") + ":</b> " + TapyrusUnits::formatHtmlWithUnit(unit, -nValue) + "<br>";
                 strHTML += "<b>" + tr("Total credit") + ":</b> " + TapyrusUnits::formatHtmlWithUnit(unit, nValue) + "<br>";
             }
-
-            CAmount nTxFee = nDebit - wtx.tx->GetValueOut(ColorIdentifier());
-            if (nTxFee > 0)
-                strHTML += "<b>" + tr("Transaction fee") + ":</b> " + TapyrusUnits::formatHtmlWithUnit(unit, -nTxFee) + "<br>";
         }
         else
         {
@@ -230,15 +239,65 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
                 }
             }
             mine = wtx.txout_is_mine.begin();
-            for (const CTxOut& txout : wtx.tx->vout) {
+            for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
                 if (*(mine++)) {
-                    strHTML += "<b>" + tr("Credit") + ":</b> " + TapyrusUnits::formatHtmlWithUnit(unit, wallet.getCredit(txout, ISMINE_ALL)) + "<br>";
+                    // Skip colored outputs — shown in token section
+                    if (!wtx.txout_color_id[i].empty()) continue;
+                    strHTML += "<b>" + tr("Credit") + ":</b> " + TapyrusUnits::formatHtmlWithUnit(unit, wallet.getCredit(wtx.tx->vout[i], ISMINE_ALL)) + "<br>";
                 }
             }
         }
     }
 
     strHTML += "<b>" + tr("Net amount") + ":</b> " + TapyrusUnits::formatHtmlWithUnit(unit, nNet, true) + "<br>";
+
+    //
+    // Token section: one block per color ID showing credit and debit
+    //
+    {
+        std::map<std::string, CAmount> tokenCredit, tokenDebit;
+        for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
+            if (wtx.txout_color_id[i].empty()) continue;
+            if (wtx.txout_is_mine[i] != ISMINE_NO)
+                tokenCredit[wtx.txout_color_id[i]] += wtx.tx->vout[i].nValue;
+        }
+        for (unsigned int i = 0; i < wtx.txin_color_id.size(); i++) {
+            if (wtx.txin_color_id[i].empty()) continue;
+            tokenDebit[wtx.txin_color_id[i]] += wtx.txin_amount[i];
+        }
+
+        std::set<std::string> allColorHexes;
+        for (const auto& e : tokenCredit) allColorHexes.insert(e.first);
+        for (const auto& e : tokenDebit)  allColorHexes.insert(e.first);
+
+        if (!allColorHexes.empty()) {
+            for (const std::string& colorHex : allColorHexes) {
+                CAmount cAmt = tokenCredit.count(colorHex) ? tokenCredit.at(colorHex) : 0;
+                CAmount dAmt = tokenDebit.count(colorHex)  ? tokenDebit.at(colorHex)  : 0;
+                strHTML += "<hr>";
+                strHTML += "<b>" + tr("Token") + ":</b> " + GUIUtil::HtmlEscape(colorHex) + "<br>";
+                strHTML += "<b>" + tr("Total debit") + ":</b> " +
+                    TapyrusUnits::format(TapyrusUnits::TOKEN, -dAmt, true, TapyrusUnits::separatorAlways) + "<br>";
+                strHTML += "<b>" + tr("Total credit") + ":</b> " +
+                    TapyrusUnits::format(TapyrusUnits::TOKEN, cAmt, true, TapyrusUnits::separatorAlways) + "<br>";
+            }
+            strHTML += "<hr>";
+        }
+    }
+
+    //
+    // TPC fee (shown after token section)
+    //
+    {
+        isminetype fAllFromMe2 = ISMINE_SPENDABLE;
+        for (isminetype mine : wtx.txin_is_mine)
+            if (fAllFromMe2 > mine) fAllFromMe2 = mine;
+        if (fAllFromMe2) {
+            CAmount nTxFee = nDebit - wtx.tx->GetValueOut(ColorIdentifier());
+            if (nTxFee > 0)
+                strHTML += "<b>" + tr("Transaction fee") + ":</b> " + TapyrusUnits::formatHtmlWithUnit(unit, -nTxFee) + "<br>";
+        }
+    }
 
     //
     // Message

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -188,24 +188,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         }
     }
 
-    // For token transactions funded by this wallet, show each TPC change output
-    // as a SendToSelf row so the user can see the TPC balance returned.
-    if (hasTokenInvolvement && fAllFromMe != ISMINE_NO) {
-        for (unsigned int nOut = 0; nOut < wtx.tx->vout.size(); nOut++) {
-            if (!wtx.txout_color_id[nOut].empty()) continue; // token outputs handled separately
-            if (!wtx.txout_is_mine[nOut]) continue;          // only mine TPC outputs
-            const CTxOut& txout = wtx.tx->vout[nOut];
-            TransactionRecord sub(hash, nTime);
-            sub.idx = nOut;
-            sub.involvesWatchAddress = involvesWatchAddress;
-            sub.credit = txout.nValue;
-            sub.type = TransactionRecord::SendToSelf;
-            if (!std::get_if<CNoDestination>(&wtx.txout_address[nOut]))
-                sub.address = EncodeDestination(wtx.txout_address[nOut]);
-            parts.append(sub);
-        }
-    }
-
     // --- Token records ---
     // Compute token credit/debit directly from the transaction's outputs and inputs,
     // similar to how TPC amounts are derived from txout.nValue / prev-out nValue.
@@ -272,8 +254,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         // self) OR has a genuine recipient address.  The burn script
         // (OP_COLOR + OP_TRUE) has CNoDestination and is not mine, so it is
         // intentionally excluded — otherwise a burn would be misclassified as
-        // a TokenTransfer.  Outgoing transfers to another wallet still have a
-        // real destination address, so they are correctly kept as transfers.
+        // a send.  Outgoing transfers to another wallet still have a real
+        // destination address, so they are correctly classified as sends.
         bool hasColoredOutputForColor = false;
         for (unsigned int i = 0; i < wtx.txout_color_id.size(); i++) {
             if (wtx.txout_color_id[i] != colorHex) continue;
@@ -283,57 +265,70 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         }
 
         bool isIssue = (netAmt > 0 && fAllFromMe);
-        bool isBurn  = (netAmt < 0 && !hasColoredOutputForColor);
+        bool isBurn  = (debitAmt > 0 && !hasColoredOutputForColor);
 
-        // For transfers with both credit and debit: show two entries so the
-        // user can differentiate the send side (negative) from the receive
-        // side (positive) by address.
-        if (!isIssue && !isBurn && creditAmt > 0 && debitAmt > 0) {
-            auto [creditIdx, creditAddr, creditWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
-            auto [debitIdx,  debitAddr,  debitWatch]  = findColoredOutput(colorHex, /*preferMine=*/false, creditIdx);
+        TransactionRecord sub(hash, nTime);
+        sub.colorId   = colorHex;
+        sub.tokenType = tokenTypeName(colorId.type);
+        sub.involvesWatchAddress = involvesWatchAddress;
 
-            TransactionRecord credit(hash, nTime);
-            credit.idx    = creditIdx >= 0 ? creditIdx : 0;
-            credit.colorId    = colorHex;
-            credit.tokenType  = tokenTypeName(colorId.type);
-            credit.tokenAmount = creditAmt;
-            credit.involvesWatchAddress = creditWatch;
-            credit.address = creditAddr;
-            credit.type   = TransactionRecord::TokenTransfer;
-            parts.append(credit);
-
-            TransactionRecord debit(hash, nTime);
-            debit.idx    = debitIdx >= 0 ? debitIdx : credit.idx;
-            debit.colorId    = colorHex;
-            debit.tokenType  = tokenTypeName(colorId.type);
-            debit.tokenAmount = -(debitAmt - creditAmt);
-            debit.involvesWatchAddress = debitWatch;
-            debit.address = debitAddr;
-            debit.type   = TransactionRecord::TokenTransfer;
-            parts.append(debit);
+        if (isIssue) {
+            // Tokens received as issuance or reissuance
+            auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
+            sub.idx = outIdx >= 0 ? outIdx : 0;
+            sub.address = addr;
+            sub.involvesWatchAddress = involvesWatch;
+            sub.tokenAmount = netAmt;
+            sub.type = TransactionRecord::TokenIssue;
+            parts.append(sub);
             return;
         }
 
-        // Single record for issuance, burn, or pure send/receive
-        auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, netAmt >= 0);
-
-        TransactionRecord sub(hash, nTime);
-        sub.idx = outIdx >= 0 ? outIdx : 0;
-        sub.colorId = colorHex;
-        sub.tokenType = tokenTypeName(colorId.type);
-        sub.tokenAmount = netAmt;
-        sub.involvesWatchAddress = involvesWatch;
-        sub.address = addr;
-
-        if (isIssue) {
-            sub.type = TransactionRecord::TokenIssue;
-        } else if (isBurn) {
+        if (isBurn) {
+            // Tokens destroyed — no colored output recipient
+            auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/false);
+            sub.idx = outIdx >= 0 ? outIdx : 0;
+            sub.address = addr;
+            sub.involvesWatchAddress = involvesWatch;
+            sub.tokenAmount = netAmt; // negative
             sub.type = TransactionRecord::TokenBurn;
-        } else {
-            sub.type = TransactionRecord::TokenTransfer;
+            parts.append(sub);
+            return;
         }
 
-        parts.append(sub);
+        // --- Token transfer (not issuance, not burn) ---
+        // Use TPC-style types based on who sent/received.
+        if (debitAmt > 0 && creditAmt > 0 && netAmt == 0) {
+            // Self-transfer: tokens moved between own addresses (address rotation or
+            // payment to own known address).  Subtract change so we show the
+            // intentional payment amount, mirroring the TPC SendToSelf logic.
+            auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
+            sub.idx = outIdx >= 0 ? outIdx : 0;
+            sub.address = addr;
+            sub.involvesWatchAddress = involvesWatch;
+            CAmount tokenChange = wtx.getChange(colorId);
+            sub.tokenAmount = creditAmt - tokenChange;
+            sub.type = TransactionRecord::SendToSelf;
+            parts.append(sub);
+        } else if (debitAmt > 0) {
+            // Wallet sent tokens (net outflow); show the recipient output
+            auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/false);
+            sub.idx = outIdx >= 0 ? outIdx : 0;
+            sub.address = addr;
+            sub.involvesWatchAddress = involvesWatch;
+            sub.tokenAmount = netAmt; // negative
+            sub.type = addr.empty() ? TransactionRecord::SendToOther : TransactionRecord::SendToAddress;
+            parts.append(sub);
+        } else {
+            // Pure receive: wallet received tokens from an external sender
+            auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
+            sub.idx = outIdx >= 0 ? outIdx : 0;
+            sub.address = addr;
+            sub.involvesWatchAddress = involvesWatch;
+            sub.tokenAmount = creditAmt;
+            sub.type = addr.empty() ? TransactionRecord::RecvFromOther : TransactionRecord::RecvWithAddress;
+            parts.append(sub);
+        }
     };
 
     for (const std::string& colorHex : allColorHexes) {
@@ -353,17 +348,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
     // Stamp fee on every record so the tooltip can display it
     for (TransactionRecord& sub : parts)
         sub.tpcFee = tpcFeeAmt;
-
-    // For token transactions funded by this wallet, emit an explicit fee row
-    if (hasTokenInvolvement && tpcFeeAmt > 0) {
-        TransactionRecord feeRec(hash, nTime);
-        feeRec.idx = (int)wtx.tx->vout.size(); // sort after all outputs
-        feeRec.debit = -tpcFeeAmt;
-        feeRec.tpcFee = tpcFeeAmt;
-        feeRec.involvesWatchAddress = involvesWatchAddress;
-        feeRec.type = TransactionRecord::TPCFee;
-        parts.append(feeRec);
-    }
 
     return parts;
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -21,6 +21,16 @@ bool TransactionRecord::showTransaction()
     return true;
 }
 
+static std::string tokenTypeName(TokenTypes type)
+{
+    switch (type) {
+        case TokenTypes::REISSUABLE:     return "REISSUABLE";
+        case TokenTypes::NON_REISSUABLE: return "NON_REISSUABLE";
+        case TokenTypes::NFT:            return "NFT";
+        default:                         return "";
+    }
+}
+
 /*
  * Decompose CWallet transaction to model transaction records.
  */
@@ -35,6 +45,33 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
     uint256 hash = wtx.tx->GetHashMalFix();
     std::map<std::string, std::string> mapValue = wtx.value_map;
 
+    // Compute input/output mine status upfront — used by both TPC and token sections
+    bool involvesWatchAddress = false;
+    isminetype fAllFromMe = ISMINE_SPENDABLE;
+    for (isminetype mine : wtx.txin_is_mine) {
+        if (mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+        if (fAllFromMe > mine) fAllFromMe = mine;
+    }
+    isminetype fAllToMe = ISMINE_SPENDABLE;
+    for (isminetype mine : wtx.txout_is_mine) {
+        if (mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+        if (fAllToMe > mine) fAllToMe = mine;
+    }
+
+
+    // Does any output carry a colored script?
+    bool hasColoredOutputs = false;
+    for (const auto& cid : wtx.txout_color_id) if (!cid.empty()) { hasColoredOutputs = true; break; }
+
+    // Does any input spend a colored UTXO?
+    bool hasColoredInputs = false;
+    for (unsigned int i = 0; i < wtx.txin_color_id.size(); i++)
+        if (!wtx.txin_color_id[i].empty()) { hasColoredInputs = true; break; }
+
+    // If any tokens are involved, suppress standalone TPC records —
+    // the token record(s) will carry the full picture (tpcFee in tooltip).
+    bool hasTokenInvolvement = hasColoredOutputs || hasColoredInputs;
+
     if (nNet > 0 || wtx.is_coinbase)
     {
         //
@@ -44,6 +81,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         {
             const CTxOut& txout = wtx.tx->vout[i];
             isminetype mine = wtx.txout_is_mine[i];
+            // Skip token outputs here; they are handled in the token section below
+            if (!wtx.txout_color_id[i].empty())
+                continue;
             if(mine)
             {
                 TransactionRecord sub(hash, nTime);
@@ -74,47 +114,40 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
     }
     else
     {
-        bool involvesWatchAddress = false;
-        isminetype fAllFromMe = ISMINE_SPENDABLE;
-        for (isminetype mine : wtx.txin_is_mine)
-        {
-            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllFromMe > mine) fAllFromMe = mine;
-        }
-
-        isminetype fAllToMe = ISMINE_SPENDABLE;
-        for (isminetype mine : wtx.txout_is_mine)
-        {
-            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllToMe > mine) fAllToMe = mine;
-        }
-
         if (fAllFromMe && fAllToMe)
         {
-            // Payment to self
-            CAmount nChange = wtx.getChange();
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
-                            -(nDebit - nChange), nCredit - nChange));
-            parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
+            // Only emit a TPC self-payment record if no tokens are involved.
+            // Token transactions (issuance, burn) emit their own token record.
+            if (!hasTokenInvolvement)
+            {
+                CAmount nChange = wtx.getChange();
+                parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
+                                -(nDebit - nChange), nCredit - nChange));
+                parts.last().involvesWatchAddress = involvesWatchAddress;
+            }
         }
         else if (fAllFromMe)
         {
             //
-            // Debit
+            // Debit (TPC outputs only; token outputs handled below)
             //
             CAmount nTxFee = nDebit - wtx.tx->GetValueOut(ColorIdentifier());
 
             for (unsigned int nOut = 0; nOut < wtx.tx->vout.size(); nOut++)
             {
                 const CTxOut& txout = wtx.tx->vout[nOut];
+                // Skip token outputs; they are handled in the token section below
+                if (!wtx.txout_color_id[nOut].empty())
+                    continue;
+
                 TransactionRecord sub(hash, nTime);
                 sub.idx = nOut;
                 sub.involvesWatchAddress = involvesWatchAddress;
 
                 if(wtx.txout_is_mine[nOut])
                 {
-                    // Ignore parts sent to self, as this is usually the change
-                    // from a transaction sent back to our own address.
+                    // Change output going back to our own address — skip it.
+                    // It does not represent a meaningful send in the transaction list.
                     continue;
                 }
 
@@ -145,13 +178,163 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         }
         else
         {
-            //
-            // Mixed debit transaction, can't break down payees
-            //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
-            parts.last().involvesWatchAddress = involvesWatchAddress;
+            // Mixed debit transaction, can't break down payees.
+            // Skip if tokens are involved — the token section will emit the record.
+            if (!hasTokenInvolvement)
+            {
+                parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
+                parts.last().involvesWatchAddress = involvesWatchAddress;
+            }
         }
     }
+
+    // --- Token records ---
+    // Compute token credit/debit directly from the transaction's outputs and inputs,
+    // similar to how TPC amounts are derived from txout.nValue / prev-out nValue.
+    std::map<std::string, CAmount> tokenCredit, tokenDebit;
+    for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
+        if (wtx.txout_color_id[i].empty()) continue;
+        if (wtx.txout_is_mine[i] != ISMINE_NO)
+            tokenCredit[wtx.txout_color_id[i]] += wtx.tx->vout[i].nValue;
+    }
+    for (unsigned int i = 0; i < wtx.txin_color_id.size(); i++) {
+        if (wtx.txin_color_id[i].empty()) continue;
+        tokenDebit[wtx.txin_color_id[i]] += wtx.txin_amount[i];
+    }
+
+    // Collect all distinct color hex strings involved (credit or debit)
+    std::set<std::string> allColorHexes;
+    for (const auto& e : tokenCredit) allColorHexes.insert(e.first);
+    for (const auto& e : tokenDebit)  allColorHexes.insert(e.first);
+
+    std::set<std::string> processedColors;
+
+    // Helper: find the best output index/address for a color with a mine-preference flag.
+    auto findColoredOutput = [&](const std::string& colorHex, bool preferMine, int skipIdx = -1)
+        -> std::tuple<int, std::string, bool>
+    {
+        int outIdx = -1;
+        std::string addr;
+        bool involvesWatch = false;
+        for (unsigned int i = 0; i < wtx.txout_color_id.size(); i++) {
+            if (wtx.txout_color_id[i] != colorHex) continue;
+            if ((int)i == skipIdx) continue;
+            bool isMine = wtx.txout_is_mine[i] != ISMINE_NO;
+            if (preferMine && !isMine) continue;
+            if (!preferMine && isMine) continue;
+            outIdx = i;
+            if (!std::get_if<CNoDestination>(&wtx.txout_address[i]))
+                addr = EncodeDestination(wtx.txout_address[i]);
+            involvesWatch = wtx.txout_is_mine[i] & ISMINE_WATCH_ONLY;
+            break;
+        }
+        // Fallback: take any remaining output with this color
+        if (outIdx < 0) {
+            for (unsigned int i = 0; i < wtx.txout_color_id.size(); i++) {
+                if (wtx.txout_color_id[i] != colorHex) continue;
+                if ((int)i == skipIdx) continue;
+                outIdx = i;
+                if (!std::get_if<CNoDestination>(&wtx.txout_address[i]))
+                    addr = EncodeDestination(wtx.txout_address[i]);
+                involvesWatch = wtx.txout_is_mine[i] & ISMINE_WATCH_ONLY;
+                break;
+            }
+        }
+        return {outIdx, addr, involvesWatch};
+    };
+
+    auto appendTokenRecord = [&](const ColorIdentifier& colorId, CAmount creditAmt, CAmount debitAmt) {
+        std::string colorHex = colorId.toHexString();
+        if (!processedColors.insert(colorHex).second)
+            return; // already emitted a record for this color
+
+        CAmount netAmt = creditAmt - debitAmt;
+
+        // A "real" colored output is one that is wallet-owned (change back to
+        // self) OR has a genuine recipient address.  The burn script
+        // (OP_COLOR + OP_TRUE) has CNoDestination and is not mine, so it is
+        // intentionally excluded — otherwise a burn would be misclassified as
+        // a TokenTransfer.  Outgoing transfers to another wallet still have a
+        // real destination address, so they are correctly kept as transfers.
+        bool hasColoredOutputForColor = false;
+        for (unsigned int i = 0; i < wtx.txout_color_id.size(); i++) {
+            if (wtx.txout_color_id[i] != colorHex) continue;
+            bool isMine  = wtx.txout_is_mine[i] != ISMINE_NO;
+            bool hasAddr = !std::get_if<CNoDestination>(&wtx.txout_address[i]);
+            if (isMine || hasAddr) { hasColoredOutputForColor = true; break; }
+        }
+
+        bool isIssue = (netAmt > 0 && fAllFromMe);
+        bool isBurn  = (netAmt < 0 && !hasColoredOutputForColor);
+
+        // For transfers with both credit and debit: show two entries so the
+        // user can differentiate the send side (negative) from the receive
+        // side (positive) by address.
+        if (!isIssue && !isBurn && creditAmt > 0 && debitAmt > 0) {
+            auto [creditIdx, creditAddr, creditWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
+            auto [debitIdx,  debitAddr,  debitWatch]  = findColoredOutput(colorHex, /*preferMine=*/false, creditIdx);
+
+            TransactionRecord credit(hash, nTime);
+            credit.idx    = creditIdx >= 0 ? creditIdx : 0;
+            credit.colorId    = colorHex;
+            credit.tokenType  = tokenTypeName(colorId.type);
+            credit.tokenAmount = creditAmt;
+            credit.involvesWatchAddress = creditWatch;
+            credit.address = creditAddr;
+            credit.type   = TransactionRecord::TokenTransfer;
+            parts.append(credit);
+
+            TransactionRecord debit(hash, nTime);
+            debit.idx    = debitIdx >= 0 ? debitIdx : credit.idx;
+            debit.colorId    = colorHex;
+            debit.tokenType  = tokenTypeName(colorId.type);
+            debit.tokenAmount = -debitAmt;
+            debit.involvesWatchAddress = debitWatch;
+            debit.address = debitAddr;
+            debit.type   = TransactionRecord::TokenTransfer;
+            parts.append(debit);
+            return;
+        }
+
+        // Single record for issuance, burn, or pure send/receive
+        auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, netAmt >= 0);
+
+        TransactionRecord sub(hash, nTime);
+        sub.idx = outIdx >= 0 ? outIdx : 0;
+        sub.colorId = colorHex;
+        sub.tokenType = tokenTypeName(colorId.type);
+        sub.tokenAmount = netAmt;
+        sub.involvesWatchAddress = involvesWatch;
+        sub.address = addr;
+
+        if (isIssue) {
+            sub.type = TransactionRecord::TokenIssue;
+        } else if (isBurn) {
+            sub.type = TransactionRecord::TokenBurn;
+        } else {
+            sub.type = TransactionRecord::TokenTransfer;
+        }
+
+        parts.append(sub);
+    };
+
+    for (const std::string& colorHex : allColorHexes) {
+        const std::vector<unsigned char> vColor = ParseHex(colorHex);
+        ColorIdentifier colorId(vColor);
+        CAmount cAmt = tokenCredit.count(colorHex) ? tokenCredit[colorHex] : 0;
+        CAmount dAmt = tokenDebit.count(colorHex)  ? tokenDebit[colorHex]  : 0;
+        appendTokenRecord(colorId, cAmt, dAmt);
+    }
+
+    // Compute fee: only meaningful when wallet funded all inputs
+    CAmount tpcFeeAmt = 0;
+    if (fAllFromMe != ISMINE_NO)
+        tpcFeeAmt = nDebit - wtx.tx->GetValueOut(ColorIdentifier());
+    if (tpcFeeAmt < 0) tpcFeeAmt = 0; // guard against rounding / mixed-input edge cases
+
+    // Stamp fee on every record so the tooltip can display it
+    for (TransactionRecord& sub : parts)
+        sub.tpcFee = tpcFeeAmt;
 
     return parts;
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -188,6 +188,24 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         }
     }
 
+    // For token transactions funded by this wallet, show each TPC change output
+    // as a SendToSelf row so the user can see the TPC balance returned.
+    if (hasTokenInvolvement && fAllFromMe != ISMINE_NO) {
+        for (unsigned int nOut = 0; nOut < wtx.tx->vout.size(); nOut++) {
+            if (!wtx.txout_color_id[nOut].empty()) continue; // token outputs handled separately
+            if (!wtx.txout_is_mine[nOut]) continue;          // only mine TPC outputs
+            const CTxOut& txout = wtx.tx->vout[nOut];
+            TransactionRecord sub(hash, nTime);
+            sub.idx = nOut;
+            sub.involvesWatchAddress = involvesWatchAddress;
+            sub.credit = txout.nValue;
+            sub.type = TransactionRecord::SendToSelf;
+            if (!std::get_if<CNoDestination>(&wtx.txout_address[nOut]))
+                sub.address = EncodeDestination(wtx.txout_address[nOut]);
+            parts.append(sub);
+        }
+    }
+
     // --- Token records ---
     // Compute token credit/debit directly from the transaction's outputs and inputs,
     // similar to how TPC amounts are derived from txout.nValue / prev-out nValue.
@@ -288,7 +306,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
             debit.idx    = debitIdx >= 0 ? debitIdx : credit.idx;
             debit.colorId    = colorHex;
             debit.tokenType  = tokenTypeName(colorId.type);
-            debit.tokenAmount = -debitAmt;
+            debit.tokenAmount = -(debitAmt - creditAmt);
             debit.involvesWatchAddress = debitWatch;
             debit.address = debitAddr;
             debit.type   = TransactionRecord::TokenTransfer;
@@ -335,6 +353,17 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
     // Stamp fee on every record so the tooltip can display it
     for (TransactionRecord& sub : parts)
         sub.tpcFee = tpcFeeAmt;
+
+    // For token transactions funded by this wallet, emit an explicit fee row
+    if (hasTokenInvolvement && tpcFeeAmt > 0) {
+        TransactionRecord feeRec(hash, nTime);
+        feeRec.idx = (int)wtx.tx->vout.size(); // sort after all outputs
+        feeRec.debit = -tpcFeeAmt;
+        feeRec.tpcFee = tpcFeeAmt;
+        feeRec.involvesWatchAddress = involvesWatchAddress;
+        feeRec.type = TransactionRecord::TPCFee;
+        parts.append(feeRec);
+    }
 
     return parts;
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -299,17 +299,30 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         // --- Token transfer (not issuance, not burn) ---
         // Use TPC-style types based on who sent/received.
         if (debitAmt > 0 && creditAmt > 0 && netAmt == 0) {
-            // Self-transfer: tokens moved between own addresses (address rotation or
-            // payment to own known address).  Subtract change so we show the
-            // intentional payment amount, mirroring the TPC SendToSelf logic.
-            auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
-            sub.idx = outIdx >= 0 ? outIdx : 0;
-            sub.address = addr;
-            sub.involvesWatchAddress = involvesWatch;
+            // Tokens moved within the wallet (netAmt == 0).  Subtract change to
+            // find the intentional payment amount.
             CAmount tokenChange = wtx.getChange(colorId);
-            sub.tokenAmount = creditAmt - tokenChange;
-            sub.type = TransactionRecord::SendToSelf;
-            parts.append(sub);
+            CAmount intentionalAmt = creditAmt - tokenChange;
+            if (intentionalAmt > 0) {
+                // There is an explicit recipient output going to a receive address
+                // (even if it is also owned by this wallet) — classify as a send.
+                auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
+                sub.idx = outIdx >= 0 ? outIdx : 0;
+                sub.address = addr;
+                sub.involvesWatchAddress = involvesWatch;
+                sub.tokenAmount = intentionalAmt;
+                sub.type = addr.empty() ? TransactionRecord::SendToOther : TransactionRecord::SendToAddress;
+                parts.append(sub);
+            } else {
+                // All token outputs are change — pure internal consolidation.
+                auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/true);
+                sub.idx = outIdx >= 0 ? outIdx : 0;
+                sub.address = addr;
+                sub.involvesWatchAddress = involvesWatch;
+                sub.tokenAmount = 0;
+                sub.type = TransactionRecord::SendToSelf;
+                parts.append(sub);
+            }
         } else if (debitAmt > 0) {
             // Wallet sent tokens (net outflow); show the recipient output
             auto [outIdx, addr, involvesWatch] = findColoredOutput(colorHex, /*preferMine=*/false);

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -85,6 +85,7 @@ public:
         TokenIssue,     // Tokens minted/issued (fresh or reissuance) to this wallet
         TokenBurn,      // Tokens destroyed (no colored output recipient)
         TokenTransfer,  // Tokens transferred (sent to others, received from others, or self-transfer)
+        TPCFee,         // Network fee paid in TPC for a token transaction
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -80,20 +80,25 @@ public:
         SendToOther,
         RecvWithAddress,
         RecvFromOther,
-        SendToSelf
+        SendToSelf,
+        // Token-specific types
+        TokenIssue,     // Tokens minted/issued (fresh or reissuance) to this wallet
+        TokenBurn,      // Tokens destroyed (no colored output recipient)
+        TokenTransfer,  // Tokens transferred (sent to others, received from others, or self-transfer)
     };
 
     /** Number of confirmation recommended for accepting a transaction */
     static const int RecommendedNumConfirmations = 1;
 
     TransactionRecord():
-            hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0)
+            hash(), time(0), type(Other), address(""), debit(0), credit(0),
+            tokenAmount(0), colorId(""), tokenType(""), tpcFee(0), idx(0)
     {
     }
 
     TransactionRecord(uint256 _hash, qint64 _time):
             hash(_hash), time(_time), type(Other), address(""), debit(0),
-            credit(0), idx(0)
+            credit(0), tokenAmount(0), colorId(""), tokenType(""), tpcFee(0), idx(0)
     {
     }
 
@@ -101,7 +106,7 @@ public:
                 Type _type, const std::string &_address,
                 const CAmount& _debit, const CAmount& _credit):
             hash(_hash), time(_time), type(_type), address(_address), debit(_debit), credit(_credit),
-            idx(0)
+            tokenAmount(0), colorId(""), tokenType(""), tpcFee(0), idx(0)
     {
     }
 
@@ -118,6 +123,11 @@ public:
     std::string address;
     CAmount debit;
     CAmount credit;
+    // Token fields (empty/zero for TPC transactions)
+    CAmount tokenAmount;     // net token amount (credit - debit); 0 for TPC
+    std::string colorId;     // hex color ID; empty for TPC
+    std::string tokenType;   // "REISSUABLE", "NON_REISSUABLE", "NFT", or "" for TPC
+    CAmount tpcFee;          // TPC fee paid by this tx; 0 if wallet did not fund the fee
     /**@}*/
 
     /** Subtransaction index, for sort key */

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -84,8 +84,6 @@ public:
         // Token-specific types
         TokenIssue,     // Tokens minted/issued (fresh or reissuance) to this wallet
         TokenBurn,      // Tokens destroyed (no colored output recipient)
-        TokenTransfer,  // Tokens transferred (sent to others, received from others, or self-transfer)
-        TPCFee,         // Network fee paid in TPC for a token transaction
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -34,6 +34,7 @@ static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter, /* date */
         Qt::AlignLeft|Qt::AlignVCenter, /* type */
         Qt::AlignLeft|Qt::AlignVCenter, /* address */
+        Qt::AlignLeft|Qt::AlignVCenter, /* color id */
         Qt::AlignRight|Qt::AlignVCenter /* amount */
     };
 
@@ -223,7 +224,7 @@ TransactionTableModel::TransactionTableModel(const PlatformStyle *_platformStyle
         fProcessingQueuedTransactions(false),
         platformStyle(_platformStyle)
 {
-    columns << QString() << QString() << tr("Date") << tr("Type") << tr("Label") << TapyrusUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
+    columns << QString() << QString() << tr("Date") << tr("Type") << tr("Label") << tr("Color ID") << TapyrusUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
     priv->refreshWallet(walletModel->wallet());
 
     connect(walletModel->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &TransactionTableModel::updateDisplayUnit);
@@ -351,6 +352,12 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
+    case TransactionRecord::TokenIssue:
+        return tr("Token Issue");
+    case TransactionRecord::TokenBurn:
+        return tr("Token Burn");
+    case TransactionRecord::TokenTransfer:
+        return tr("Token Transfer");
     default:
         return QString();
     }
@@ -368,6 +375,12 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     case TransactionRecord::SendToAddress:
     case TransactionRecord::SendToOther:
         return QIcon(":/icons/tx_output");
+    case TransactionRecord::TokenIssue:
+        return QIcon(":/icons/tx_input");   // receive direction
+    case TransactionRecord::TokenBurn:
+        return QIcon(":/icons/tx_output");  // send/destroy direction
+    case TransactionRecord::TokenTransfer:
+        return QIcon(":/icons/tx_inout");   // bidirectional transfer
     default:
         return QIcon(":/icons/tx_inout");
     }
@@ -391,7 +404,15 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
         return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
+    case TransactionRecord::TokenIssue:
+    case TransactionRecord::TokenBurn:
+    case TransactionRecord::TokenTransfer:
+        return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToSelf:
+        // Change outputs have an address set; the collapsed self-payment does not
+        if (!wtx->address.empty())
+            return lookupAddress(wtx->address, tooltip) + watchAddress;
+        return tr("(n/a)") + watchAddress;
     default:
         return tr("(n/a)") + watchAddress;
     }
@@ -420,7 +441,13 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
 
 QString TransactionTableModel::formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed, TapyrusUnits::SeparatorStyle separators) const
 {
-    QString str = TapyrusUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), wtx->credit + wtx->debit, false, separators);
+    QString str;
+    if (!wtx->colorId.empty()) {
+        // Token record: format as integer token amount
+        str = TapyrusUnits::format(TapyrusUnits::TOKEN, wtx->tokenAmount, false, separators);
+    } else {
+        str = TapyrusUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), wtx->credit + wtx->debit, false, separators);
+    }
     if(showUnconfirmed)
     {
         if(!wtx->status.countsForBalance)
@@ -478,6 +505,11 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
     {
         tooltip += QString(" ") + formatTxToAddress(rec, true);
     }
+    if (!rec->colorId.empty())
+        tooltip += QString("\nToken: ") + QString::fromStdString(rec->colorId);
+    if (rec->tpcFee > 0)
+        tooltip += QString("\nFee: ") + TapyrusUnits::formatWithUnit(
+            walletModel->getOptionsModel()->getDisplayUnit(), rec->tpcFee);
     return tooltip;
 }
 
@@ -514,6 +546,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return formatTxType(rec);
         case ToAddress:
             return formatTxToAddress(rec, false);
+        case ColorId:
+            return QString::fromStdString(rec->colorId);
         case Amount:
             return formatTxAmount(rec, true, TapyrusUnits::separatorAlways);
         }
@@ -532,8 +566,11 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return (rec->involvesWatchAddress ? 1 : 0);
         case ToAddress:
             return formatTxToAddress(rec, true);
+        case ColorId:
+            return QString::fromStdString(rec->colorId);
         case Amount:
-            return qint64(rec->credit + rec->debit);
+            // Token records sort by token amount; TPC records sort by TPC net
+            return rec->colorId.empty() ? qint64(rec->credit + rec->debit) : qint64(rec->tokenAmount);
         }
         break;
     case Qt::ToolTipRole:
@@ -546,14 +583,15 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         {
             return COLOR_TX_STATUS_DANGER;
         }
-        // Non-confirmed (but not immature) as transactions are grey
+        // Outgoing transactions (sends) are always red, confirmed or not
+        if(index.column() == Amount) {
+            qint64 net = rec->colorId.empty() ? (rec->credit + rec->debit) : rec->tokenAmount;
+            if (net < 0) return COLOR_NEGATIVE;
+        }
+        // Non-confirmed (but not immature) receives are grey
         if(!rec->status.countsForBalance)
         {
             return COLOR_UNCONFIRMED;
-        }
-        if(index.column() == Amount && (rec->credit+rec->debit) < 0)
-        {
-            return COLOR_NEGATIVE;
         }
         if(index.column() == ToAddress)
         {
@@ -615,6 +653,14 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return formatTxAmount(rec, false, TapyrusUnits::separatorNever);
     case StatusRole:
         return rec->status.status;
+    case TokenAmountRole:
+        return qint64(rec->tokenAmount);
+    case ColorIdRole:
+        return QString::fromStdString(rec->colorId);
+    case TokenTypeRole:
+        return QString::fromStdString(rec->tokenType);
+    case IsTokenRole:
+        return !rec->colorId.empty();
     }
     return QVariant();
 }
@@ -644,6 +690,8 @@ QVariant TransactionTableModel::headerData(int section, Qt::Orientation orientat
                 return tr("Whether or not a watch-only address is involved in this transaction.");
             case ToAddress:
                 return tr("User-defined intent/purpose of the transaction.");
+            case ColorId:
+                return tr("Color identifier for token transactions.");
             case Amount:
                 return tr("Amount removed from or added to balance.");
             }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -356,10 +356,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Token Issue");
     case TransactionRecord::TokenBurn:
         return tr("Token Burn");
-    case TransactionRecord::TokenTransfer:
-        return tr("Token Transfer");
-    case TransactionRecord::TPCFee:
-        return tr("Network Fee");
     default:
         return QString();
     }
@@ -381,10 +377,6 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
         return QIcon(":/icons/tx_input");   // receive direction
     case TransactionRecord::TokenBurn:
         return QIcon(":/icons/tx_output");  // send/destroy direction
-    case TransactionRecord::TokenTransfer:
-        return QIcon(":/icons/tx_inout");   // bidirectional transfer
-    case TransactionRecord::TPCFee:
-        return QIcon(":/icons/tx_output");  // outgoing (fee paid)
     default:
         return QIcon(":/icons/tx_inout");
     }
@@ -410,10 +402,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::TokenIssue:
     case TransactionRecord::TokenBurn:
-    case TransactionRecord::TokenTransfer:
         return lookupAddress(wtx->address, tooltip) + watchAddress;
-    case TransactionRecord::TPCFee:
-        return tr("(network fee)") + watchAddress;
     case TransactionRecord::SendToSelf:
         // Change outputs have an address set; the collapsed self-payment does not
         if (!wtx->address.empty())
@@ -513,7 +502,7 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
     }
     if (!rec->colorId.empty())
         tooltip += QString("\nToken: ") + QString::fromStdString(rec->colorId);
-    if (rec->tpcFee > 0 && rec->type != TransactionRecord::TPCFee)
+    if (rec->tpcFee > 0)
         tooltip += QString("\nFee: ") + TapyrusUnits::formatWithUnit(
             walletModel->getOptionsModel()->getDisplayUnit(), rec->tpcFee);
     return tooltip;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -358,6 +358,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Token Burn");
     case TransactionRecord::TokenTransfer:
         return tr("Token Transfer");
+    case TransactionRecord::TPCFee:
+        return tr("Network Fee");
     default:
         return QString();
     }
@@ -381,6 +383,8 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
         return QIcon(":/icons/tx_output");  // send/destroy direction
     case TransactionRecord::TokenTransfer:
         return QIcon(":/icons/tx_inout");   // bidirectional transfer
+    case TransactionRecord::TPCFee:
+        return QIcon(":/icons/tx_output");  // outgoing (fee paid)
     default:
         return QIcon(":/icons/tx_inout");
     }
@@ -408,6 +412,8 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::TokenBurn:
     case TransactionRecord::TokenTransfer:
         return lookupAddress(wtx->address, tooltip) + watchAddress;
+    case TransactionRecord::TPCFee:
+        return tr("(network fee)") + watchAddress;
     case TransactionRecord::SendToSelf:
         // Change outputs have an address set; the collapsed self-payment does not
         if (!wtx->address.empty())
@@ -507,7 +513,7 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
     }
     if (!rec->colorId.empty())
         tooltip += QString("\nToken: ") + QString::fromStdString(rec->colorId);
-    if (rec->tpcFee > 0)
+    if (rec->tpcFee > 0 && rec->type != TransactionRecord::TPCFee)
         tooltip += QString("\nFee: ") + TapyrusUnits::formatWithUnit(
             walletModel->getOptionsModel()->getDisplayUnit(), rec->tpcFee);
     return tooltip;

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -37,7 +37,8 @@ public:
         Date = 2,
         Type = 3,
         ToAddress = 4,
-        Amount = 5
+        ColorId = 5,
+        Amount = 6
     };
 
     /** Roles to get specific information from a transaction row.
@@ -74,6 +75,14 @@ public:
         StatusRole,
         /** Unprocessed icon */
         RawDecorationRole,
+        /** Net token amount (0 for TPC transactions) */
+        TokenAmountRole,
+        /** Color ID hex string (empty for TPC transactions) */
+        ColorIdRole,
+        /** Token type string: "REISSUABLE", "NON_REISSUABLE", "NFT", or "" for TPC */
+        TokenTypeRole,
+        /** True if this record is a token (not TPC) transaction */
+        IsTokenRole,
     };
 
     int rowCount(const QModelIndex &parent) const override;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -90,6 +90,9 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    typeWidget->addItem(tr("Token Issued"), TransactionFilterProxy::TYPE(TransactionRecord::TokenIssue));
+    typeWidget->addItem(tr("Token Burned"), TransactionFilterProxy::TYPE(TransactionRecord::TokenBurn));
+    typeWidget->addItem(tr("Token Transfer"), TransactionFilterProxy::TYPE(TransactionRecord::TokenTransfer));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 
     hlayout->addWidget(typeWidget);
@@ -150,6 +153,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     bumpFeeAction = new QAction(tr("Increase transaction fee"), this);
     bumpFeeAction->setObjectName("bumpFeeAction");
     QAction *copyAddressAction = new QAction(tr("Copy address"), this);
+    QAction *copyColorIdAction = new QAction(tr("Copy color ID"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
     QAction *copyTxIDAction = new QAction(tr("Copy transaction ID"), this);
@@ -161,6 +165,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     contextMenu = new QMenu(this);
     contextMenu->setObjectName("contextMenu");
     contextMenu->addAction(copyAddressAction);
+    contextMenu->addAction(copyColorIdAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyAmountAction);
     contextMenu->addAction(copyTxIDAction);
@@ -195,6 +200,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     connect(bumpFeeAction, &QAction::triggered, this, &TransactionView::bumpFee);
     connect(abandonAction, &QAction::triggered, this, &TransactionView::abandonTx);
     connect(copyAddressAction, &QAction::triggered, this, &TransactionView::copyAddress);
+    connect(copyColorIdAction, &QAction::triggered, this, &TransactionView::copyColorId);
     connect(copyLabelAction, &QAction::triggered, this, &TransactionView::copyLabel);
     connect(copyAmountAction, &QAction::triggered, this, &TransactionView::copyAmount);
     connect(copyTxIDAction, &QAction::triggered, this, &TransactionView::copyTxID);
@@ -441,6 +447,11 @@ void TransactionView::bumpFee()
 void TransactionView::copyAddress()
 {
     GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::AddressRole);
+}
+
+void TransactionView::copyColorId()
+{
+    GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::ColorIdRole);
 }
 
 void TransactionView::copyLabel()

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -92,7 +92,6 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Token Issued"), TransactionFilterProxy::TYPE(TransactionRecord::TokenIssue));
     typeWidget->addItem(tr("Token Burned"), TransactionFilterProxy::TYPE(TransactionRecord::TokenBurn));
-    typeWidget->addItem(tr("Token Transfer"), TransactionFilterProxy::TYPE(TransactionRecord::TokenTransfer));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 
     hlayout->addWidget(typeWidget);

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -91,6 +91,7 @@ private Q_SLOTS:
     void dateRangeChanged();
     void showDetails();
     void copyAddress();
+    void copyColorId();
     void editLabel();
     void copyLabel();
     void copyAmount();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -23,6 +23,7 @@
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
+#include <set>
 #include <stdint.h>
 
 #include <QDebug>
@@ -87,6 +88,7 @@ void WalletModel::pollBalanceChanged()
         cachedNumBlocks = m_node.getNumBlocks();
 
         checkBalanceChanged(new_balances);
+        checkTokenListChanged();
         if(transactionTableModel)
             transactionTableModel->updateConfirmations();
     }
@@ -97,6 +99,15 @@ void WalletModel::checkBalanceChanged(const interfaces::WalletBalances& new_bala
     if(new_balances.balanceChanged(m_cached_balances)) {
         m_cached_balances = new_balances;
         Q_EMIT balanceChanged(new_balances);
+    }
+}
+
+void WalletModel::checkTokenListChanged()
+{
+    QList<IssuedTokenRecord> newList = getIssuedTokens();
+    if (newList != m_cached_tokens) {
+        m_cached_tokens = newList;
+        Q_EMIT tokenListChanged(m_cached_tokens);
     }
 }
 
@@ -112,11 +123,6 @@ void WalletModel::updateAddressBook(const QString &address, const QString &label
     if(addressTableModel)
         addressTableModel->updateEntry(address, label, isMine, purpose, status);
 
-    if (isMine && purpose == "receive") {
-        CTxDestination dest = DecodeDestination(address.toStdString());
-        if (std::get_if<CColorScriptID>(&dest) || std::get_if<CColorKeyID>(&dest) )
-            Q_EMIT tokenAddressBookChanged();
-    }
 }
 
 void WalletModel::updateWatchOnlyFlag(bool fHaveWatchonly)
@@ -128,6 +134,18 @@ void WalletModel::updateWatchOnlyFlag(bool fHaveWatchonly)
 bool WalletModel::validateAddress(const QString &address)
 {
     return IsValidDestinationString(address.toStdString());
+}
+
+bool WalletModel::isColoredAddress(const QString &address)
+{
+    return IsColoredDestination(address.toStdString(), nullptr);
+}
+
+ColorIdentifier WalletModel::getColorFromAddress(const QString &address) const
+{
+    ColorIdentifier colorId;
+    IsColoredDestination(address.toStdString(), &colorId);
+    return colorId;
 }
 
 WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl)
@@ -329,37 +347,30 @@ WalletModel::BurnTokenResult WalletModel::burnToken(const QString& colorId, CAmo
 QList<WalletModel::IssuedTokenRecord> WalletModel::getIssuedTokens() const
 {
     QList<IssuedTokenRecord> result;
-    QSet<QString> seenColorIds;  // guard against duplicate address book entries for the same color
     interfaces::WalletBalances wb = m_wallet->getBalances();
 
-    for (const auto& wa : m_wallet->getAddresses()) {
-        if (wa.is_mine == ISMINE_NO || wa.purpose != "receive")
-            continue;
+    // Collect all distinct color IDs present in confirmed or unconfirmed balances
+    std::set<ColorIdentifier, ColorIdentifierCompare> colors;
+    for (const auto& entry : wb.balances)
+        if (entry.first.type != TokenTypes::NONE)
+            colors.insert(entry.first);
+    for (const auto& entry : wb.unconfirmed_balances)
+        if (entry.first.type != TokenTypes::NONE)
+            colors.insert(entry.first);
 
-        const CColorScriptID* cid = std::get_if<CColorScriptID>(&wa.dest);
-        if (!cid)
-            continue;
-
+    for (const ColorIdentifier& color : colors) {
         IssuedTokenRecord rec;
-        rec.colorId = QString::fromStdString(cid->color.toHexString());
-
-        if (seenColorIds.contains(rec.colorId))
-            continue;
-        seenColorIds.insert(rec.colorId);
-
-        rec.label   = QString::fromStdString(wa.name);
-        switch (cid->color.type) {
+        rec.colorId = QString::fromStdString(color.toHexString());
+        switch (color.type) {
             case TokenTypes::REISSUABLE:     rec.tokenType = "REISSUABLE";     break;
             case TokenTypes::NON_REISSUABLE: rec.tokenType = "NON_REISSUABLE"; break;
             case TokenTypes::NFT:            rec.tokenType = "NFT";            break;
             default: continue;
         }
-        rec.address = QString::fromStdString(EncodeDestination(wa.dest));
-
-        auto conf_it = wb.balances.find(cid->color);
+        auto conf_it = wb.balances.find(color);
         rec.balance = (conf_it != wb.balances.end()) ? conf_it->second : 0;
 
-        auto unconf_it = wb.unconfirmed_balances.find(cid->color);
+        auto unconf_it = wb.unconfirmed_balances.find(color);
         rec.unconfirmedBalance = (unconf_it != wb.unconfirmed_balances.end()) ? unconf_it->second : 0;
 
         result.append(rec);
@@ -395,14 +406,6 @@ OptionsModel *WalletModel::getOptionsModel()
 AddressTableModel *WalletModel::getAddressTableModel()
 {
     return addressTableModel;
-}
-
-ColorIdentifier WalletModel::getColorFromAddress(const QString &address) const
-{
-    CTxDestination dest = DecodeDestination(address.toStdString());
-    if (const CColorScriptID* p = std::get_if<CColorScriptID>(&dest)) return p->color;
-    if (const CColorKeyID*   p = std::get_if<CColorKeyID>(&dest))   return p->color;
-    return ColorIdentifier();
 }
 
 TransactionTableModel *WalletModel::getTransactionTableModel()
@@ -676,11 +679,9 @@ bool WalletModel::isMultiwallet()
     return m_node.getWallets().size() > 1;
 }
 
-//Constructor definition moved here to initialize colorid
+// Constructor definition moved here to initialize colorid from address
 SendCoinsRecipient::SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message):
     address(addr), label(_label), amount(_amount), message(_message), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION)
-    {
-        CTxDestination dest = DecodeDestination(address.toStdString());
-        if (const CColorScriptID* p = std::get_if<CColorScriptID>(&dest)) colorid = p->color;
-        else if (const CColorKeyID* p = std::get_if<CColorKeyID>(&dest)) colorid = p->color;
-    }
+{
+    IsColoredDestination(address.toStdString(), &colorid);
+}

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -138,8 +138,9 @@ public:
 
     // Check address for validity
     bool validateAddress(const QString &address);
-
-    // Return the ColorIdentifier encoded in a colored address, or ColorIdentifier() (NONE) for TPC.
+    //! Check if the address is a colored (token) address.
+    bool isColoredAddress(const QString &address);
+    //! Return the ColorIdentifier encoded in a colored address, or ColorIdentifier() (NONE) for TPC.
     ColorIdentifier getColorFromAddress(const QString &address) const;
 
     // Return status record for SendCoins, contains error id + information
@@ -200,6 +201,11 @@ public:
         CAmount balance = 0;          // confirmed balance
         CAmount unconfirmedBalance = 0; // unconfirmed (mempool) balance
         QString address;              // CColorScriptID encoded address
+
+        bool operator==(const IssuedTokenRecord& o) const {
+            return colorId == o.colorId && tokenType == o.tokenType &&
+                   balance == o.balance && unconfirmedBalance == o.unconfirmedBalance;
+        }
     };
 
     // Return all colored-coin addresses owned by this wallet as IssuedTokenRecord list.
@@ -273,6 +279,7 @@ private:
 
     // Cache some values to be able to detect changes
     interfaces::WalletBalances m_cached_balances;
+    QList<IssuedTokenRecord> m_cached_tokens;
     EncryptionStatus cachedEncryptionStatus;
     int cachedNumBlocks;
 
@@ -281,13 +288,14 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
     void checkBalanceChanged(const interfaces::WalletBalances& new_balances);
+    void checkTokenListChanged();
 
 Q_SIGNALS:
     // Signal that balance in wallet changed
     void balanceChanged(const interfaces::WalletBalances& balances);
 
-    // Signal that a colored-coin address book entry was added or updated
-    void tokenAddressBookChanged();
+    // Signal that the colored-coin token list changed (new token, balance change, or token fully spent)
+    void tokenListChanged(const QList<WalletModel::IssuedTokenRecord>& tokens);
 
     // Encryption status of wallet changed
     void encryptionStatusChanged();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1469,6 +1469,7 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int n
                 feeEntry.pushKV("category", "fee");
                 feeEntry.pushKV("token", ColorIdentifier().toHexString()); // always TPC
                 feeEntry.pushKV("amount", ValueFromAmount(-nFee));
+                if (fLong) WalletTxToJSON(wtx, feeEntry);
                 ret.push_back(feeEntry);
             }
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -6,6 +6,7 @@
 
 #include <amount.h>
 #include <chain.h>
+#include <coloridentifier.h>
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <httpserver.h>
@@ -1350,9 +1351,17 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int n
     std::list<COutputEntry> listSent;
 
     wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter);
-    bool feeAdded = false;
 
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
+
+    // Detect token involvement: any output carries a colored script
+    bool hasTokenInvolvement = false;
+    for (const CTxOut& txout : wtx.tx->vout) {
+        if (GetColorIdFromScript(txout.scriptPubKey).type != TokenTypes::NONE) {
+            hasTokenInvolvement = true;
+            break;
+        }
+    }
 
     // Sent
     if ((!listSent.empty() || nFee != 0))
@@ -1372,8 +1381,10 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int n
                 entry.pushKV("label", pwallet->mapAddressBook[s.destination].name);
             }
             entry.pushKV("vout", s.vout);
-            entry.pushKV("fee", ValueFromAmount(-nFee));
-            feeAdded = true;
+            if (!hasTokenInvolvement) {
+                // For non-token transactions, attach fee to the send entry as before
+                entry.pushKV("fee", ValueFromAmount(-nFee));
+            }
             if (fLong)
                 WalletTxToJSON(wtx, entry);
             entry.pushKV("abandoned", wtx.isAbandoned());
@@ -1413,7 +1424,7 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int n
                 entry.pushKV("label", account);
             }
             entry.pushKV("vout", r.vout);
-            if(!feeAdded)
+            if (!hasTokenInvolvement && listSent.empty())
                 entry.pushKV("fee", ValueFromAmount(-nFee));
             if (fLong)
                 WalletTxToJSON(wtx, entry);
@@ -1421,7 +1432,47 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int n
         }
     }
 
+    // For token transactions funded by this wallet: add change outputs and an explicit
+    // fee entry to match the GUI transaction table display (SendToSelf + TPCFee rows).
+    if (hasTokenInvolvement) {
+        bool walletFunded = wtx.GetDebit(filter, ColorIdentifier()) > 0;
+        if (walletFunded) {
+            // Show change outputs (TPC and token) that GetAmounts hides via IsChange().
+            // These correspond to the SendToSelf rows in the GUI transaction table.
+            if (wtx.GetDepthInMainChain() >= nMinDepth) {
+                for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
+                    const CTxOut& txout = wtx.tx->vout[i];
+                    isminetype fIsMine = pwallet->IsMine(txout);
+                    if (!(fIsMine & filter)) continue;
+                    if (!pwallet->IsChange(txout)) continue; // non-change already in listReceived
 
+                    CTxDestination address;
+                    ExtractDestination(txout.scriptPubKey, address);
+
+                    UniValue entry(UniValue::VOBJ);
+                    if (involvesWatchonly || (fIsMine & ISMINE_WATCH_ONLY))
+                        entry.pushKV("involvesWatchonly", true);
+                    MaybePushAddress(entry, address);
+                    entry.pushKV("category", "receive");
+                    addTokenKV(address, txout.nValue, entry);
+                    if (pwallet->mapAddressBook.count(address))
+                        entry.pushKV("label", pwallet->mapAddressBook[address].name);
+                    entry.pushKV("vout", (int)i);
+                    if (fLong) WalletTxToJSON(wtx, entry);
+                    ret.push_back(entry);
+                }
+            }
+
+            // Explicit fee entry — corresponds to the TPCFee row in the GUI.
+            if (nFee > 0) {
+                UniValue feeEntry(UniValue::VOBJ);
+                feeEntry.pushKV("category", "fee");
+                feeEntry.pushKV("token", ColorIdentifier().toHexString()); // always TPC
+                feeEntry.pushKV("amount", ValueFromAmount(-nFee));
+                ret.push_back(feeEntry);
+            }
+        }
+    }
 }
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1421,6 +1421,7 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int n
         }
     }
 
+
 }
 
 
@@ -4293,6 +4294,7 @@ UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& script,
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("color", coin_control.m_colorId.toHexString());
+    result.pushKV("address", EncodeDestination(colorDest));
     UniValue txidlist(UniValue::VARR);
     txidlist.push_back(tx1->GetHashMalFix().GetHex());
     txidlist.push_back(tx2->GetHashMalFix().GetHex());
@@ -4345,6 +4347,7 @@ UniValue IssueToken(CWallet* const pwallet, CAmount tokenValue, CCoinControl& co
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("color", coin_control.m_colorId.toHexString());
+    result.pushKV("address", EncodeDestination(colorDest));
     result.pushKV("txid", tx->GetHashMalFix().GetHex());
     return result;
 }

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -389,6 +389,16 @@ class WalletColoredCoinTest(BitcoinTestFramework):
                                 {"token" : self.colorids[5],
                                 "amount": 1,
                                 "confirmations": 0})
+        # Verify that multiple entries exist for the same txid after sending a token
+        txlist = self.nodes[0].listtransactions(count=50)
+        entries = [e for e in txlist if e['txid'] == txid1]
+        assert len(entries) >= 2, "Token tx should have multiple entries (send + fee)"
+
+        # Verify the existence of a fee entry with a negative amount
+        fee_entries = [e for e in txlist if e['txid'] == txid1 and e['category'] == 'fee']
+        assert len(fee_entries) >= 1, "Expected a fee entry for txid1"
+        assert fee_entries[0]['amount'] < 0, "Fee amount should be negative"
+
         #mine a block, confirmations should change:
         self.nodes[2].generate(1, self.signblockprivkey_wif)
         self.sync_all([self.nodes[0:3]])

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -537,11 +537,15 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         res = self.nodes[0].issuetoken(1, 100, bytes_to_hex_str(scr))
         reissue_color=res['color']
         assert_equal(res['color'], self.nodes[0].getcolor(1, bytes_to_hex_str(scr)))
+        assert 'address' in res
+        assert_equal(self.nodes[0].getaddressinfo(res['address'])['token'], res['color'])
         self.sync_all([self.nodes[0:3]])
 
         res = self.nodes[0].reissuetoken(reissue_color, 100)
         assert_equal(res['color'], reissue_color)
         assert_equal(len(res['txids']), 2)
+        assert 'address' in res
+        assert_equal(self.nodes[0].getaddressinfo(res['address'])['token'], res['color'])
 
         if not self.options.usecli:
             assert_raises_rpc_error(-3, "Invalid amount", self.nodes[0].reissuetoken, self.colorids[1], 'foo')
@@ -581,23 +585,33 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         reissue_color=res1['color']
         assert_equal(res1['color'], self.nodes[2].getcolor(1, bytes_to_hex_str(scr)))
         assert_equal(len(res1['txids']), 2)
+        assert 'address' in res1
+        assert_equal(self.nodes[2].getaddressinfo(res1['address'])['token'], res1['color'])
         self.sync_all([self.nodes[0:3]])
 
         node2_utxos = self.nodes[2].listunspent(3)
 
         res2 = self.nodes[2].issuetoken(2, 100, node2_utxos[1]['txid'], node2_utxos[1]['vout'])
         assert_equal(res2['color'], self.nodes[2].getcolor(2, node2_utxos[1]['txid'], node2_utxos[1]['vout']))
+        assert 'address' in res2
+        assert_equal(self.nodes[2].getaddressinfo(res2['address'])['token'], res2['color'])
 
         res3 = self.nodes[2].issuetoken(3, 1, node2_utxos[2]['txid'], node2_utxos[2]['vout'])
         assert_equal(res3['color'], self.nodes[2].getcolor(3, node2_utxos[2]['txid'], node2_utxos[2]['vout']))
+        assert 'address' in res3
+        assert_equal(self.nodes[2].getaddressinfo(res3['address'])['token'], res3['color'])
 
         res4 = self.nodes[2].issuetoken(1, 100, bytes_to_hex_str(scr))
         assert_equal(res4['color'], reissue_color)
         assert_equal(len(res4['txids']), 2)
+        assert 'address' in res4
+        assert_equal(self.nodes[2].getaddressinfo(res4['address'])['token'], res4['color'])
 
         res4 = self.nodes[2].issuetoken(1, 100, bytes_to_hex_str(scr))
         assert_equal(res4['color'], reissue_color)
         assert_equal(len(res4['txids']), 2)
+        assert 'address' in res4
+        assert_equal(self.nodes[2].getaddressinfo(res4['address'])['token'], res4['color'])
 
         self.nodes[2].generate(1, self.signblockprivkey_wif)
         self.sync_all([self.nodes[0:3]])
@@ -612,6 +626,8 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         res = self.nodes[2].reissuetoken(reissue_color, 100)
         assert_equal(res['color'], reissue_color)
         assert_equal(len(res['txids']), 2)
+        assert 'address' in res
+        assert_equal(self.nodes[2].getaddressinfo(res['address'])['token'], res['color'])
 
         self.nodes[2].generate(1, self.signblockprivkey_wif)
         self.sync_all([self.nodes[0:3]])
@@ -746,16 +762,22 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         res1 = self.nodes[3].issuetoken(1, 100, scr_hex)
         assert_equal(len(res1['txids']), 2)
         color1 = res1['color']
+        assert 'address' in res1
+        assert_equal(self.nodes[3].getaddressinfo(res1['address'])['token'], color1)
 
         # reissuetoken must use that unconfirmed change.
         res2 = self.nodes[3].reissuetoken(color1, 50)
         assert_equal(res2['color'], color1)
         assert_equal(len(res2['txids']), 2)
+        assert 'address' in res2
+        assert_equal(self.nodes[3].getaddressinfo(res2['address'])['token'], color1)
 
         # A third reissue (still no confirmed UTXOs) must also succeed.
         res3 = self.nodes[3].reissuetoken(color1, 25)
         assert_equal(res3['color'], color1)
         assert_equal(len(res3['txids']), 2)
+        assert 'address' in res3
+        assert_equal(self.nodes[3].getaddressinfo(res3['address'])['token'], color1)
 
         # NON_REISSUABLE using an unconfirmed TPC UTXO ---
         # listunspent(0) includes mempool UTXOs (minconf=0).
@@ -769,6 +791,8 @@ class WalletColoredCoinTest(BitcoinTestFramework):
 
         res4 = self.nodes[3].issuetoken(2, 75, unconf_tpc['txid'], unconf_tpc['vout'])
         assert 'txid' in res4  # NON_REISSUABLE returns a single 'txid' string, not a 'txids' list
+        assert 'address' in res4
+        assert_equal(self.nodes[3].getaddressinfo(res4['address'])['token'], res4['color'])
 
         # Mine one block to confirm everything, then verify final balances.
         # Earlier, because of duplicate address book entries, color1's balance would

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -306,15 +306,13 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         self.sync_all([self.nodes[0:3]])
 
         assert_array_result(self.nodes[0].listtransactions(),
-                            {"txid": txid1},
-                            {"category": "send",
-                            "token" : self.colorids[1],
+                            {"txid": txid1, "category": "send"},
+                            {"token" : self.colorids[1],
                             "amount": -10,
                             "confirmations": 0})
         assert_array_result(self.nodes[1].listtransactions(),
-                            {"txid": txid1},
-                            {"category": "receive",
-                            "token" : self.colorids[1],
+                            {"txid": txid1, "category": "receive"},
+                            {"token" : self.colorids[1],
                             "amount": 10,
                             "confirmations": 0})
 
@@ -322,15 +320,13 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         self.sync_all([self.nodes[0:3]])
 
         assert_array_result(self.nodes[0].listtransactions(),
-                            {"txid": txid2},
-                            {"category": "send",
-                            "token" : self.colorids[1],
+                            {"txid": txid2, "category": "send"},
+                            {"token" : self.colorids[1],
                             "amount": -10,
                             "confirmations": 0})
         assert_array_result(self.nodes[1].listtransactions(),
-                            {"txid": txid2},
-                            {"category": "receive",
-                            "token" : self.colorids[1],
+                            {"txid": txid2, "category": "receive"},
+                            {"token" : self.colorids[1],
                             "amount": 10,
                             "confirmations": 0})
 
@@ -338,15 +334,13 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         self.sync_all([self.nodes[0:3]])
 
         assert_array_result(self.nodes[0].listtransactions(),
-                            {"txid": txid3},
-                            {"category": "send",
-                            "token" : self.colorids[2],
+                            {"txid": txid3, "category": "send"},
+                            {"token" : self.colorids[2],
                             "amount": -10,
                             "confirmations": 0})
         assert_array_result(self.nodes[1].listtransactions(),
-                            {"txid": txid3},
-                            {"category": "receive",
-                            "token" : self.colorids[2],
+                            {"txid": txid3, "category": "receive"},
+                            {"token" : self.colorids[2],
                             "amount": 10,
                             "confirmations": 0})
 
@@ -356,15 +350,13 @@ class WalletColoredCoinTest(BitcoinTestFramework):
             self.sync_all([self.nodes[0:3]])
 
             assert_array_result(self.nodes[0].listtransactions(),
-                                {"txid": txid4},
-                                {"category": "send",
-                                "token" : self.colorids[3],
+                                {"txid": txid4, "category": "send"},
+                                {"token" : self.colorids[3],
                                 "amount": -1,
                                 "confirmations": 0})
             assert_array_result(self.nodes[1].listtransactions(),
-                                {"txid": txid4},
-                                {"category": "receive",
-                                "token" : self.colorids[3],
+                                {"txid": txid4, "category": "receive"},
+                                {"token" : self.colorids[3],
                                 "amount": 1,
                                 "confirmations": 0})
 
@@ -372,15 +364,13 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         self.sync_all([self.nodes[0:3]])
 
         assert_array_result(self.nodes[0].listtransactions(),
-                            {"txid": txid5},
-                            {"category": "send",
-                            "token" : self.colorids[4],
+                            {"txid": txid5, "category": "send"},
+                            {"token" : self.colorids[4],
                             "amount": -10,
                             "confirmations": 0})
         assert_array_result(self.nodes[1].listtransactions(),
-                            {"txid": txid5},
-                            {"category": "receive",
-                            "token" : self.colorids[4],
+                            {"txid": txid5, "category": "receive"},
+                            {"token" : self.colorids[4],
                             "amount": 10,
                             "confirmations": 0})
 
@@ -390,15 +380,13 @@ class WalletColoredCoinTest(BitcoinTestFramework):
             self.sync_all([self.nodes[0:3]])
 
             assert_array_result(self.nodes[0].listtransactions(),
-                                {"txid": txid6},
-                                {"category": "send",
-                                "token" : self.colorids[5],
+                                {"txid": txid6, "category": "send"},
+                                {"token" : self.colorids[5],
                                 "amount": -1,
                                 "confirmations": 0})
             assert_array_result(self.nodes[1].listtransactions(),
-                                {"txid": txid6},
-                                {"category": "receive",
-                                "token" : self.colorids[5],
+                                {"txid": txid6, "category": "receive"},
+                                {"token" : self.colorids[5],
                                 "amount": 1,
                                 "confirmations": 0})
         #mine a block, confirmations should change:
@@ -414,7 +402,7 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         assert_array_result(unspent, {"txid": txid5, "token" : self.colorids[4]},
                             {"amount": self.balance_expected[0][self.stage][5], "confirmations": 1})
 
-        txlist = self.nodes[0].listtransactions()
+        txlist = self.nodes[0].listtransactions(count=50)
         assert_array_result(txlist,{"txid": txid1},{"confirmations": 1})
         assert_array_result(txlist,{"txid": txid2},{"confirmations": 1})
         assert_array_result(txlist,{"txid": txid3},{"confirmations": 1})


### PR DESCRIPTION
- The overview page now contains a new box listing Tokens and their balances. When there are no colored coins in the wallet, this box is not visible.
- The transaction table page now lists all colored coin transactions also. New categories "Token Issue" and "Token Burn" are added. Token transfer is the same as "Send to" or "Payment to self" or "Received with" with a color id. The transaction tool tip and transaction details from the right click menu now show token output and TPC output. 
- `gettransaction` rpc output is also enhanced to show all the credits and debits to the wallet separately. functional tests are updated according to the output.