### PR TITLE
update build doc with recursive option

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -43,8 +43,8 @@ Build Tapyrus Core
 
 1. Clone the Tapyrus Core source code and cd into `tapyrus`
 
-        git clone https://github.com/chaintope/tapyrus-core
-        cd tapyrus
+        git clone --recursive https://github.com/chaintope/tapyrus-core
+        cd tapyrus-core
 
 2.  Build Tapyrus Core:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -230,7 +230,7 @@ Setup and Build Example: Arch Linux
 This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
 
     pacman -S git base-devel boost libevent python
-    git clone https://github.com/chaintope/tapyrus-core
+    git clone --recursive https://github.com/chaintope/tapyrus-core
     cd tapyrus-core/
     ./autogen.sh
     ./configure --disable-wallet --without-gui --without-miniupnpc


### PR DESCRIPTION
Updated build documentation to use the `--recursive` option to install `libsecp256k1` submodules at the same time when `git clone`.