### PR TITLE
Remove redundant command line options

### DIFF
--- a/doc/man/tapyrusd.1
+++ b/doc/man/tapyrusd.1
@@ -238,10 +238,6 @@ networks.
 Support filtering of blocks and transaction with bloom filters (default:
 1)
 .HP
-\fB\-permitbaremultisig\fR
-.IP
-Relay non\-P2SH multisig (default: 1)
-.HP
 \fB\-port=\fR<port>
 .IP
 Listen for connections on <port> (default: 2357)
@@ -549,11 +545,6 @@ Password for JSON\-RPC connections
 \fB\-rpcport=\fR<port>
 .IP
 Listen for JSON\-RPC connections on <port> (default: 2377)
-.HP
-\fB\-rpcserialversion\fR
-.IP
-Sets the serialization of raw transaction or block hex returned in
-non\-verbose mode, non\-segwit(0) or segwit(1) (default: 1)
 .HP
 \fB\-rpcthreads=\fR<n>
 .IP

--- a/doc/man/tapyrusd.1
+++ b/doc/man/tapyrusd.1
@@ -182,10 +182,6 @@ Allow DNS lookups for \fB\-addnode\fR, \fB\-seednode\fR and \fB\-connect\fR (def
 Query for peer addresses via DNS lookup, if low on addresses (default: 1
 unless \fB\-connect\fR used)
 .HP
-\fB\-enablebip61\fR
-.IP
-Send reject messages per BIP61 (default: 1)
-.HP
 \fB\-externalip=\fR<ip>
 .IP
 Specify your own public address

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -15,15 +15,13 @@
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
-/** Default for BIP61 (sending reject messages) */
-static constexpr bool DEFAULT_ENABLE_BIP61 = true;
 
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:
     CConnman* const connman;
 
 public:
-    explicit PeerLogicValidation(CConnman* connman, CScheduler &scheduler, bool enable_bip61);
+    explicit PeerLogicValidation(CConnman* connman, CScheduler &scheduler);
 
     /**
      * Overridden from CValidationInterface.
@@ -71,8 +69,6 @@ public:
 private:
     int64_t m_stale_tip_check_time; //! Next time to check for stale tip
 
-    /** Enable BIP61 (sending reject messages) */
-    const bool m_enable_bip61;
 };
 
 struct CNodeStateStats {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -123,7 +123,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
 
         if (whichType == TX_NULL_DATA)
             nDataOut++;
-        else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
+        else if (whichType == TX_MULTISIG) {
             reason = "bare-multisig";
             return false;
         } else if (IsDust(txout, ::dustRelayFee)) {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -123,10 +123,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
 
         if (whichType == TX_NULL_DATA)
             nDataOut++;
-        else if (whichType == TX_MULTISIG) {
-            reason = "bare-multisig";
-            return false;
-        } else if (IsDust(txout, ::dustRelayFee)) {
+        else if (IsDust(txout, ::dustRelayFee)) {
             reason = "dust";
             return false;
         }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -563,12 +563,4 @@ void RPCRunLater(const std::string& name, std::function<void(void)> func, int64_
     deadlineTimers.emplace(name, std::unique_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));
 }
 
-int RPCSerializationFlags()
-{
-    int flag = 0;
-    if (gArgs.GetArg("-rpcserialversion", DEFAULT_RPC_SERIALIZE_VERSION) == 0)
-        flag |= SERIALIZE_TRANSACTION_NO_WITNESS;
-    return flag;
-}
-
 CRPCTable tableRPC;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -563,4 +563,9 @@ void RPCRunLater(const std::string& name, std::function<void(void)> func, int64_
     deadlineTimers.emplace(name, std::unique_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));
 }
 
+int RPCSerializationFlags()
+{
+    return SERIALIZE_TRANSACTION_NO_WITNESS;
+}
+
 CRPCTable tableRPC;

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -16,8 +16,7 @@
 #include <string>
 
 #include <univalue.h>
-
-static const unsigned int DEFAULT_RPC_SERIALIZE_VERSION = 1;
+#include <primitives/transaction.h>
 
 class CRPCCommand;
 
@@ -204,7 +203,7 @@ void InterruptRPC();
 void StopRPC();
 std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
 
-// Retrieves any serialization flags requested in command line argument
-int RPCSerializationFlags();
+// Default serialization flag
+int RPCSerializationFlags() { return SERIALIZE_TRANSACTION_NO_WITNESS; }
 
 #endif // BITCOIN_RPC_SERVER_H

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -204,6 +204,6 @@ void StopRPC();
 std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
 
 // Default serialization flag
-int RPCSerializationFlags() { return SERIALIZE_TRANSACTION_NO_WITNESS; }
+int RPCSerializationFlags();
 
 #endif // BITCOIN_RPC_SERVER_H

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1,6 +1,6 @@
 all:
-	$(MAKE) -C .. bitcoin_test
+	$(MAKE) -C .. tapyrus_test
 clean:
-	$(MAKE) -C .. bitcoin_test_clean
+	$(MAKE) -C .. tapyrus_test_clean
 check:
-	$(MAKE) -C .. bitcoin_test_check
+	$(MAKE) -C .. tapyrus_test_check

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK(IsStandardTx(txTo[i], reason));
     }
 }
 

