### PR TITLE
New <xfield_type:xfield> parameter in getnewblock RPC

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -91,7 +91,7 @@ void BlockAssembler::resetBlock()
     nFees = 0;
 }
 
-std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx, int required_age_in_secs)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, int required_age_in_secs, TAPYRUS_XFIELDTYPES xfieldType, const xFieldInput* value)
 {
     int64_t nTimeStart = GetTimeMicros();
 
@@ -118,6 +118,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // -blockversion=N to test forking scenarios
     if (chainparams.MineBlocksOnDemand())
         pblock->nFeatures = gArgs.GetArg("-blockfeatures", pblock->nFeatures);
+
+    if(xfieldType != TAPYRUS_XFIELDTYPES::NONE)
+    {
+        pblock->xfieldType = (uint8_t)xfieldType;
+        pblock->xfield = value->xFieldValue.aggPubKey;
+    }
 
     pblock->nTime = GetAdjustedTime();
     const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -91,7 +91,7 @@ void BlockAssembler::resetBlock()
     nFees = 0;
 }
 
-std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, int required_age_in_secs, TAPYRUS_XFIELDTYPES xfieldType, const xFieldInput* value)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, int required_age_in_secs, TAPYRUS_XFIELDTYPES xfieldType, const xFieldData* value)
 {
     int64_t nTimeStart = GetTimeMicros();
 
@@ -122,7 +122,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     if(xfieldType != TAPYRUS_XFIELDTYPES::NONE)
     {
         pblock->xfieldType = (uint8_t)xfieldType;
-        pblock->xfield = value->xFieldValue.aggPubKey;
+        pblock->xfield = value->aggPubKey;
     }
 
     pblock->nTime = GetAdjustedTime();

--- a/src/miner.h
+++ b/src/miner.h
@@ -121,6 +121,30 @@ struct update_for_parent_inclusion
     CTxMemPool::txiter iter;
 };
 
+/* extensible structure to store the xfield input from RPC getnewblock
+xFieldData is a union holding either aggpubkey or max block size. It is extensible in the future
+*/
+
+struct xFieldInput{
+    bool invalid;
+    union xFieldData{
+        std::vector<unsigned char> aggPubKey;
+
+        /*
+         default constructor and destructor
+         need to be changed when new xfield types are added
+        */
+        xFieldData():aggPubKey({'\0'}){}
+        xFieldData(unsigned char* begin, unsigned char* end):aggPubKey(begin, end){}
+        ~xFieldData(){}
+
+    } xFieldValue;
+
+    xFieldInput():invalid(true), xFieldValue(){}
+    xFieldInput(unsigned char* begin, unsigned char* end):xFieldValue(begin, end){}
+    ~xFieldInput(){}
+};
+
 /** Generate a new block, without valid proof-of-work */
 class BlockAssembler
 {
@@ -157,7 +181,7 @@ public:
     BlockAssembler(const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true, int required_age_in_secs=0);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, int required_age_in_secs=0, TAPYRUS_XFIELDTYPES xfieldType = TAPYRUS_XFIELDTYPES::NONE, const xFieldInput* Value = nullptr);
 
 private:
     // utility functions

--- a/src/miner.h
+++ b/src/miner.h
@@ -125,8 +125,7 @@ struct update_for_parent_inclusion
 xFieldData is a union holding either aggpubkey or max block size. It is extensible in the future
 */
 
-struct xFieldInput{
-    bool invalid;
+
     union xFieldData{
         std::vector<unsigned char> aggPubKey;
 
@@ -138,12 +137,7 @@ struct xFieldInput{
         xFieldData(unsigned char* begin, unsigned char* end):aggPubKey(begin, end){}
         ~xFieldData(){}
 
-    } xFieldValue;
-
-    xFieldInput():invalid(true), xFieldValue(){}
-    xFieldInput(unsigned char* begin, unsigned char* end):xFieldValue(begin, end){}
-    ~xFieldInput(){}
-};
+    };
 
 /** Generate a new block, without valid proof-of-work */
 class BlockAssembler
@@ -181,7 +175,7 @@ public:
     BlockAssembler(const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, int required_age_in_secs=0, TAPYRUS_XFIELDTYPES xfieldType = TAPYRUS_XFIELDTYPES::NONE, const xFieldInput* Value = nullptr);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, int required_age_in_secs=0, TAPYRUS_XFIELDTYPES xfieldType = TAPYRUS_XFIELDTYPES::NONE, const xFieldData* Value = nullptr);
 
 private:
     // utility functions

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -16,6 +16,8 @@ enum class TAPYRUS_XFIELDTYPES
 {
     NONE = 0, //no xfield
     AGGPUBKEY = 1, //xfield is 33 byte aggpubkey
+
+    MAX_XFIELDTYPE
 };
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -73,6 +73,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblock", 1, "verbose" },
     { "getblockheader", 1, "verbose" },
     { "getchaintxstats", 0, "nblocks" },
