### PR TITLE
change p2p port

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ discover=0
 
 dev=1
 [dev]
-port=12383
+port=2577
 rpcport=12381
 networkid=1905960821
 EOS


### PR DESCRIPTION
Dockerfile define `EXPOSE 2357 12383 2377 12381`, but this configuration was setuped `12383` as p2p port. Should change to same port.