### PR TITLE
Fix segmentation fault in issue token

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   multi:
-    if: ${{ github.repository == 'chaintope/tapyrus-core' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -2,8 +2,6 @@ name: Push Docker Image
 
 on:
   push:
-    tags:
-      - v*
 
 jobs:
   multi:
@@ -78,7 +76,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64/v8
-          push: true
+          push: false
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}

--- a/doc/release-notes/tapyrus/release-notes-0.5.0.md
+++ b/doc/release-notes/tapyrus/release-notes-0.5.0.md
@@ -14,20 +14,12 @@ How to Upgrade
 
 If you are running a node on older version(v0.3.0, v0.4.0, v0.4.1) testnet, shut it down. Wait until it has completelyshut down. Follow the instruction in [getting_started](doc/tapyrus/getting_started.md#how-to-start-a-node-on-tapyrus-testnet) to sart a new Tapyrus v0.5.0 node.
 
-<<<<<<< HEAD
 If you want to running a private tapyrus network, shut down all nodes. Follow the instruction in [getting_started](doc/tapyrus/getting_started.md#how-to-start-a-new-tapyrus-network) to sart a new Tapyrus v0.5.0 network. As v0.5.0 makes significant changes to consensus rules, when a running network is stopped all nodes should be upgraded before restarting the network again. Please note that tapyrus-signer network should also be upgraded to v0.5.0 following [tapyrus signer network setup](https://github.com/chaintope/tapyrus-signer/blob/master/doc/setup.md#how-to-set-up-new-tapyrus-signer-network)
-=======
-If you want to running a private tapyrus network, shut down all nodes. Follow the instruction in [getting_started](doc/tapyrus/getting_started.md#how-to-start-a-new-tapyrus-network) to sart a new Tapyrus v0.5.0 network. Please note that tapyrus-signer network should also be upgraded to v0.5.0 following [tapyrus signer network setup](https://github.com/chaintope/tapyrus-signer/blob/master/doc/setup.md#how-to-set-up-new-tapyrus-signer-network)
->>>>>>> added release notes for 0.5.0 release
 
 Downgrading warning
 -------------------
 
-<<<<<<< HEAD
 Tapyrus blockchain created by older versions(v0.3.0, v0.4.0 and v0.4.1) is not compatible with v0.5.0 and vice-versa. The testnet is reset with the release of v0.5.0.
-=======
-Tapyrus blockchain created by older versions(v0.3.0) is not compatible with v0.5.0 and vice-versa. The testnet is reset with the release of v0.5.0.
->>>>>>> added release notes for 0.5.0 release
 
 Compatibility
 ==============
@@ -37,7 +29,6 @@ Tapyrus v0.5.0 is supported on three platforms : Linux, MacOS and Windows(WSL)
 0.5.0 change log
 ------------------
 
-<<<<<<< HEAD
 *Colored coin*
 
 With version v0.5.0 Tapyrus blockchain supports tokens or colored coins. Tapyrus consensus, script and wallet layers have been enhanced to support the same. Apart from TPC, the default tapyrus coin, other tokens like NFTs, single issue tokens and reissuable tokens are now supported. Tokens may be issued, sent or received and burnt on Tapyrus blockchain. Complete specification of colored coins in Tapyrus can be found in [[Tapyrus colored coin](../../tapyrus/colored_coin.md)]
@@ -46,8 +37,6 @@ With version v0.5.0 Tapyrus blockchain supports tokens or colored coins. Tapyrus
 
 * OP_COLOR opcode has been added to identify and process token/colorid in a transaction script.
 
-=======
->>>>>>> added release notes for 0.5.0 release
 *Colored coin wallet*
 
 Tapyrus core wallet now supports colored coins. Coin issue, transfer and burn can be performed using tapyrus core wallet. New RPCs have been added to support these operations.
@@ -62,7 +51,6 @@ Tapyrus core wallet now supports colored coins. Coin issue, transfer and burn ca
 
 Tapyrus RPCs has been modified to remove old deprecated features and parameters. Account API support has been removed. Colored coin support has been added to other RPCs as follows.
 
-<<<<<<< HEAD
 * getnewaddress - addresstype parameter has been removed and color parameter has been added.
 * getrawchangeaddress - address type parameter has been removed and color parameter has been added.
 * addmultisigaddress - address type parameter has been removed.
@@ -75,20 +63,6 @@ Tapyrus RPCs has been modified to remove old deprecated features and parameters.
 * listtransactions - dummy parameter has been removed.
 * listunspent - account has been removed from the result.
 * fundrawtransaction - iswitness flag has been removed.
-=======
-* getnewaddress addresstype parameter has been removed and color parameter has been added.
-* getrawchangeaddress address type parameter has been removed and color parameter has been added.
-* addmultisigaddress address type parameter has been removed
-* getreceivedbyaddress minconf parameter has been removed.
-* getreceivedbylabel minconf parameter has been removed.
-* getbalance account parameter has been removed and color parameter has been added
-* sendmany account and minconf parameters have been removed and color parameter has been added.
-* listreceivedbyaddress  minconf parameter has been removed.
-* listreceivedbylabel minconf parameter has been removed.
-* listtransactions dummy parameter has been removed.
-* listunspent account has been removed from the result.
-* fundrawtransaction iswitness flag has been removed.
->>>>>>> added release notes for 0.5.0 release
 
 *Removed RPCs*
 

--- a/doc/release-notes/tapyrus/release-notes-0.5.0.md
+++ b/doc/release-notes/tapyrus/release-notes-0.5.0.md
@@ -14,12 +14,20 @@ How to Upgrade
 
 If you are running a node on older version(v0.3.0, v0.4.0, v0.4.1) testnet, shut it down. Wait until it has completelyshut down. Follow the instruction in [getting_started](doc/tapyrus/getting_started.md#how-to-start-a-node-on-tapyrus-testnet) to sart a new Tapyrus v0.5.0 node.
 
+<<<<<<< HEAD
 If you want to running a private tapyrus network, shut down all nodes. Follow the instruction in [getting_started](doc/tapyrus/getting_started.md#how-to-start-a-new-tapyrus-network) to sart a new Tapyrus v0.5.0 network. As v0.5.0 makes significant changes to consensus rules, when a running network is stopped all nodes should be upgraded before restarting the network again. Please note that tapyrus-signer network should also be upgraded to v0.5.0 following [tapyrus signer network setup](https://github.com/chaintope/tapyrus-signer/blob/master/doc/setup.md#how-to-set-up-new-tapyrus-signer-network)
+=======
+If you want to running a private tapyrus network, shut down all nodes. Follow the instruction in [getting_started](doc/tapyrus/getting_started.md#how-to-start-a-new-tapyrus-network) to sart a new Tapyrus v0.5.0 network. Please note that tapyrus-signer network should also be upgraded to v0.5.0 following [tapyrus signer network setup](https://github.com/chaintope/tapyrus-signer/blob/master/doc/setup.md#how-to-set-up-new-tapyrus-signer-network)
+>>>>>>> added release notes for 0.5.0 release
 
 Downgrading warning
 -------------------
 
+<<<<<<< HEAD
 Tapyrus blockchain created by older versions(v0.3.0, v0.4.0 and v0.4.1) is not compatible with v0.5.0 and vice-versa. The testnet is reset with the release of v0.5.0.
+=======
+Tapyrus blockchain created by older versions(v0.3.0) is not compatible with v0.5.0 and vice-versa. The testnet is reset with the release of v0.5.0.
+>>>>>>> added release notes for 0.5.0 release
 
 Compatibility
 ==============
@@ -29,6 +37,7 @@ Tapyrus v0.5.0 is supported on three platforms : Linux, MacOS and Windows(WSL)
 0.5.0 change log
 ------------------
 
+<<<<<<< HEAD
 *Colored coin*
 
 With version v0.5.0 Tapyrus blockchain supports tokens or colored coins. Tapyrus consensus, script and wallet layers have been enhanced to support the same. Apart from TPC, the default tapyrus coin, other tokens like NFTs, single issue tokens and reissuable tokens are now supported. Tokens may be issued, sent or received and burnt on Tapyrus blockchain. Complete specification of colored coins in Tapyrus can be found in [[Tapyrus colored coin](../../tapyrus/colored_coin.md)]
@@ -37,6 +46,8 @@ With version v0.5.0 Tapyrus blockchain supports tokens or colored coins. Tapyrus
 
 * OP_COLOR opcode has been added to identify and process token/colorid in a transaction script.
 
+=======
+>>>>>>> added release notes for 0.5.0 release
 *Colored coin wallet*
 
 Tapyrus core wallet now supports colored coins. Coin issue, transfer and burn can be performed using tapyrus core wallet. New RPCs have been added to support these operations.
@@ -51,6 +62,7 @@ Tapyrus core wallet now supports colored coins. Coin issue, transfer and burn ca
 
 Tapyrus RPCs has been modified to remove old deprecated features and parameters. Account API support has been removed. Colored coin support has been added to other RPCs as follows.
 
+<<<<<<< HEAD
 * getnewaddress - addresstype parameter has been removed and color parameter has been added.
 * getrawchangeaddress - address type parameter has been removed and color parameter has been added.
 * addmultisigaddress - address type parameter has been removed.
@@ -63,6 +75,20 @@ Tapyrus RPCs has been modified to remove old deprecated features and parameters.
 * listtransactions - dummy parameter has been removed.
 * listunspent - account has been removed from the result.
 * fundrawtransaction - iswitness flag has been removed.
+=======
+* getnewaddress addresstype parameter has been removed and color parameter has been added.
+* getrawchangeaddress address type parameter has been removed and color parameter has been added.
+* addmultisigaddress address type parameter has been removed
+* getreceivedbyaddress minconf parameter has been removed.
+* getreceivedbylabel minconf parameter has been removed.
+* getbalance account parameter has been removed and color parameter has been added
+* sendmany account and minconf parameters have been removed and color parameter has been added.
+* listreceivedbyaddress  minconf parameter has been removed.
+* listreceivedbylabel minconf parameter has been removed.
+* listtransactions dummy parameter has been removed.
+* listunspent account has been removed from the result.
+* fundrawtransaction iswitness flag has been removed.
+>>>>>>> added release notes for 0.5.0 release
 
 *Removed RPCs*
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4221,11 +4221,12 @@ static UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& 
         txnouttype type;
         std::vector<CTxDestination> vDest;
         int nRequired;
-        if (ExtractDestinations(scriptPubKey, type, vDest, nRequired)) {
-            for (const CTxDestination &dest : vDest)
-                if(!IsValidDestination(dest))
-                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
+        if (!ExtractDestinations(scriptPubKey, type, vDest, nRequired)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
         }
+        for (const CTxDestination &dest : vDest)
+            if(!IsValidDestination(dest))
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
         pwallet->SetAddressBook(vDest[0], "", "receive");
 
         // Create and send the transaction

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4222,11 +4222,11 @@ static UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& 
         std::vector<CTxDestination> vDest;
         int nRequired;
         if (!ExtractDestinations(scriptPubKey, type, vDest, nRequired)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid Tapyrus script: ") + script);
         }
         for (const CTxDestination &dest : vDest)
             if(!IsValidDestination(dest))
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
+                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid Tapyrus script:") + script);
         pwallet->SetAddressBook(vDest[0], "", "receive");
 
         // Create and send the transaction
@@ -4408,7 +4408,6 @@ static UniValue issuetoken(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid token amount for NFT. It must be 1");
     }
 
-    //TODO : validate utxo
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: Private keys are disabled for this wallet");
     }
@@ -4424,7 +4423,29 @@ static UniValue issuetoken(const JSONRPCRequest& request)
         return IssueReissuableToken(pwallet, request.params[2].getValStr(), tokenValue, coin_control);
     else
     {
-        COutPoint out(uint256S(request.params[2].get_str()), request.params[3].get_int());
+        uint256 hash = uint256S(request.params[2].get_str());
+        uint8_t vout = request.params[3].get_int();
+        COutPoint out(hash, vout);
+
+        //Check if the UTXO belongs to us and is spendable
+        //1. check transaction id
+        auto it = pwallet->mapWallet.find(hash);
+        if (it == pwallet->mapWallet.end()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid or non-wallet transaction id :") + request.params[2].get_str());
+        }
+
+        //2. vout and its type
+        if(vout < 0 || vout >= it->second.tx->vout.size() || GetColorIdFromScript(it->second.tx->vout[vout].scriptPubKey).type != TokenTypes::NONE) {
+            std::string strError = strprintf("Invalid vout %d in tx: %s", request.params[3].get_int(), request.params[2].get_str());
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strError);
+        }
+
+        //3. spendable
+        CTxOut txout(it->second.tx->vout[vout].nValue, it->second.tx->vout[vout].scriptPubKey);
+        if(pwallet->IsMine(txout)  != ISMINE_SPENDABLE)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Transaction is not spendable :") + request.params[2].get_str() + " : " + request.params[3].get_str());
+
+        //This output is ours. Add it to coin control so that it will be used as an input in transaction creation
         coin_control.Select(out);
         coin_control.m_colorTxType = ColoredTxType::ISSUE;
         return IssueToken(pwallet, tokenValue, coin_control);

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -629,6 +629,12 @@ class WalletColoredCoinTest(BitcoinTestFramework):
             assert_raises_rpc_error(-3, "Invalid amount", self.nodes[0].issuetoken, 2, 66.99, node2_utxos[4]['txid'], node2_utxos[4]['vout'])
             assert_raises_rpc_error(-3, "Amount out of range", self.nodes[0].issuetoken, 2, -10, node2_utxos[4]['txid'], node2_utxos[4]['vout'])
             assert_raises_rpc_error(-3, "Invalid token amount", self.nodes[0].issuetoken, 2, 0, node2_utxos[4]['txid'], node2_utxos[4]['vout'])
+            assert_raises_rpc_error(-8, "Invalid Tapyrus script: fuy", self.nodes[0].issuetoken, 1, 100, "fuy")
+            assert_raises_rpc_error(-8, "Invalid or non-wallet transaction id :aaa", self.nodes[0].issuetoken, 2, 100, "aaa", 1)
+            assert_raises_rpc_error(-8, str("Invalid or non-wallet transaction id :%s" % node2_utxos[1]['txid']), self.nodes[0].issuetoken, 2, 100, node2_utxos[1]['txid'], 1)
+            assert_raises_rpc_error(-8, str("Invalid or non-wallet transaction id :%s" %  res4['txids'][1]), self.nodes[0].issuetoken, 2, 100, res4['txids'][1], 10)
+            assert_raises_rpc_error(-8, "Invalid vout 10 in tx: "+ node2_utxos[1]['txid'], self.nodes[2].issuetoken, 2, 100, node2_utxos[1]['txid'], 10)
+            assert_raises_rpc_error(-8, str("Invalid vout 0 in tx: %s" % res1['txids'][1]), self.nodes[2].issuetoken, 2, 100, res1['txids'][1], 0)
 
     def run_test(self):
         # Check that there's no UTXO on any of the nodes


### PR DESCRIPTION
Issue Reissuable token checks the script for validity. but the checks were incorrect. These have been fixed.
Issue non-reissuable and NFT did not have checks for the outpoint given in input. these have been added.
Functional tests have been added with the new error scenarios.