+    { "getnewblock", 1, "required_age" },
     { "gettransaction", 1, "include_watchonly" },
     { "getrawtransaction", 1, "verbose" },
     { "createrawtransaction", 0, "inputs" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -140,7 +140,7 @@ UniValue getnewblock(const JSONRPCRequest& request)
                 "blockhex      (hex) The block hex\n"
                 "\nExamples:\n"
                 + HelpExampleCli("getnewblock", "")
-                + HelpExampleCli("getnewblock", "address 0 \"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc\"")
+                + HelpExampleCli("getnewblock", "\"1DV3jX8bujEW4vAUYgsKDNa8UwAxAXGiEb\" 10 \"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc\"")
         );
 
     CTxDestination destination = DecodeDestination(request.params[0].get_str());

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK(!pool.exists(tx3.GetHashMalFix()));
 
     CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(tx3) + GetVirtualTransactionSize(tx2));
-        BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
+    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
 
     CMutableTransaction tx4 = CMutableTransaction();
     tx4.vin.resize(2);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK(!pool.exists(tx3.GetHashMalFix()));
 
     CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(tx3) + GetVirtualTransactionSize(tx2));
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
+        BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
 
     CMutableTransaction tx4 = CMutableTransaction();
     tx4.vin.resize(2);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_required_age_in_secs)
                              entry.Fee(1000).Time(GetTime() - 60).SpendsCoinbase(true).FromTx(tx));
     }
 
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(Params()).CreateNewBlock(scriptPubKey, true, 60));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(Params()).CreateNewBlock(scriptPubKey, 60));
     BOOST_CHECK(pblocktemplate->block.vtx.size() == 2); // index 0 is coinbase tx.
     BOOST_CHECK(pblocktemplate->block.vtx[1]->GetHashMalFix() == hashPastTimeTx);
 }

--- a/test/functional/rpc_getnewblock.py
+++ b/test/functional/rpc_getnewblock.py
@@ -27,8 +27,13 @@ class GetNewBlockTest(BitcoinTestFramework):
         self.log.info("Test starting...")
         self.nodes[0].generate(1, self.signblockprivkey_wif)
 
-        self.log.info("getnewblock aggpubkey tests")
+        self.log.info("getnewblock regression tests")
         address = self.nodes[0].getnewaddress()
