### PR TITLE
Fix segmentation fault in issuetoken

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4221,11 +4221,12 @@ static UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& 
         txnouttype type;
         std::vector<CTxDestination> vDest;
         int nRequired;
-        if (ExtractDestinations(scriptPubKey, type, vDest, nRequired)) {
-            for (const CTxDestination &dest : vDest)
-                if(!IsValidDestination(dest))
-                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
+        if (!ExtractDestinations(scriptPubKey, type, vDest, nRequired)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
         }
+        for (const CTxDestination &dest : vDest)
+            if(!IsValidDestination(dest))
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
         pwallet->SetAddressBook(vDest[0], "", "receive");
 
         // Create and send the transaction

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4222,11 +4222,11 @@ static UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& 
         std::vector<CTxDestination> vDest;
         int nRequired;
         if (!ExtractDestinations(scriptPubKey, type, vDest, nRequired)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid Tapyrus script: ") + script);
         }
         for (const CTxDestination &dest : vDest)
             if(!IsValidDestination(dest))
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Tapyrus address: ") + script);
+                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid Tapyrus script:") + script);
         pwallet->SetAddressBook(vDest[0], "", "receive");
 
         // Create and send the transaction
@@ -4408,7 +4408,6 @@ static UniValue issuetoken(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid token amount for NFT. It must be 1");
     }
 
-    //TODO : validate utxo
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: Private keys are disabled for this wallet");
     }
@@ -4424,7 +4423,29 @@ static UniValue issuetoken(const JSONRPCRequest& request)
         return IssueReissuableToken(pwallet, request.params[2].getValStr(), tokenValue, coin_control);
     else
     {
-        COutPoint out(uint256S(request.params[2].get_str()), request.params[3].get_int());
+        uint256 hash = uint256S(request.params[2].get_str());
+        uint8_t vout = request.params[3].get_int();
+        COutPoint out(hash, vout);
+
+        //Check if the UTXO belongs to us and is spendable
+        //1. check transaction id
+        auto it = pwallet->mapWallet.find(hash);
+        if (it == pwallet->mapWallet.end()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid or non-wallet transaction id :") + request.params[2].get_str());
+        }
+
+        //2. vout and its type
+        if(vout < 0 || vout >= it->second.tx->vout.size() || GetColorIdFromScript(it->second.tx->vout[vout].scriptPubKey).type != TokenTypes::NONE) {
+            std::string strError = strprintf("Invalid vout %d in tx: %s", request.params[3].get_int(), request.params[2].get_str());
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strError);
+        }
+
+        //3. spendable
+        CTxOut txout(it->second.tx->vout[vout].nValue, it->second.tx->vout[vout].scriptPubKey);
+        if(pwallet->IsMine(txout)  != ISMINE_SPENDABLE)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Transaction is not spendable :") + request.params[2].get_str() + " : " + request.params[3].get_str());
+
+        //This output is ours. Add it to coin control so that it will be used as an input in transaction creation
         coin_control.Select(out);
         coin_control.m_colorTxType = ColoredTxType::ISSUE;
         return IssueToken(pwallet, tokenValue, coin_control);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4391,9 +4391,9 @@ static UniValue issuetoken(const JSONRPCRequest& request)
             "    ]\n"
             "}\n"
             "\nExamples:\n"
-            + HelpExampleCli("issuetoken", "\"1\" \"100\" 8282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508")
+            + HelpExampleCli("issuetoken", "\"1\" \"100\" 76a9145834479edbbe0539b31ffd3a8f8ebadc2165ed0188ac")
             + HelpExampleCli("issuetoken", "\"2\" \"1000\" 485273f6703f038a234400edadb543eb44b4af5372e8b207990beebc386e7954 0")
-            + HelpExampleCli("issuetoken", "\"3\" \"500\" 485273f6703f038a234400edadb543eb44b4af5372e8b207990beebc386e7954 1")
+            + HelpExampleCli("issuetoken", "\"3\" \"1\" 485273f6703f038a234400edadb543eb44b4af5372e8b207990beebc386e7954 1")
         );
     RPCTypeCheck(request.params, {UniValue::VNUM, UniValue::VNUM, UniValue::VSTR});
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4425,11 +4425,11 @@ static UniValue issuetoken(const JSONRPCRequest& request)
     {
         uint256 txid = uint256S(request.params[2].get_str());
         uint8_t vout = request.params[3].get_int();
-        COutPoint out(hash, vout);
+        COutPoint out(txid, vout);
 
         //Check if the UTXO belongs to us and is spendable
         //1. check transaction id
-        auto it = pwallet->mapWallet.find(hash);
+        auto it = pwallet->mapWallet.find(txid);
         if (it == pwallet->mapWallet.end()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid or non-wallet transaction id :") + request.params[2].get_str());
         }

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -629,6 +629,12 @@ class WalletColoredCoinTest(BitcoinTestFramework):
             assert_raises_rpc_error(-3, "Invalid amount", self.nodes[0].issuetoken, 2, 66.99, node2_utxos[4]['txid'], node2_utxos[4]['vout'])
             assert_raises_rpc_error(-3, "Amount out of range", self.nodes[0].issuetoken, 2, -10, node2_utxos[4]['txid'], node2_utxos[4]['vout'])
             assert_raises_rpc_error(-3, "Invalid token amount", self.nodes[0].issuetoken, 2, 0, node2_utxos[4]['txid'], node2_utxos[4]['vout'])
+            assert_raises_rpc_error(-8, "Invalid Tapyrus script: fuy", self.nodes[0].issuetoken, 1, 100, "fuy")
+            assert_raises_rpc_error(-8, "Invalid or non-wallet transaction id :aaa", self.nodes[0].issuetoken, 2, 100, "aaa", 1)
+            assert_raises_rpc_error(-8, str("Invalid or non-wallet transaction id :%s" % node2_utxos[1]['txid']), self.nodes[0].issuetoken, 2, 100, node2_utxos[1]['txid'], 1)
+            assert_raises_rpc_error(-8, str("Invalid or non-wallet transaction id :%s" %  res4['txids'][1]), self.nodes[0].issuetoken, 2, 100, res4['txids'][1], 10)
+            assert_raises_rpc_error(-8, "Invalid vout 10 in tx: "+ node2_utxos[1]['txid'], self.nodes[2].issuetoken, 2, 100, node2_utxos[1]['txid'], 10)
+            assert_raises_rpc_error(-8, str("Invalid vout 0 in tx: %s" % res1['txids'][1]), self.nodes[2].issuetoken, 2, 100, res1['txids'][1], 0)
 
     def run_test(self):
         # Check that there's no UTXO on any of the nodes


### PR DESCRIPTION
Issue Reissuable token checks the script for validity. but the checks were incorrect. These have been fixed.
Issue non-reissuable and NFT did not have checks for the outpoint given in input. these have been added.
Functional tests have been added with the new error scenarios.