### PR TITLE
 only_token filter in listunspent rpc

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2709,6 +2709,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
             "      \"maximumAmount\"    (numeric or string, default=unlimited) Maximum value of each UTXO in " + CURRENCY_UNIT + "\n"
             "      \"maximumCount\"     (numeric or string, default=unlimited) Maximum number of UTXOs\n"
             "      \"minimumSumAmount\" (numeric or string, default=unlimited) Minimum sum value of all UTXOs in " + CURRENCY_UNIT + "\n"
+            "      \"only_token\" (boolean, default=false) Filter and return only tokens in the output\n"
             "    }\n"
             "\nResult\n"
             "[                   (array of json object)\n"
@@ -2736,6 +2737,8 @@ static UniValue listunspent(const JSONRPCRequest& request)
             + HelpExampleRpc("listunspent", "6, 9999999 \"[\\\"1PGFqEzfmQch1gKD3ra4k18PNj3tTUUSqg\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"")
             + HelpExampleCli("listunspent", "6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'")
             + HelpExampleRpc("listunspent", "6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ")
+            + HelpExampleCli("listunspent", "6 9999999 '[]' true '{ \"only_token\": true }'")
+            + HelpExampleRpc("listunspent", "6, 9999999, [] , true, { \"only_token\": true} ")
         );
 
     int nMinDepth = 1;
@@ -2776,6 +2779,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
     CAmount nMaximumAmount = MAX_MONEY;
     CAmount nMinimumSumAmount = MAX_MONEY;
     uint64_t nMaximumCount = 0;
+    bool only_token = false;
 
     if (!request.params[4].isNull()) {
         const UniValue& options = request.params[4].get_obj();
@@ -2791,6 +2795,10 @@ static UniValue listunspent(const JSONRPCRequest& request)
 
         if (options.exists("maximumCount"))
             nMaximumCount = options["maximumCount"].get_int64();
+
+        if (options.exists("only_token"))
+            only_token =  options["only_token"].get_bool();
+
     }
 
     // Make sure the results are valid at least up to the most recent block
@@ -2801,7 +2809,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
     std::vector<COutput> vecOutputs;
     {
         LOCK2(cs_main, pwallet->cs_wallet);
-        pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
+        pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth, only_token);
     }
 
     LOCK(pwallet->cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2193,7 +2193,7 @@ TxColoredCoinBalancesMap CWallet::GetAvailableBalance(const CCoinControl* coinCo
     return balance;
 }
 
-void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const CCoinControl *coinControl, const CAmount &nMinimumAmount, const CAmount &nMaximumAmount, const CAmount &nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth) const
+void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const CCoinControl *coinControl, const CAmount &nMinimumAmount, const CAmount &nMaximumAmount, const CAmount &nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth, bool only_token) const
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(cs_wallet);
@@ -2264,6 +2264,9 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                 continue;
 
             if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsSelected(COutPoint(entry.first, i)))
+                continue;
+
+            if (only_token && colorId.type == TokenTypes::NONE)
                 continue;
 
             if (IsLockedCoin(entry.first, i))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -840,7 +840,7 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999, bool only_token = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -631,6 +631,15 @@ class WalletColoredCoinTest(BitcoinTestFramework):
             assert_raises_rpc_error(-3, "Invalid token amount", self.nodes[0].issuetoken, 2, 0, node2_utxos[4]['txid'], node2_utxos[4]['vout'])
 
     def test_only_token_filter(self):
+
+        self.log.info("Testing only_token filter in listunspent")
+        # all utxos
+        assert_equal(len(self.nodes[0].listunspent()), 15)
+        # token utxos
+        assert_equal(len(self.nodes[0].listunspent(1,99999,[],False,{"only_token": True})), 6)
+        # utxos with "only_token" = false  is the same as no filter
+        assert_equal(len(self.nodes[0].listunspent(1,99999,[],False,{"only_token": False})), 15)
+
         # issue token on node 0 to create safe unconfirmed token transactions
         tpc_utxo = findTPC(self.nodes[0].listunspent())
         pubkeyhash = hash160(hex_str_to_bytes(self.nodes[0].getaddressinfo(tpc_utxo['address'])['pubkey']))
@@ -655,15 +664,13 @@ class WalletColoredCoinTest(BitcoinTestFramework):
 
         #checking different combinations of min and max confirmations
         res = [7, 8, 6, 6, 1, 2, 1, 2]
-        i = 0
-        for options in [[0,30,[],False], [0,30,[],True], \
+        for i, options in enumerate( [[0,30,[],False], [0,30,[],True], \
                         [1,30,[],False], [1,30,[],True], \
                         [0,10,[],False], [0,10,[],True], \
-                        [0,0,[],False],  [0,0,[],True] ]:
+                        [0,0,[],False],  [0,0,[],True] ]):
 
             token_unspent = self.nodes[0].listunspent(options[0],options[1],options[2],options[3],{"only_token": True})
             assert_equal(len(token_unspent), res[i])
-            i = i+1
 
     def run_test(self):
         # Check that there's no UTXO on any of the nodes

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -677,7 +677,10 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance(), 300)
 
         total_unspent = len(self.nodes[0].listunspent())
-        token_unspent = len(self.nodes[0].listunspent(6,9999999,[],True,{"only_token": True}))
+        if self.options.usecli:
+            token_unspent = len(self.nodes[0].listunspent(query_options="{\"only_token\": true}"))
+        else:
+            token_unspent = len(self.nodes[0].listunspent(query_options={"only_token": True}))
         assert_equal(total_unspent, 6)
         assert_equal(token_unspent, 0)
 
@@ -696,7 +699,8 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         self.test_burntoken()
         self.test_reissuetoken()
         self.test_issuetoken()
-        self.test_only_token_filter()
+        if not self.options.usecli:
+            self.test_only_token_filter()
 
 
 reverse_bytes = (lambda txid  : txid[-1: -len(txid)-1: -1])


### PR DESCRIPTION
Added only_token option to listunspent RPC to filter only token outputs.
Updated tests