### PR TITLE
Add ability to retry functional tests which timeout

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -34,7 +34,7 @@ from test_framework.util import (
 # message is received from the node-under-test. Subclass P2PInterface and
 # override the on_*() methods if you need custom behaviour.
 class BaseNode(P2PInterface):
-    def __init__(self):
+    def __init__(self, time_to_connect):
         """Initialize the P2PInterface
 
         Used to initialize custom properties for the Node that aren't
@@ -45,7 +45,7 @@ class BaseNode(P2PInterface):
 
         Call super().__init__() first for standard initialization and then
         initialize custom properties."""
-        super().__init__()
+        super().__init__(time_to_connect)
         # Stores a dictionary of all blocks received
         self.block_receive_map = defaultdict(int)
 

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1352,7 +1352,7 @@ class FullBlockTest(BitcoinTestFramework):
         """Add a P2P connection to the node.
 
         Helper to connect and wait for version handshake."""
-        self.nodes[0].add_p2p_connection(P2PDataStore())
+        self.nodes[0].add_p2p_connection(P2PDataStore(self.nodes[0].time_to_connect))
         # We need to wait for the initial getheaders from the peer before we
         # start populating our blockstore. If we don't, then we may run ahead
         # to the next subtest before we receive the getheaders. We'd then send

--- a/test/functional/feature_blockheaderxfield.py
+++ b/test/functional/feature_blockheaderxfield.py
@@ -74,12 +74,12 @@ class BlockHeaderXFieldTest(BitcoinTestFramework):
         The node gets disconnected several times in this test. This helper
         method reconnects the p2p and restarts the network thread."""
         self.nodes[0].disconnect_p2ps()
-        self.nodes[0].add_p2p_connection(P2PDataStore())
+        self.nodes[0].add_p2p_connection(P2PDataStore(self.nodes[0].time_to_connect))
         self.nodes[0].p2p.wait_for_getheaders(timeout=5)
 
     def run_test(self):
         node = self.nodes[0]
-        node.add_p2p_connection(P2PDataStore())
+        node.add_p2p_connection(P2PDataStore(node.time_to_connect))
         node.p2p.wait_for_getheaders(timeout=5)
 
         self.tip = node.getbestblockhash()

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -61,7 +61,7 @@ class BIP65Test(BitcoinTestFramework):
 
     def run_test(self):
         SCHEME = self.options.scheme
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(node.time_to_connect))
 
         self.log.info("Mining %d blocks", CLTV_HEIGHT-1)
         self.coinbase_txids = [self.nodes[0].getblock(b)['tx'][0] for b in self.nodes[0].generate(CLTV_HEIGHT-1, self.signblockprivkey_wif)]

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -61,7 +61,7 @@ class BIP65Test(BitcoinTestFramework):
 
     def run_test(self):
         SCHEME = self.options.scheme
-        self.nodes[0].add_p2p_connection(P2PInterface(node.time_to_connect))
+        self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
 
         self.log.info("Mining %d blocks", CLTV_HEIGHT-1)
         self.coinbase_txids = [self.nodes[0].getblock(b)['tx'][0] for b in self.nodes[0].generate(CLTV_HEIGHT-1, self.signblockprivkey_wif)]

--- a/test/functional/feature_coloredcoin.py
+++ b/test/functional/feature_coloredcoin.py
@@ -115,7 +115,7 @@ class ColoredCoinTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node
         self.address = node.getnewaddress()
-        node.add_p2p_connection(P2PDataStore())
+        node.add_p2p_connection(P2PDataStore(node.time_to_connect))
         node.p2p.wait_for_getheaders(timeout=5)
         self.address = self.nodes[0].getnewaddress()
 

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -158,12 +158,12 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
         if not success and reject_code == 16:
             #reconnect as this node is disconnected for sending the invalid block.
-            self.nodes[0].add_p2p_connection(P2PDataStore())
+            self.nodes[0].add_p2p_connection(P2PDataStore(self.nodes[0].time_to_connect))
             self.nodes[0].p2p.wait_for_getheaders(timeout=5)
 
     def run_test(self):
         SCHEME = self.options.scheme
-        self.nodes[0].add_p2p_connection(P2PDataStore())
+        self.nodes[0].add_p2p_connection(P2PDataStore(self.nodes[0].time_to_connect))
 
         self.log.info("Generate blocks in the past for coinbase outputs.")
         long_past_time = int(time.time()) - 600 * 1000  # enough to build up to 1000 blocks 10 minutes apart without worrying about getting into the future

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -47,7 +47,7 @@ class BIP66Test(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
 
         self.log.info("Mining %d blocks", DERSIG_HEIGHT - 1)
         self.coinbase_txids = [self.nodes[0].getblock(b)['tx'][0] for b in self.nodes[0].generate(DERSIG_HEIGHT - 1, self.signblockprivkey_wif)]

--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -113,7 +113,7 @@ class FederationManagementTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node
         self.address = node.getnewaddress()
-        node.add_p2p_connection(P2PDataStore())
+        node.add_p2p_connection(P2PDataStore(node.time_to_connect))
         node.p2p.wait_for_getheaders(timeout=5)
 
         self.log.info("Test starting...")

--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -18,7 +18,7 @@ class HelpTest(BitcoinTestFramework):
         # Don't start the node
 
     def get_node_output(self, *, ret_code_expected):
-        ret_code = self.nodes[0].process.wait(timeout=5)
+        ret_code = self.nodes[0].process.wait(timeout=self.nodes[0].time_to_connect*2)
         assert_equal(ret_code, ret_code_expected)
         self.nodes[0].stdout.seek(0)
         self.nodes[0].stderr.seek(0)

--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -18,7 +18,7 @@ class HelpTest(BitcoinTestFramework):
         # Don't start the node
 
     def get_node_output(self, *, ret_code_expected):
-        ret_code = self.nodes[0].process.wait(timeout=self.nodes[0].time_to_connect*2)
+        ret_code = self.nodes[0].process.wait(timeout=5)
         assert_equal(ret_code, ret_code_expected)
         self.nodes[0].stdout.seek(0)
         self.nodes[0].stderr.seek(0)

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -57,7 +57,7 @@ class MaxUploadTest(BitcoinTestFramework):
         p2p_conns = []
 
         for _ in range(3):
-            p2p_conns.append(self.nodes[0].add_p2p_connection(TestP2PConn()))
+            p2p_conns.append(self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect)))
 
         # Now mine a big block
         mine_large_block(self.nodes[0], self.utxo_cache)
@@ -143,7 +143,7 @@ class MaxUploadTest(BitcoinTestFramework):
         self.start_node(0, ["-whitelist=127.0.0.1", "-maxuploadtarget=1"])
 
         # Reconnect to self.nodes[0]
-        self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect))
 
         #retrieve 20 blocks which should be enough to break the 1MB limit
         getdata_request.inv = [CInv(2, big_new_block)]

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -20,8 +20,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, mine_large_block
 
 class TestP2PConn(P2PInterface):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
         self.block_receive_map = defaultdict(int)
 
     def on_inv(self, message):

--- a/test/functional/feature_serialization.py
+++ b/test/functional/feature_serialization.py
@@ -88,7 +88,7 @@ class SerializationTest(BitcoinTestFramework):
         self.pubkey = ""
 
     def run_test(self):
-        self.nodes[0].add_p2p_connection(P2PDataStore())
+        self.nodes[0].add_p2p_connection(P2PDataStore(self.nodes[0].time_to_connect))
         self.nodeaddress = self.nodes[0].getnewaddress()
         self.pubkey = self.nodes[0].getaddressinfo(self.nodeaddress)["pubkey"]
         self.log.info("Mining %d blocks", CHAIN_HEIGHT)

--- a/test/functional/feature_signedgenesisblock.py
+++ b/test/functional/feature_signedgenesisblock.py
@@ -269,7 +269,7 @@ class SignedGenesisBlockTest(BitcoinTestFramework):
         self.log.info("Starting node")
         self.writeGenesisBlockToFile(self.nodes[0].datadir)
         self.start_node(0)
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
 
         self.log.info("Generating 10 blocks")
         blocks = self.nodes[0].generate(10, self.signblockprivkey_wif)
@@ -296,7 +296,7 @@ class SignedGenesisBlockTest(BitcoinTestFramework):
         shutil.rmtree(self.nodes[0].datadir)
         shutil.copytree(os.path.join(self.options.tmpdir, "backup"), self.nodes[0].datadir)
         self.start_node(0)
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
         self.sync_all([self.nodes[0:1]])
 
         assert_equal(self.nodes[0].getbestblockhash(), blocks[-1])

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -761,8 +761,8 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections
-        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
-        self.old_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect))
+        self.old_node = self.nodes[1].add_p2p_connection(TestP2PConn(self.nodes[1].time_to_connect), services=NODE_NETWORK)
         
         self.log.info("Tapyrus NODE_WITNESS connections are unsupported")
         self.segwit_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS, wait_for_verack = False)

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -21,8 +21,8 @@ from test_framework.util import assert_equal, sync_blocks, wait_until
 
 # TestP2PConn: A peer we use to send messages to bitcoind, and store responses.
 class TestP2PConn(P2PInterface):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
         self.last_sendcmpct = []
         self.block_announced = False
         # Store the hashes of blocks we've seen announced.

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -765,9 +765,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.old_node = self.nodes[1].add_p2p_connection(TestP2PConn(self.nodes[1].time_to_connect), services=NODE_NETWORK)
         
         self.log.info("Tapyrus NODE_WITNESS connections are unsupported")
-        self.segwit_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS, wait_for_verack = False)
+        self.segwit_node = self.nodes[1].add_p2p_connection(TestP2PConn(self.nodes[1].time_to_connect), services=NODE_NETWORK | NODE_WITNESS, wait_for_verack = False)
         self.segwit_node.wait_for_disconnect(timeout=10)
-        self.extra_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
+        self.extra_node = self.nodes[1].add_p2p_connection(TestP2PConn(self.nodes[1].time_to_connect), services=NODE_NETWORK)
 
         # We will need UTXOs to construct transactions in later tests.
         self.make_utxos()

--- a/test/functional/p2p_federation_block.py
+++ b/test/functional/p2p_federation_block.py
@@ -24,7 +24,7 @@ class FederationBlockTest(BitcoinTestFramework):
     def run_test(self):
         # Add p2p connection to node0
         node = self.nodes[0]  # convenience reference to the node
-        node.add_p2p_connection(P2PDataStore())
+        node.add_p2p_connection(P2PDataStore(node.time_to_connect))
 
         best_block = node.getblock(node.getbestblockhash())
         tip = int(node.getbestblockhash(), 16)

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -55,7 +55,7 @@ class FeeFilterTest(BitcoinTestFramework):
         node1.generate(1, self.signblockprivkey_wif)
         sync_blocks(self.nodes)
 
-        self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect))
 
         # Test that invs are received for all txs at feerate of 20 sat/byte
         node1.settxfee(Decimal("0.00020000"))

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -27,8 +27,8 @@ def allInvsMatch(invsExpected, testnode):
     return False
 
 class TestP2PConn(P2PInterface):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
         self.txinvs = []
 
     def on_inv(self, message):

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -77,7 +77,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
     # This does not currently test that stale blocks timestamped within the
     # last month but that have over a month's worth of work are also withheld.
     def run_test(self):
-        node0 = self.nodes[0].add_p2p_connection(P2PInterface())
+        node0 = self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
 
         self.nodes[0].setmocktime(int(time.time()) - 50 * 24 * 60 * 60)
         # Generating a chain of 10 blocks

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -28,7 +28,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
     def run_test(self):
         # Add p2p connection to node0
         node = self.nodes[0]  # convenience reference to the node
-        node.add_p2p_connection(P2PDataStore())
+        node.add_p2p_connection(P2PDataStore(node.time_to_connect))
 
         best_block = node.getblock(node.getbestblockhash())
         tip = int(node.getbestblockhash(), 16)

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -24,14 +24,14 @@ class InvalidLocatorTest(BitcoinTestFramework):
         block_count = node.getblockcount()
         for msg in [msg_getheaders(), msg_getblocks()]:
             self.log.info('Wait for disconnect when sending {} hashes in locator'.format(MAX_LOCATOR_SZ + 1))
-            node.add_p2p_connection(P2PInterface())
+            node.add_p2p_connection(P2PInterface(node.time_to_connect))
             msg.locator.vHave = [int(node.getblockhash(i - 1), 16) for i in range(block_count, block_count - (MAX_LOCATOR_SZ + 1), -1)]
             node.p2p.send_message(msg)
             node.p2p.wait_for_disconnect()
             node.disconnect_p2ps()
 
             self.log.info('Wait for response when sending {} hashes in locator'.format(MAX_LOCATOR_SZ))
-            node.add_p2p_connection(P2PInterface())
+            node.add_p2p_connection(P2PInterface(node.time_to_connect))
             msg.locator.vHave = [int(node.getblockhash(i - 1), 16) for i in range(block_count, block_count - (MAX_LOCATOR_SZ), -1)]
             node.p2p.send_message(msg)
             if type(msg) == msg_getheaders:

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -34,7 +34,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
         Helper to connect and wait for version handshake."""
         for _ in range(num_connections):
-            self.nodes[0].add_p2p_connection(P2PDataStore())
+            self.nodes[0].add_p2p_connection(P2PDataStore(self.nodes[0].time_to_connect))
 
     def reconnect_p2p(self, **kwargs):
         """Tear down and bootstrap the P2P connection to the node.

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -21,8 +21,8 @@ from test_framework.util import wait_until
 banscore = 10
 
 class CLazyNode(P2PInterface):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
         self.unexpected_msg = False
         self.ever_connected = False
 
@@ -70,14 +70,14 @@ class CNodeNoVersionBan(CLazyNode):
 # Node that never sends a version. This one just sits idle and hopes to receive
 # any message (it shouldn't!)
 class CNodeNoVersionIdle(CLazyNode):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
 
 # Node that sends a version but not a verack.
 class CNodeNoVerackIdle(CLazyNode):
-    def __init__(self):
+    def __init__(self, time_to_connect):
         self.version_received = False
-        super().__init__()
+        super().__init__(time_to_connect)
 
     def on_reject(self, message): pass
     def on_verack(self, message): pass
@@ -95,9 +95,9 @@ class P2PLeakTest(BitcoinTestFramework):
         self.extra_args = [['-banscore=' + str(banscore)]]
 
     def run_test(self):
-        no_version_bannode = self.nodes[0].add_p2p_connection(CNodeNoVersionBan(), send_version=False, wait_for_verack=False)
-        no_version_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVersionIdle(), send_version=False, wait_for_verack=False)
-        no_verack_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVerackIdle())
+        no_version_bannode = self.nodes[0].add_p2p_connection(CNodeNoVersionBan(self.nodes[0].time_to_connect), send_version=False, wait_for_verack=False)
+        no_version_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVersionIdle(self.nodes[0].time_to_connect), send_version=False, wait_for_verack=False)
+        no_verack_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVerackIdle(self.nodes[0].time_to_connect))
 
         wait_until(lambda: no_version_bannode.ever_connected, timeout=10, lock=mininode_lock)
         wait_until(lambda: no_version_idlenode.ever_connected, timeout=10, lock=mininode_lock)

--- a/test/functional/p2p_mempool.py
+++ b/test/functional/p2p_mempool.py
@@ -21,7 +21,7 @@ class P2PMempoolTests(BitcoinTestFramework):
 
     def run_test(self):
         # Add a p2p connection
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
 
         #request mempool
         self.nodes[0].p2p.send_message(msg_mempool())

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -48,7 +48,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.disconnect_all()
 
     def run_test(self):
-        node = self.nodes[0].add_p2p_connection(P2PIgnoreInv())
+        node = self.nodes[0].add_p2p_connection(P2PIgnoreInv(self.nodes[0].time_to_connect))
 
         expected_services = NODE_BLOOM | NODE_NETWORK_LIMITED
 
@@ -73,7 +73,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
 
         self.log.info("Check local address relay, do a fresh connection.")
         self.nodes[0].disconnect_p2ps()
-        node1 = self.nodes[0].add_p2p_connection(P2PIgnoreInv())
+        node1 = self.nodes[0].add_p2p_connection(P2PIgnoreInv(self.nodes[0].time_to_connect))
         node1.send_message(msg_verack())
 
         node1.wait_for_addr()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -237,9 +237,9 @@ class SegWitTest(BitcoinTestFramework):
         self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect), services=NODE_NETWORK)
 
         # self.old_node sets only NODE_NETWORK
-        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
+        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect), services=NODE_NETWORK)
         # self.std_node is for testing node1 (acceptnonstdtxn=true)
-        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
+        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(self.nodes[1].time_to_connect), services=NODE_NETWORK)
 
         assert self.test_node.nServices & NODE_WITNESS == 0
         assert self.old_node.nServices & NODE_WITNESS == 0

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -155,8 +155,8 @@ def test_witness_block(rpc, p2p, block, with_witness, accepted, reason=None):
             assert_equal(p2p.last_message["reject"].reason, reason)
 
 class TestP2PConn(P2PInterface):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
         self.getdataset = set()
 
     def on_getdata(self, message):

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -232,9 +232,9 @@ class SegWitTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections
         # self.test_node sets NODE_WITNESS|NODE_NETWORK
-        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS, wait_for_verack = False)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect), services=NODE_NETWORK | NODE_WITNESS, wait_for_verack = False)
         self.test_node.wait_for_disconnect(timeout=10)
-        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect), services=NODE_NETWORK)
 
         # self.old_node sets only NODE_NETWORK
         self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -111,8 +111,8 @@ from test_framework.util import (
 DIRECT_FETCH_RESPONSE_TIME = 0.05
 
 class BaseNode(P2PInterface):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
 
         self.block_announced = False
         self.last_blockhash_announced = None
@@ -240,12 +240,12 @@ class SendHeadersTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections
-        inv_node = self.nodes[0].add_p2p_connection(BaseNode())
+        inv_node = self.nodes[0].add_p2p_connection(BaseNode(self.nodes[0].time_to_connect))
         # Make sure NODE_NETWORK is not set for test_node, so no block download
         # will occur outside of direct fetching
-        test_node = self.nodes[0].add_p2p_connection(BaseNode(), services=NODE_WITNESS, wait_for_verack=False)
+        test_node = self.nodes[0].add_p2p_connection(BaseNode(self.nodes[0].time_to_connect), services=NODE_WITNESS, wait_for_verack=False)
         test_node.wait_for_disconnect()
-        test_node = self.nodes[0].add_p2p_connection(BaseNode())
+        test_node = self.nodes[0].add_p2p_connection(BaseNode(self.nodes[0].time_to_connect))
 
         # Ensure verack's have been processed by our peer
         inv_node.sync_with_ping()

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -39,9 +39,9 @@ class TimeoutsTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections
-        no_verack_node = self.nodes[0].add_p2p_connection(TestP2PConn())
-        no_version_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False, wait_for_verack=False)
-        no_send_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False, wait_for_verack=False)
+        no_verack_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect))
+        no_version_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect), send_version=False, wait_for_verack=False)
+        no_send_node = self.nodes[0].add_p2p_connection(TestP2PConn(self.nodes[0].time_to_connect), send_version=False, wait_for_verack=False)
 
         sleep(1)
 

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -77,10 +77,10 @@ class AcceptBlockTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections
         # test_node connects to node0 (not whitelisted)
-        test_node = self.nodes[0].add_p2p_connection(P2PInterface())
+        test_node = self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
         self.nodes[0].setmocktime(self.mocktime)
         # min_work_node connects to node1 (whitelisted)
-        min_work_node = self.nodes[1].add_p2p_connection(P2PInterface())
+        min_work_node = self.nodes[1].add_p2p_connection(P2PInterface(self.nodes[1].time_to_connect))
         self.nodes[1].setmocktime(self.mocktime)
 
         # 1. Have nodes mine a block (leave IBD)
@@ -203,7 +203,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         self.nodes[0].disconnect_p2ps()
         self.nodes[1].disconnect_p2ps()
 
-        test_node = self.nodes[0].add_p2p_connection(P2PInterface())
+        test_node = self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
 
         test_node.send_message(msg_block(block_h1f))
 
@@ -288,7 +288,7 @@ class AcceptBlockTest(BitcoinTestFramework):
             test_node.wait_for_disconnect()
 
             self.nodes[0].disconnect_p2ps()
-            test_node = self.nodes[0].add_p2p_connection(P2PInterface())
+            test_node = self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
 
         # We should have failed reorg and switched back to 290 (but have block 291)
         assert_equal(self.nodes[0].getblockcount(), 290)

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -284,7 +284,7 @@ class AcceptBlockTest(BitcoinTestFramework):
             # Only wait a short while so the test doesn't take forever if we do get
             # disconnected
             test_node.sync_with_ping(timeout=1)
-        except AssertionError:
+        except TimeoutError:
             test_node.wait_for_disconnect()
 
             self.nodes[0].disconnect_p2ps()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -236,7 +236,7 @@ class BlockchainTest(BitcoinTestFramework):
     def _test_waitforblockheight(self):
         self.log.info("Test waitforblockheight")
         node = self.nodes[0]
-        node.add_p2p_connection(P2PInterface())
+        node.add_p2p_connection(P2PInterface(node.time_to_connect))
 
         current_height = node.getblock(node.getbestblockhash())['height']
 

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -13,7 +13,7 @@ import ctypes
 import ctypes.util
 import hashlib
 
-ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library ('ssl'))
+ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library ('ssl') or 'libeay32')
 
 ssl.BN_new.restype = ctypes.c_void_p
 ssl.BN_new.argtypes = []

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -13,7 +13,7 @@ import ctypes
 import ctypes.util
 import hashlib
 
-ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library ('ssl') or 'libeay32')
+ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library ('ssl'))
 
 ssl.BN_new.restype = ctypes.c_void_p
 ssl.BN_new.argtypes = []

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -236,6 +236,8 @@ class P2PInterface(P2PConnection):
         # The network services received from the peer
         self.nServices = 0
 
+        # timeout needs to be long enough to wait for the network and wallet to sync.
+        # 5 is just a random number, there is no reason behind it.
         self.timeout = time_to_connect * 5
 
     def peer_connect(self, *args, services=NODE_NETWORK, send_version=True, **kwargs):

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -222,7 +222,7 @@ class P2PInterface(P2PConnection):
 
     Individual testcases should subclass this and override the on_* methods
     if they want to alter message handling behaviour."""
-    def __init__(self):
+    def __init__(self, time_to_connect):
         super().__init__()
 
         # Track number of messages of each type received and the most recent
@@ -235,6 +235,8 @@ class P2PInterface(P2PConnection):
 
         # The network services received from the peer
         self.nServices = 0
+
+        self.timeout = time_to_connect * 5
 
     def peer_connect(self, *args, services=NODE_NETWORK, send_version=True, **kwargs):
         create_conn = super().peer_connect(*args, **kwargs)
@@ -417,8 +419,8 @@ class P2PDataStore(P2PInterface):
 
     Keeps a block and transaction store and responds correctly to getdata and getheaders requests."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
         self.reject_code_received = None
         self.reject_reason_received = None
         # store of blocks. key is block hash, value is a CBlock object

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -511,9 +511,9 @@ class P2PDataStore(P2PInterface):
             assert rpc.getbestblockhash() != blocks[-1].hash
 
         if reject_code is not None:
-            wait_until(lambda: self.reject_code_received != None or self.reject_code_received == reject_code, lock=mininode_lock, timeout=timeout)
+            wait_until(lambda: self.reject_code_received != None or self.reject_code_received == reject_code or not self.is_connected, lock=mininode_lock, timeout=timeout)
         if reject_reason is not None:
-            wait_until(lambda: self.reject_reason_received!= None or self.reject_reason_received == reject_reason, lock=mininode_lock, timeout=timeout)
+            wait_until(lambda: self.reject_reason_received!= None or self.reject_reason_received == reject_reason or not self.is_connected, lock=mininode_lock, timeout=timeout)
 
     def send_txs_and_test(self, txs, rpc, success=True, expect_disconnect=False, reject_code=None, reject_reason=None):
         """Send txs to test node and test whether they're accepted to the mempool.
@@ -550,6 +550,6 @@ class P2PDataStore(P2PInterface):
                 assert tx.hashMalFix not in raw_mempool, "{} tx found in mempool".format(tx.hashMalFix)
 
         if reject_code is not None:
-            wait_until(lambda: self.reject_code_received == reject_code, lock=mininode_lock)
+            wait_until(lambda: self.reject_code_received == reject_code or not self.is_connected, lock=mininode_lock)
         if reject_reason is not None:
-            wait_until(lambda: self.reject_reason_received == reject_reason, lock=mininode_lock)
+            wait_until(lambda: self.reject_reason_received == reject_reason or not self.is_connected, lock=mininode_lock)

--- a/test/functional/test_framework/schnorr.py
+++ b/test/functional/test_framework/schnorr.py
@@ -14,7 +14,7 @@ import hashlib
 import hmac
 import threading
 
-ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('ssl'))
+ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('ssl') or 'libeay32')
 
 ssl.BN_new.restype = ctypes.c_void_p
 ssl.BN_new.argtypes = []

--- a/test/functional/test_framework/schnorr.py
+++ b/test/functional/test_framework/schnorr.py
@@ -14,7 +14,7 @@ import hashlib
 import hmac
 import threading
 
-ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('ssl') or 'libeay32')
+ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('ssl'))
 
 ssl.BN_new.restype = ctypes.c_void_p
 ssl.BN_new.argtypes = []

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -231,7 +231,14 @@ class TestNode():
         return True
 
     def wait_until_stopped(self, timeout=BITCOIND_PROC_WAIT_TIMEOUT):
-        wait_until(self.is_node_stopped, timeout=timeout)
+        i = 0
+        while i < 2:
+            try:
+                i = i + 1
+                wait_until(self.is_node_stopped, timeout=timeout)
+            except TimeoutError as e:
+                pass
+
 
     def assert_start_raises_init_error(self, extra_args=None, expected_msg=None, match=ErrorMatch.FULL_TEXT, *args, **kwargs):
         """Attempt to start the node and expect it to raise an error.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -170,7 +170,7 @@ class TestNode():
                 self.url = self.rpc.url
                 self.log.debug("RPC successfully started")
                 self.time_to_connect = datetime.now() - start_time
-                return self.time_to_connect
+                return
             except IOError as e:
                 if e.errno != errno.ECONNREFUSED:  # Port not yet open?
                     raise  # unknown IO error
@@ -255,7 +255,7 @@ class TestNode():
              tempfile.NamedTemporaryFile(dir=self.stdout_dir, delete=False) as log_stdout:
             try:
                 self.start(extra_args, stdout=log_stdout, stderr=log_stderr, *args, **kwargs)
-                timeout = self.wait_for_rpc_connection()
+                self.wait_for_rpc_connection()
                 self.stop_node()
                 self.wait_until_stopped()
             except FailedToStartError as e:

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -244,7 +244,7 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=N
     if attempt >= attempts:
         raise AssertionError("Predicate {} not true after {} attempts".format(predicate_source, attempts))
     elif time.time() >= time_end:
-        raise AssertionError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
+        raise TimeoutError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
     raise RuntimeError('Unreachable')
 
 # RPC/P2P connection constants and functions
@@ -409,7 +409,7 @@ def sync_blocks(rpc_connections, *, wait=1, timeout=60):
         if best_hash.count(best_hash[0]) == len(rpc_connections):
             return
         time.sleep(wait)
-    raise AssertionError("Block sync timed out:{}".format("".join("\n  {!r}".format(b) for b in best_hash)))
+    raise TimeoutError("Block sync timed out:{}".format("".join("\n  {!r}".format(b) for b in best_hash)))
 
 def sync_mempools(rpc_connections, *, wait=1, timeout=60, flush_scheduler=True):
     """

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -525,9 +525,9 @@ class TestHandler:
             self.jobs.append((test,
                               time.time(),
                               subprocess.Popen([sys.executable, self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + portseed_arg + tmpdir_arg,
-                                               universal_newlines=True,
-                                               stdout=log_stdout,
-                                               stderr=log_stderr),
+                              universal_newlines=True,
+                              stdout=log_stdout,
+                              stderr=log_stderr),
                               testdir,
                               log_stdout,
                               log_stderr))

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -30,17 +30,20 @@ import re
 import logging
 
 # Formatting. Default colors to empty strings.
-BOLD, BLUE, RED, GREY = ("", ""), ("", ""), ("", ""), ("", "")
+BOLD, BLUE, RED, GREY, YELLOW = ("", ""), ("", ""), ("", ""), ("", ""), ("", "")
 try:
     # Make sure python thinks it can write unicode to its stdout
     "\u2713".encode("utf_8").decode(sys.stdout.encoding)
+    "\u2727".encode("utf_8").decode(sys.stdout.encoding)
     TICK = "✓ "
     CROSS = "✖ "
     CIRCLE = "○ "
+    BOX = "✧ "
 except UnicodeDecodeError:
     TICK = "P "
     CROSS = "x "
     CIRCLE = "o "
+    BOX = "~ "
 
 if os.name == 'posix':
     # primitive formatting on supported
@@ -49,9 +52,11 @@ if os.name == 'posix':
     BLUE = ('\033[0m', '\033[0;34m')
     RED = ('\033[0m', '\033[0;31m')
     GREY = ('\033[0m', '\033[1;30m')
+    YELLOW = ('\033[0m', '\033[1;33m')
 
 TEST_EXIT_PASSED = 0
 TEST_EXIT_SKIPPED = 77
+TEST_EXIT_TIMEOUT = 124
 
 # 20 minutes represented in seconds
 TRAVIS_TIMEOUT_DURATION = 20 * 60
@@ -338,7 +343,7 @@ def main():
     if not args.keepcache:
         shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
 
-    run_tests(
+    exit_code, retry_list = run_tests(
         test_list,
         config["environment"]["SRCDIR"],
         config["environment"]["BUILDDIR"],
@@ -350,7 +355,28 @@ def main():
         failfast=args.failfast,
     )
 
-def run_tests(test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False):
+    if len(retry_list) == 0:
+        sys.exit(exit_code)
+
+    print("Retrying TIMEOUT tests.")
+
+    exit_code, retry = run_tests(
+        retry_list,
+        config["environment"]["SRCDIR"],
+        config["environment"]["BUILDDIR"],
+        tmpdir,
+        jobs=args.jobs,
+        enable_coverage=args.coverage,
+        args=passon_args,
+        combined_logs_len=args.combinedlogslen,
+        failfast=args.failfast,
+        retry = True
+    )
+
+    sys.exit(exit_code)
+
+
+def run_tests(test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, retry = False):
     args = args or []
 
     # Warn if tapyrusd is already running (unix only)
@@ -360,14 +386,9 @@ def run_tests(test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=Fal
     except (OSError, subprocess.SubprocessError):
         pass
 
-    # Warn if there is a cache directory
-    cache_dir = "%s/test/cache" % build_dir
-    if os.path.isdir(cache_dir):
-        print("%sWARNING!%s There is a cache directory here: %s. If tests fail unexpectedly, try deleting the cache directory." % (BOLD[1], BOLD[0], cache_dir))
-
     tests_dir = src_dir + '/test/functional/'
 
-    flags = ['--cachedir={}'.format(cache_dir)] + args
+    flags = args
 
     if enable_coverage:
         coverage = RPCCoverage()
@@ -376,29 +397,44 @@ def run_tests(test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=Fal
     else:
         coverage = None
 
-    if len(test_list) > 1 and jobs > 1:
-        # Populate cache
-        try:
-            subprocess.check_output([sys.executable, tests_dir + 'create_cache.py'] + flags + ["--tmpdir=%s/cache" % tmpdir])
-        except subprocess.CalledProcessError as e:
-            sys.stdout.buffer.write(e.output)
-            raise
+    # create cache only on first attempt
+    if not retry :
+
+        # Warn if there is a cache directory
+        cache_dir = "%s/test/cache" % build_dir
+        if os.path.isdir(cache_dir):
+            print("%sWARNING!%s There is a cache directory here: %s. If tests fail unexpectedly, try deleting the cache directory." % (BOLD[1], BOLD[0], cache_dir))
+
+        flags = ['--cachedir={}'.format(cache_dir)] + args
+
+        if len(test_list) > 1 and jobs > 1:
+            # Populate cache
+            try:
+                subprocess.check_output([sys.executable, tests_dir + 'create_cache.py'] + flags + ["--tmpdir=%s/cache" % tmpdir])
+            except subprocess.CalledProcessError as e:
+                sys.stdout.buffer.write(e.output)
+                raise
 
     #Run Tests
     job_queue = TestHandler(jobs, tests_dir, tmpdir, test_list, flags)
     start_time = time.time()
     test_results = []
+    retry_list = []
 
     max_len_name = len(max(test_list, key=len))
 
     for _ in range(len(test_list)):
-        test_result, testdir, stdout, stderr = job_queue.get_next()
+        test_result, testdir, stdout, stderr, retry = job_queue.get_next()
         test_results.append(test_result)
+        if retry is not None:
+            retry_list.append(retry)
 
         if test_result.status == "Passed":
             logging.debug("\n%s%s%s passed, Duration: %s s" % (BOLD[1], test_result.name, BOLD[0], test_result.time))
         elif test_result.status == "Skipped":
             logging.debug("\n%s%s%s skipped" % (BOLD[1], test_result.name, BOLD[0]))
+        elif test_result.status == "Timeout":
+            logging.debug("\n%s%s%s timeout" % (BOLD[1], test_result.name, BOLD[0]))
         else:
             print("\n%s%s%s failed, Duration: %s s\n" % (BOLD[1], test_result.name, BOLD[0], test_result.time))
             print(BOLD[1] + 'stdout:\n' + BOLD[0] + stdout + '\n')
@@ -434,7 +470,7 @@ def run_tests(test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=Fal
     # processes which need to be killed.
     job_queue.kill_and_join()
 
-    sys.exit(not all_passed)
+    return (not all_passed), retry_list
 
 def print_results(test_results, max_len_name, runtime):
     results = "\n" + BOLD[1] + "%s | %s | %s\n\n" % ("TEST".ljust(max_len_name), "STATUS   ", "DURATION") + BOLD[0]
@@ -472,6 +508,7 @@ class TestHandler:
         self.flags = flags
         self.num_running = 0
         self.jobs = []
+        self.retry = None
 
     def get_next(self):
         while self.num_running < self.num_jobs and self.test_list:
@@ -512,12 +549,15 @@ class TestHandler:
                         status = "Passed"
                     elif proc.returncode == TEST_EXIT_SKIPPED:
                         status = "Skipped"
+                    elif proc.returncode == TEST_EXIT_TIMEOUT:
+                        self.retry = name
+                        status = "Timeout"
                     else:
                         status = "Failed"
                     self.num_running -= 1
                     self.jobs.remove(job)
 
-                    return TestResult(name, status, int(time.time() - start_time)), testdir, stdout, stderr
+                    return TestResult(name, status, int(time.time() - start_time)), testdir, stdout, stderr, self.retry
             print('.', end='', flush=True)
 
     def kill_and_join(self):
@@ -545,6 +585,8 @@ class TestResult():
             return 2, self.name.lower()
         elif self.status == "Skipped":
             return 1, self.name.lower()
+        elif self.status == "Timeout":
+            return 3, self.name.lower()
 
     def __repr__(self):
         if self.status == "Passed":
@@ -556,12 +598,15 @@ class TestResult():
         elif self.status == "Skipped":
             color = GREY
             glyph = CIRCLE
+        elif self.status == "Timeout":
+            color = YELLOW
+            glyph = BOX
 
         return color[1] + "%s | %s%s | %s s\n" % (self.name.ljust(self.padding), glyph, self.status.ljust(7), self.time) + color[0]
 
     @property
     def was_successful(self):
-        return self.status != "Failed"
+        return self.status != "Failed" and self.status != "Timeout"
 
 
 def check_script_prefixes():

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -246,10 +246,10 @@ class WalletTest(BitcoinTestFramework):
         sync_mempools(self.nodes[0:2])
 
         self.stop_nodes()
-        self.start_node(3, extra_args = ['-acceptnonstdtxn=1'])
-        self.start_node(2, extra_args = ['-acceptnonstdtxn=1'])
-        self.start_node(1, extra_args = ['-acceptnonstdtxn=1'])
-        self.start_node(0, extra_args = ['-acceptnonstdtxn=1'])
+        self.start_node(3)
+        self.start_node(2)
+        self.start_node(1)
+        self.start_node(0)
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
         connect_nodes_bi(self.nodes, 0, 2)
@@ -279,19 +279,9 @@ class WalletTest(BitcoinTestFramework):
         signed_raw_tx = self.nodes[1].signrawtransactionwithwallet(raw_tx, [], "ALL", self.options.scheme)
         decoded_raw_tx = self.nodes[1].decoderawtransaction(signed_raw_tx['hex'])
         zero_value_txid = decoded_raw_tx['txid']
-        self.nodes[1].sendrawtransaction(signed_raw_tx['hex'], True)
+        assert_raises_rpc_error(-26, "dust", self.nodes[1].sendrawtransaction, signed_raw_tx['hex'], True)
 
         self.sync_all()
-        self.nodes[1].generate(1, self.signblockprivkey_wif)  # mine a block
-        self.sync_all()
-
-        unspent_txs = self.nodes[0].listunspent()  # zero value tx must be in listunspents output
-        found = False
-        for uTx in unspent_txs:
-            if uTx['txid'] == zero_value_txid:
-                found = True
-                assert_equal(uTx['amount'], Decimal('0'))
-        assert(found)
 
         # do some -walletbroadcast tests
         self.stop_nodes()


### PR DESCRIPTION
This PR makes changes in the functional test framework to add the following features:

1. Retry tests which timeout
      After the initial run with all eligible tests the second run lists only the tests which fail on a timeout. The error code used to identify this has been changed and new status added to identify this.

2. Use a dynamic timeout value depending on the time taken to connect to a node
      When the test framework starts a node, it remembers the time taken to establish the RPC connection to it. Every RPC request to the node uses the time_to_connect*5 as the timeout. As this is very dynamic, according to the test environment we expect that the tests would not fail because of short timeout values.