### PR TITLE
Restrict Tapyrus Network id to Four bytes

### DIFF
--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -102,7 +102,11 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
 {
     gArgs.SelectConfigNetwork(TAPYRUS_MODES::GetChainName(mode));
 
-    const int networkId = gArgs.GetArg("-networkid", TAPYRUS_MODES::GetDefaultNetworkId(mode));
+    int64_t nid;
+    bool inRange = gArgs.IsGetArgInRange("-networkid", 1, 4294967295,  TAPYRUS_MODES::GetDefaultNetworkId(mode), nid);
+    if(!inRange || nid <= 0)
+        throw std::runtime_error(strprintf("Network Id [%ld] was out of range. Expected range is 1 to 4294967295.", nid));
+    const uint networkId = (uint32_t)nid;
     const std::string dataDirName(GetDataDirNameFromNetworkId(networkId));
     const std::string genesisHex(withGenesis ? ReadGenesisBlock() : "");
 
@@ -114,7 +118,7 @@ void SelectFederationParams(const TAPYRUS_OP_MODE mode, const bool withGenesis)
     globalChainFederationParams = CreateFederationParams(mode, withGenesis);
 }
 
-CFederationParams::CFederationParams(const int networkId, const std::string dataDirName, const std::string genesisHex) : nNetworkId(networkId), strNetworkID(std::to_string(networkId)), dataDir(dataDirName) {
+CFederationParams::CFederationParams(const uint networkId, const std::string dataDirName, const std::string genesisHex) : nNetworkId(networkId), strNetworkID(std::to_string(networkId)), dataDir(dataDirName) {
 
     /**
      * The message start string is designed to be unlikely to occur in normal data.

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -106,7 +106,7 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
     bool inRange = gArgs.IsGetArgInRange("-networkid", 1, 4294967295,  TAPYRUS_MODES::GetDefaultNetworkId(mode), nid);
     if(!inRange || nid <= 0)
         throw std::runtime_error(strprintf("Network Id [%ld] was out of range. Expected range is 1 to 4294967295.", nid));
-    const uint networkId = (uint32_t)nid;
+    const uint32_t networkId = (uint32_t)nid;
     const std::string dataDirName(GetDataDirNameFromNetworkId(networkId));
     const std::string genesisHex(withGenesis ? ReadGenesisBlock() : "");
 
@@ -118,7 +118,7 @@ void SelectFederationParams(const TAPYRUS_OP_MODE mode, const bool withGenesis)
     globalChainFederationParams = CreateFederationParams(mode, withGenesis);
 }
 
-CFederationParams::CFederationParams(const uint networkId, const std::string dataDirName, const std::string genesisHex) : nNetworkId(networkId), strNetworkID(std::to_string(networkId)), dataDir(dataDirName) {
+CFederationParams::CFederationParams(const uint32_t networkId, const std::string dataDirName, const std::string genesisHex) : nNetworkId(networkId), strNetworkID(std::to_string(networkId)), dataDir(dataDirName) {
 
     /**
      * The message start string is designed to be unlikely to occur in normal data.

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
     gArgs.SelectConfigNetwork(TAPYRUS_MODES::GetChainName(mode));
 
     int64_t nid;
-    bool inRange = gArgs.IsGetArgInRange("-networkid", 1, 4294967295,  TAPYRUS_MODES::GetDefaultNetworkId(mode), nid);
+    bool inRange = gArgs.IsGetArgInRange("-networkid", 1, UINT_MAX,  TAPYRUS_MODES::GetDefaultNetworkId(mode), nid);
     if(!inRange || nid <= 0)
         throw std::runtime_error(strprintf("Network Id [%ld] was out of range. Expected range is 1 to 4294967295.", nid));
     const uint32_t networkId = (uint32_t)nid;

--- a/src/federationparams.h
+++ b/src/federationparams.h
@@ -53,10 +53,10 @@ public:
     CPubKey& GetAggPubkeyFromHeight(int height) const;
 
     CFederationParams();
-    CFederationParams(const int networkId, const std::string dataDirName, const std::string genesisHex);
+    CFederationParams(const uint networkId, const std::string dataDirName, const std::string genesisHex);
 
 private:
-    int nNetworkId;
+    uint nNetworkId;
     CMessageHeader::MessageStartChars pchMessageStart;
     std::string strNetworkID;
     std::string dataDir;

--- a/src/federationparams.h
+++ b/src/federationparams.h
@@ -53,10 +53,10 @@ public:
     CPubKey& GetAggPubkeyFromHeight(int height) const;
 
     CFederationParams();
-    CFederationParams(const uint networkId, const std::string dataDirName, const std::string genesisHex);
+    CFederationParams(const uint32_t networkId, const std::string dataDirName, const std::string genesisHex);
 
 private:
-    uint nNetworkId;
+    uint32_t nNetworkId;
     CMessageHeader::MessageStartChars pchMessageStart;
     std::string strNetworkID;
     std::string dataDir;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -354,7 +354,7 @@ void SetupServerArgs()
     // When adding new options to the categories, please keep and ensure alphabetical ordering.
     gArgs.AddArg("-?", "Print this help message and exit", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-version", "Print version and exit", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-networkid=<id>", "Network Identifier, a number representing to this tapyrus network", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-networkid=<id>", "Network Identifier, an unsigned number representing this tapyrus network. The range is from 0 to 4294967295.", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-alertnotify=<cmd>", "Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-assumevalid=<hex>", "If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: 0)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-blocksdir=<dir>", "Specify blocks directory (default: <datadir>/blocks)", false, OptionsCategory::OPTIONS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -354,7 +354,7 @@ void SetupServerArgs()
     // When adding new options to the categories, please keep and ensure alphabetical ordering.
     gArgs.AddArg("-?", "Print this help message and exit", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-version", "Print version and exit", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-networkid=<id>", "Network Identifier, an unsigned number representing this tapyrus network. The range is from 0 to 4294967295.", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-networkid=<id>", "Network Identifier, an unsigned number representing this tapyrus network. The range is from 1 to 4294967295.", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-alertnotify=<cmd>", "Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-assumevalid=<hex>", "If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: 0)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-blocksdir=<dir>", "Specify blocks directory (default: <datadir>/blocks)", false, OptionsCategory::OPTIONS);

--- a/src/test/chainparams_tests.cpp
+++ b/src/test/chainparams_tests.cpp
@@ -160,4 +160,51 @@ BOOST_AUTO_TEST_CASE(custom_networkId_test)
     BOOST_CHECK(memcmp(FederationParams().MessageStart(), pchMessageStart1, sizeof(pchMessageStart1)) == 0);
 }
 
+BOOST_AUTO_TEST_CASE(custom_networkId_range_test)
+{
+    //netowrk id 1 - 1 (0x00000001)
+    gArgs.ForceSetArg("-networkid", "1");
+    writeTestGenesisBlockToFile(GetDataDir(), "genesis.1");
+    BOOST_CHECK_NO_THROW(CreateFederationParams(TAPYRUS_OP_MODE::PROD, true));
+
+    BOOST_CHECK_NO_THROW(SelectParams(TAPYRUS_OP_MODE::PROD));
+    BOOST_CHECK_NO_THROW(SelectFederationParams(TAPYRUS_OP_MODE::PROD));
+    BOOST_CHECK(FederationParams().NetworkIDString() == "1");
+    BOOST_CHECK(FederationParams().getDataDir() == "prod-1");
+
+    //netowrk id of 4 bytes - 4294967295 (0xFFFFFFFF)
+    gArgs.ForceSetArg("-networkid", "4294967295");
+    writeTestGenesisBlockToFile(GetDataDir(), "genesis.4294967295");
+    BOOST_CHECK_NO_THROW(CreateFederationParams(TAPYRUS_OP_MODE::PROD, true));
+
+    BOOST_CHECK_NO_THROW(SelectParams(TAPYRUS_OP_MODE::PROD));
+    BOOST_CHECK_NO_THROW(SelectFederationParams(TAPYRUS_OP_MODE::PROD));
+    BOOST_CHECK(FederationParams().NetworkIDString() == "4294967295");
+    BOOST_CHECK(FederationParams().getDataDir() == "prod-4294967295");
+
+    //netowrk id 0 - (0x0)
+    gArgs.ForceSetArg("-networkid", "0");
+    writeTestGenesisBlockToFile(GetDataDir(), "genesis.0");
+    BOOST_CHECK_THROW(CreateFederationParams(TAPYRUS_OP_MODE::PROD, true), std::runtime_error);//("Network Id [0] was out of range. Expected range is 1 to 4294967295."));
+
+     //netowrk id of 4 bytes + 1 - 4294967296 (0x100000000)
+    gArgs.ForceSetArg("-networkid", "4294967296");
+    writeTestGenesisBlockToFile(GetDataDir(), "genesis.4294967296");
+    BOOST_CHECK_THROW(CreateFederationParams(TAPYRUS_OP_MODE::PROD, true), std::runtime_error);//("Network Id [4294967296] was out of range. Expected range is 1 to 4294967295."));
+
+     //netowrk id of 8 bytes - 18446744073709551615 (0xFFFFFFFF FFFFFFFF)
+    gArgs.ForceSetArg("-networkid", "18446744073709551615");
+    writeTestGenesisBlockToFile(GetDataDir(), "genesis.18446744073709551615");
+    BOOST_CHECK_THROW(CreateFederationParams(TAPYRUS_OP_MODE::PROD, true), std::runtime_error);//("Network Id [18446744073709551615] was out of range. Expected range is 1 to 4294967295."));
+
+    //netowrk id -1
+    gArgs.ForceSetArg("-networkid", "-1");
+    writeTestGenesisBlockToFile(GetDataDir(), "genesis.-1");
+    BOOST_CHECK_THROW(CreateFederationParams(TAPYRUS_OP_MODE::PROD, true), std::runtime_error);
+
+    //netowrk id -4294967295
+    gArgs.ForceSetArg("-networkid", "-4294967295");
+    writeTestGenesisBlockToFile(GetDataDir(), "genesis.-4294967295");
+    BOOST_CHECK_THROW(CreateFederationParams(TAPYRUS_OP_MODE::PROD, true), std::runtime_error);
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -699,7 +699,7 @@ static fs::path pathCached;
 static fs::path pathCachedNetSpecific;
 static CCriticalSection csPathCached;
 
-std::string GetDataDirNameFromNetworkId(const uint networkId)
+std::string GetDataDirNameFromNetworkId(const uint32_t networkId)
 {
     const std::string strNetworkId(std::to_string(networkId));
     return TAPYRUS_MODES::GetChainName(gArgs.GetChainMode()) + (strNetworkId.size() ? "-" + strNetworkId : "");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -490,6 +490,20 @@ int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const
     return nDefault;
 }
 
+bool ArgsManager::IsGetArgInRange(const std::string& strArg, const int64_t min, const int64_t max, const int64_t nDefault, int64_t& value) const
+{
+    std::pair<bool,std::string> found_res = ArgsManagerHelper::GetArg(*this, strArg);
+    if (found_res.first)
+    {
+        value = atoi64(found_res.second);
+        if(value >= min && value <= max)
+            return true;
+    }
+    else
+        value = nDefault;
+    return false;
+}
+
 bool ArgsManager::GetBoolArg(const std::string& strArg, bool fDefault) const
 {
     if (IsArgNegated(strArg)) return false;
@@ -685,7 +699,7 @@ static fs::path pathCached;
 static fs::path pathCachedNetSpecific;
 static CCriticalSection csPathCached;
 
-std::string GetDataDirNameFromNetworkId(const int networkId)
+std::string GetDataDirNameFromNetworkId(const uint networkId)
 {
     const std::string strNetworkId(std::to_string(networkId));
     return TAPYRUS_MODES::GetChainName(gArgs.GetChainMode()) + (strNetworkId.size() ? "-" + strNetworkId : "");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -494,13 +494,13 @@ bool ArgsManager::IsGetArgInRange(const std::string& strArg, const int64_t min, 
 {
     std::pair<bool,std::string> found_res = ArgsManagerHelper::GetArg(*this, strArg);
     if (found_res.first)
-    {
         value = atoi64(found_res.second);
-        if(value >= min && value <= max)
-            return true;
-    }
     else
         value = nDefault;
+
+    if(value >= min && value <= max)
+        return true;
+
     return false;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -92,7 +92,7 @@ fs::path GetDefaultDataDir();
 /*
  * Helper function to create data directory name using network mode and network id
 */
-std::string GetDataDirNameFromNetworkId(const uint networkID);
+std::string GetDataDirNameFromNetworkId(const uint32_t networkID);
 const fs::path &GetBlocksDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();

--- a/src/util.h
+++ b/src/util.h
@@ -92,7 +92,7 @@ fs::path GetDefaultDataDir();
 /*
  * Helper function to create data directory name using network mode and network id
 */
-std::string GetDataDirNameFromNetworkId(const int networkID);
+std::string GetDataDirNameFromNetworkId(const uint networkID);
 const fs::path &GetBlocksDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
@@ -228,6 +228,18 @@ public:
      * @return command-line argument (0 if invalid number) or default value
      */
     int64_t GetArg(const std::string& strArg, int64_t nDefault) const;
+
+    /**
+     * Return whether an integer argument is within the expected range
+     *
+     * @param strArg Argument to get (e.g. "-foo")
+     * @param min (e.g. 1)
+     * @param max (e.g. 4294967295)
+     * @param nDefault (e.g. 0)
+     * @param value return value assigned to this arg
+     * @return true if the value is in range. false otherwise(even when not found)
+     */
+    bool IsGetArgInRange(const std::string& strArg, const int64_t min, const int64_t max, const int64_t nDefault, int64_t& value) const;
 
     /**
      * Return boolean argument or default value


### PR DESCRIPTION
Added range check to networkId argument to tapyrusd. 
Added unit test for the same