--- a/src/test/test_tapyrus.cpp
+++ b/src/test/test_tapyrus.cpp
@@ -117,7 +117,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
             threadGroup.create_thread(&ThreadScriptCheck);
         g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
         connman = g_connman.get();
-        peerLogic.reset(new PeerLogicValidation(connman, scheduler, /*enable_bip61=*/true));
+        peerLogic.reset(new PeerLogicValidation(connman, scheduler));
 }
 
 TestingSetup::~TestingSetup()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -226,7 +226,6 @@ std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
 bool fHavePruned = false;
 bool fPruneMode = false;
-bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;

--- a/src/validation.h
+++ b/src/validation.h
@@ -117,8 +117,6 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 /** Maximum age of our tip in seconds for us to be considered current for fee estimation */
 static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
 
-/** Default for -permitbaremultisig */
-static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
@@ -161,7 +159,6 @@ extern uint256 g_best_block;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 extern int nScriptCheckThreads;
-extern bool fIsBareMultisigStd;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -38,6 +38,11 @@ class ConfArgsTest(BitcoinTestFramework):
 
         self.test_config_file_parser()
 
+        self.log.info("unsupported options(removed in tapyrus only)")
+        self.nodes[0].assert_start_raises_init_error(['-enablebip61=0'], 'Error parsing command line arguments: Invalid parameter -enablebip61')
+        self.nodes[0].assert_start_raises_init_error(['-permitbaremultisig=0'], 'Error parsing command line arguments: Invalid parameter -permitbaremultisig')
+        self.nodes[0].assert_start_raises_init_error(['-rpcserialversion'], 'Error parsing command line arguments: Invalid parameter -rpcserialversion')
+
         self.log.info("-dnsseeder and -dnsseed tests")
         # -dnsseeder and -dnsseed tests
         self.start_node(0, ['-addseeder=seed.tapyrus.dev.chaintope.com','-addseeder=static-seed.tapyrus.dev.chaintope.com'])

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -20,8 +20,9 @@ from test_framework.mininode import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
+    wait_until
 )
+from time import sleep
 
 
 class InvalidTxRequestTest(BitcoinTestFramework):
@@ -155,13 +156,12 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         wait_until(lambda: 1 == len(node.getpeerinfo()), timeout=12)  # p2ps[1] is no longer connected
         assert_equal(expected_mempool, set(node.getrawmempool()))
 
-        # restart node with sending BIP61 messages disabled, check that it disconnects without sending the reject message
-        self.log.info('Test a transaction that is rejected, with BIP61 disabled')
-        self.restart_node(0, ['-persistmempool=0'])
+        # verify that enablebip61 is not accepted by tapyrusd anymore
+        self.nodes[0].assert_start_raises_init_error(['-enablebip61=0', '-persistmempool=0'], 'Error parsing command line arguments: Invalid parameter -enablebip61')
         self.reconnect_p2p(num_connections=1)
         node.p2p.send_txs_and_test([tx1], node, success=False, expect_disconnect=False)
         # send_txs_and_test will have waited for disconnect, so we can safely check that no reject has been received
-        assert_equal(node.p2p.reject_code_received, 64)
+        assert_equal(node.p2p.reject_code_received, None)
 
 if __name__ == '__main__':
     InvalidTxRequestTest().main()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -157,11 +157,11 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
         # restart node with sending BIP61 messages disabled, check that it disconnects without sending the reject message
         self.log.info('Test a transaction that is rejected, with BIP61 disabled')
-        self.restart_node(0, ['-enablebip61=0','-persistmempool=0'])
+        self.restart_node(0, ['-persistmempool=0'])
         self.reconnect_p2p(num_connections=1)
         node.p2p.send_txs_and_test([tx1], node, success=False, expect_disconnect=False)
         # send_txs_and_test will have waited for disconnect, so we can safely check that no reject has been received
-        assert_equal(node.p2p.reject_code_received, None)
+        assert_equal(node.p2p.reject_code_received, 64)
 
 if __name__ == '__main__':
     InvalidTxRequestTest().main()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -22,7 +22,6 @@ from test_framework.util import (
     assert_equal,
     wait_until
 )
-from time import sleep
 
 
 class InvalidTxRequestTest(BitcoinTestFramework):
@@ -157,7 +156,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         assert_equal(expected_mempool, set(node.getrawmempool()))
 
         # verify that enablebip61 is not accepted by tapyrusd anymore
-        self.nodes[0].assert_start_raises_init_error(['-enablebip61=0', '-persistmempool=0'], 'Error parsing command line arguments: Invalid parameter -enablebip61')
+        self.nodes[0].assert_start_raises_init_error(['-persistmempool=0', '-enablebip61=0'], 'Error parsing command line arguments: Invalid parameter -enablebip61')
         self.reconnect_p2p(num_connections=1)
         node.p2p.send_txs_and_test([tx1], node, success=False, expect_disconnect=False)
         # send_txs_and_test will have waited for disconnect, so we can safely check that no reject has been received


### PR DESCRIPTION
According to #216 options enablebip61, permitbaremultisig and rpcserialversion have been removed in this PR