+        blockhex = self.nodes[0].getnewblock(address)
+        blockhex = self.nodes[0].getnewblock(address, 1)
+        assert_raises_rpc_error(-1, "JSON value is not a string as expected", self.nodes[0].getnewblock)
+
+        self.log.info("getnewblock aggpubkey tests")
         blockhex = self.nodes[0].getnewblock(address, 0,"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
         block = FromHex(CBlock(), blockhex)
         assert_equal(block.xfieldType, 1)

--- a/test/functional/rpc_getnewblock.py
+++ b/test/functional/rpc_getnewblock.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Copyright (c) 2019 Chaintope Inc.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the getnewblock RPC.
+
+Test parameter xfield_type:xfield
+
+xfield_type 1 - Aggregate Public key
+xfield_type 2 - Max block size
+
+"""
+
+from email import header
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal,assert_raises_rpc_error
+from test_framework.messages import FromHex, CBlock
+
+class GetNewBlockTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test (self):
+
+        self.log.info("Test starting...")
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+
+        self.log.info("getnewblock aggpubkey tests")
+        address = self.nodes[0].getnewaddress()
+        blockhex = self.nodes[0].getnewblock(address, 0,"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        block = FromHex(CBlock(), blockhex)
+        assert_equal(block.xfieldType, 1)
+        assert_equal(block.xfield, bytes.fromhex("03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc"))
+
+        blockhex = self.nodes[0].getnewblock(address, 10,"1:02bf2027c8455800c7626542219e6208b5fe787483689f1391d6d443ec85673ecf")
+        block = FromHex(CBlock(), blockhex)
+        assert_equal(block.xfieldType, 1)
+        assert_equal(block.xfield, bytes.fromhex("02bf2027c8455800c7626542219e6208b5fe787483689f1391d6d443ec85673ecf"))
+
+        self.log.info("getnewblock aggpubkey negative tests")
+        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"2:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"0:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"2:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"2:03ac")
+
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fa")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:0383fc")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee")
+
+
+
+if __name__ == '__main__':
+    GetNewBlockTest().main ()

--- a/test/functional/rpc_getnewblock.py
+++ b/test/functional/rpc_getnewblock.py
@@ -33,10 +33,13 @@ class GetNewBlockTest(BitcoinTestFramework):
         self.nodes[0].getnewblock(address)
         self.nodes[0].getnewblock(address, 1)
         self.nodes[0].getnewblock(address, 0)
+        self.nodes[0].getnewblock("mt8EZJFAhhhxv57NFYfXPecDoAbWWqnRqX")
 
         assert_raises_rpc_error(-1, "JSON value is not a string as expected", self.nodes[0].getnewblock)
         assert_raises_rpc_error(-1, "JSON value is not a string as expected", self.nodes[0].getnewblock, -10)
         assert_raises_rpc_error(-32602, "required_wait must be non-negative", self.nodes[0].getnewblock, address, -10)
+        assert_raises_rpc_error(-5, "Error: Invalid address", self.nodes[0].getnewblock, "hjgyj")
+        assert_raises_rpc_error(-5, "Error: Invalid address", self.nodes[0].getnewblock, address+ "00")
         assert_raises_rpc_error(-1, "JSON integer out of range", self.nodes[0].getnewblock, address, 565786879879785)
 
         self.log.info("getnewblock aggpubkey tests")
@@ -51,17 +54,18 @@ class GetNewBlockTest(BitcoinTestFramework):
         assert_equal(block.xfield, bytes.fromhex("02bf2027c8455800c7626542219e6208b5fe787483689f1391d6d443ec85673ecf"))
 
         self.log.info("getnewblock aggpubkey negative tests")
-        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
-        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"2:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
-        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"0:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
-        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"2:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
-        assert_raises_rpc_error(-32602, "xfield_type parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"2:03ac")
-
-        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
-        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fa")
-        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:0383fc")
-        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
-        assert_raises_rpc_error(-32602, "xfield parameter was invalid. It is expected to be <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"1:0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee")
+        assert_raises_rpc_error(-32602, "xfield parameter could not be parsed. Check if the xfield parameter has format: <xfield_type:new_xfield_value>", self.nodes[0].getnewblock, address, 0,"03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "Unknown xfield type", self.nodes[0].getnewblock, address, 0,"2:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "Unknown xfield type", self.nodes[0].getnewblock, address, 0,"0:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "Unknown xfield type", self.nodes[0].getnewblock, address, 0,"2:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "Unknown xfield type", self.nodes[0].getnewblock, address, 0,"2:03ac")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. Aggregate public key could not be parsed", self.nodes[0].getnewblock, address, 0,"1:fghjgf131423fafc")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. Aggregate public key could not be parsed", self.nodes[0].getnewblock, address, 0,"1:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafz")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. Aggregate public key was uncompressed or invalid", self.nodes[0].getnewblock, address, 0,"1:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. Aggregate public key was uncompressed or invalid", self.nodes[0].getnewblock, address, 0,"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fa")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. Aggregate public key was uncompressed or invalid", self.nodes[0].getnewblock, address, 0,"1:0383fc")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. Aggregate public key was uncompressed or invalid", self.nodes[0].getnewblock, address, 0,"1:831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")
+        assert_raises_rpc_error(-32602, "xfield parameter was invalid. Aggregate public key was uncompressed or invalid", self.nodes[0].getnewblock, address, 0,"1:0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee")
 
 
 

--- a/test/functional/rpc_getnewblock.py
+++ b/test/functional/rpc_getnewblock.py
@@ -21,6 +21,7 @@ class GetNewBlockTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
+        self.supports_cli = True
 
     def run_test (self):
 
@@ -29,9 +30,14 @@ class GetNewBlockTest(BitcoinTestFramework):
 
         self.log.info("getnewblock regression tests")
         address = self.nodes[0].getnewaddress()
-        blockhex = self.nodes[0].getnewblock(address)
-        blockhex = self.nodes[0].getnewblock(address, 1)
+        self.nodes[0].getnewblock(address)
+        self.nodes[0].getnewblock(address, 1)
+        self.nodes[0].getnewblock(address, 0)
+
         assert_raises_rpc_error(-1, "JSON value is not a string as expected", self.nodes[0].getnewblock)
+        assert_raises_rpc_error(-1, "JSON value is not a string as expected", self.nodes[0].getnewblock, -10)
+        assert_raises_rpc_error(-32602, "required_wait must be non-negative", self.nodes[0].getnewblock, address, -10)
+        assert_raises_rpc_error(-1, "JSON integer out of range", self.nodes[0].getnewblock, address, 565786879879785)
 
         self.log.info("getnewblock aggpubkey tests")
         blockhex = self.nodes[0].getnewblock(address, 0,"1:03831a69b8009833ab5b0326012eaf489bfea35a7321b1ca15b11d88131423fafc")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -108,6 +108,7 @@ BASE_SCRIPTS = [
     'wallet_disableprivatekeys.py',
     'wallet_disableprivatekeys.py --usecli',
     'interface_http.py',
+    'rpc_getnewblock.py',
     'rpc_psbt.py',
     'rpc_psbt.py --scheme SCHNORR',
     'rpc_users.py',


### PR DESCRIPTION
Implemented #230 
This PR adds a new parameter to getnewblock RPC to fill the xfieldType and xfield information in a new block being created. 
Adds new functional test for the same.