### PR TITLE
Fix issues in aggpubkey during node restart and new node addition in v0.5

### DIFF
--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -157,9 +157,10 @@ CPubKey CFederationParams::ReadAggregatePubkey(const std::vector<unsigned char>&
         if (p.aggpubkey.size() != CPubKey::COMPRESSED_PUBLIC_KEY_SIZE) {
             throw std::runtime_error(strprintf("Aggregate Public Key for Signed Block is invalid: %s", HexStr(pubkey)));
         }
+        if(height && GetAggPubkeyFromHeight(height) == p.aggpubkey)
+            return p.aggpubkey;
 
         aggregatePubkeyHeight.push_back(p);
-
         return p.aggpubkey;
 
     } else if(pubkey[0] == 0x04 || pubkey[0] == 0x06 || pubkey[0] == 0x07) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1514,6 +1514,19 @@ bool AppInitMain()
                         break;
                     }
                 }
+                //********************************************************** Step 11a: Load Xfield data from db
+                std::vector<XFieldEntry> xFieldList;
+                pblocktree->ReadXFieldAggpubkeys(xFieldList);
+                for(auto &XFieldData:xFieldList)
+                {
+                    //verify the aggpubkey from the xfield in the block db and then add to federation params
+                    CBlockIndex* pindex = LookupBlockIndex(XFieldData.blockHash);
+                    if (!pindex)//block might not be in the best chain
+                        continue;
+
+                    if((TAPYRUS_XFIELDTYPES)pindex->xfieldType == TAPYRUS_XFIELDTYPES::AGGPUBKEY && pindex->xfield == XFieldData.aggpubkey)
+                        FederationParams().ReadAggregatePubkey(XFieldData.aggpubkey, XFieldData.height);
+                }
 
                 if (!is_coinsview_empty) {
                     uiInterface.InitMessage(_("Verifying blocks..."));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -29,6 +29,8 @@ static const char DB_FLAG = 'F';
 static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
 
+static const char DB_XFIELD_AGGPUBKEY = '1';
+
 namespace {
 
 struct CoinEntry {
@@ -166,6 +168,17 @@ void CBlockTreeDB::ReadReindexing(bool &fReindexing) {
 
 bool CBlockTreeDB::ReadLastBlockFile(int &nFile) {
     return Read(DB_LAST_BLOCK, nFile);
+}
+
+bool CBlockTreeDB::ReadXFieldAggpubkeys(std::vector<XFieldEntry> & xFieldList) {
+    return Read(DB_XFIELD_AGGPUBKEY, xFieldList);
+}
+
+bool CBlockTreeDB::AddXFieldAggpubkey(XFieldEntry & xFieldEntry) {
+    std::vector<XFieldEntry> xFieldList;
+    Read(DB_XFIELD_AGGPUBKEY, xFieldList);
+    xFieldList.push_back(xFieldEntry);
+    return Write(DB_XFIELD_AGGPUBKEY, xFieldList);
 }
 
 CCoinsViewCursor *CCoinsViewDB::Cursor() const

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -22,6 +22,34 @@ class CBlockIndex;
 class CCoinsViewDBCursor;
 class uint256;
 
+/*
+struct to store and retrieve xfield aggpubkey change information into level db blocks db
+*/ 
+
+struct XFieldEntry {
+    std::vector<unsigned char> aggpubkey;
+    int32_t height;
+    uint256 blockHash;
+
+    explicit XFieldEntry(const std::vector<unsigned char>& paggpubkey, const int32_t inheight, const uint256& inblockHash) : aggpubkey(paggpubkey), height(inheight), blockHash(inblockHash) {}
+    explicit XFieldEntry() : aggpubkey(), height(0), blockHash() {}
+
+    template<typename Stream>
+    void Serialize(Stream &s) const {
+        s << aggpubkey;
+        s << height;
+        s << blockHash;
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s) {
+        s >> aggpubkey;
+        s >> height;
+        s >> blockHash;
+    }
+};
+
+
 //! No need to periodic flush if at least this much space still available.
 static constexpr int MAX_BLOCK_COINSDB_USAGE = 10;
 //! -dbcache default (MiB)
@@ -97,6 +125,8 @@ public:
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
+    bool ReadXFieldAggpubkeys(std::vector<XFieldEntry> & xFieldList);
+    bool AddXFieldAggpubkey(XFieldEntry & xFieldEntry);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2366,8 +2366,12 @@ bool CChainState::ConnectTip(CValidationState& state, CBlockIndex* pindexNew, co
 
         // if the block was added successfully and it is a federation block,
         // make sure that the aggregatepubkey from this block is added to CFederationParams
-        if(blockConnecting.xfieldType == 1 && blockConnecting.xfield.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE && (CPubKey(blockConnecting.xfield.begin(), blockConnecting.xfield.end()) != FederationParams().GetLatestAggregatePubkey()))
+        if((TAPYRUS_XFIELDTYPES)blockConnecting.xfieldType == TAPYRUS_XFIELDTYPES::AGGPUBKEY && blockConnecting.xfield.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE && (CPubKey(blockConnecting.xfield.begin(), blockConnecting.xfield.end()) != FederationParams().GetLatestAggregatePubkey()))
+        {
             FederationParams().ReadAggregatePubkey(blockConnecting.xfield, blockConnecting.GetHeight() + 1);
+            XFieldEntry xfieldEntry(blockConnecting.xfield, blockConnecting.GetHeight() + 1, blockConnecting.GetHash());
+            pblocktree->AddXFieldAggpubkey(xfieldEntry);
+        }
 
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;
         LogPrint(BCLog::BENCH, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime3 - nTime2) * MILLI, nTimeConnectTotal * MICRO, nTimeConnectTotal * MILLI / nBlocksTotal);

--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -105,17 +105,24 @@ class FederationManagementTest(BitcoinTestFramework):
         self.schnorr_key = Schnorr()
         self.schnorr_key.set_secretbytes(bytes.fromhex("12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747"))
 
-        self.num_nodes = 2
+        #test has 4 nodes.
+        # node0 is the test node where all blocks are sent.
+        # node1 is passive, always in synch with node0
+        # node2 is started and stopped at different points to test network synch
+        # node3 is a new node added to the network at the end of the test
+        self.num_nodes = 4
         self.sig_scheme = 0
         self.setup_clean_chain = True
         self.genesisBlock = createTestGenesisBlock(self.aggpubkeys[0], self.aggprivkey[0], int(time.time() - 100))
 
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node
+        syn_node = self.nodes[1]  # convenience reference to the node
         self.address = node.getnewaddress()
         node.add_p2p_connection(P2PDataStore())
         node.p2p.wait_for_getheaders(timeout=5)
-        self.stop_node(1)
+        self.stop_node(2)
+        self.stop_node(3)
 
         self.log.info("Test starting...")
 
@@ -164,6 +171,8 @@ class FederationManagementTest(BitcoinTestFramework):
         node.submitblock(bytes_to_hex_str(blocknew.serialize()))
         self.tip = self.blocks[-1]
         assert_equal(self.tip, node.getbestblockhash())
+        self.sync_all([self.nodes[0:2]])
+        assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
         # Create a new blocks B13 - B22
@@ -189,6 +198,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.tip = blocknew.hash
         node.submitblock(bytes_to_hex_str(blocknew.serialize()))
         assert_equal(self.tip, node.getbestblockhash())
+        self.sync_all([self.nodes[0:2]])
+        assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
         #call invalidate block rpc on B23 -- success - B23 is removed from the blockchain. tip is B22
@@ -250,6 +261,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.tip = blocknew.hash
         node.submitblock(bytes_to_hex_str(blocknew.serialize()))
         assert_equal(self.tip, node.getbestblockhash())
+        self.sync_all([self.nodes[0:2]])
+        assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
         #B25 -- Create block with 1 valid transaction - sign with aggpubkey3 -- success
@@ -281,9 +294,13 @@ class FederationManagementTest(BitcoinTestFramework):
         ]
         blockchaininfo = node.getblockchaininfo()
         assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
+        blockchaininfo = syn_node.getblockchaininfo()
+        assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
 
+        #restarting node0 to test presistance of aggpubkey change
         self.stop_node(0)
         self.start_node(0)
+        connect_nodes(self.nodes[0], 1)
 
         self.log.info("Simulate Blockchain Reorg  - After the last federation block")
         #B27 -- Create block with previous block hash = B26 - sign with aggpubkey3 -- success - block is accepted but there is no re-org
@@ -333,9 +350,13 @@ class FederationManagementTest(BitcoinTestFramework):
         assert_equal(self.tip, node.getbestblockhash())
         assert(node.getblock(self.tip))
 
+        blockchaininfo = node.getblockchaininfo()
+        assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
+        blockchaininfo = syn_node.getblockchaininfo()
         assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
         self.stop_node(0)
         self.start_node(0)
+        connect_nodes(self.nodes[0], 1)
 
         self.log.info("Simulate Blockchain Reorg  - Before the last federation block")
         #B24 -- Create block with previous block hash = B23 - sign with aggpubkey2 -- failure - block is in invalid chain
@@ -363,6 +384,7 @@ class FederationManagementTest(BitcoinTestFramework):
         assert_raises_rpc_error(-5, "Block not found", node.getblock, blocknew.hash)
         self.stop_node(0)
         self.start_node(0)
+        connect_nodes(self.nodes[0], 1)
 
         self.log.info("Third Federation Block - active chain")
         #B32 -- Create block with aggpubkey4 - sign with aggpubkey3 -- success - aggpubkey4 is added to the list
@@ -373,6 +395,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.forkblocks.append(blocknew.hash)
         self.tip = blocknew.hash
         assert_equal(self.tip, node.getbestblockhash())
+        self.sync_all([self.nodes[0:2]])
+        assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
         #B -- Create block - sign with aggpubkey2 -- failure - proof verification failed
@@ -393,6 +417,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.forkblocks.append(blocknew.hash)
         self.tip = blocknew.hash
         assert_equal(self.tip, node.getbestblockhash())
+        self.sync_all([self.nodes[0:2]])
+        assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
         #B34 - B35 -- Generate 2 blocks - no aggpubkey -- chain becomes longer
@@ -410,6 +436,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.tip = blocknew.hash
         self.forkblocks.append(blocknew.hash)
         assert_equal(self.tip, node.getbestblockhash())
+        self.sync_all([self.nodes[0:2]])
+        assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
         #call invalidate block rpc on B36 -- failure - B36 is a federation block
@@ -426,6 +454,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.tip = blocknew.hash
         self.forkblocks.append(blocknew.hash)
         assert_equal(self.tip, node.getbestblockhash())
+        self.sync_all([self.nodes[0:2]])
+        assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
         self.log.info("Verifying getblockchaininfo")
@@ -439,11 +469,14 @@ class FederationManagementTest(BitcoinTestFramework):
         ]
         blockchaininfo = node.getblockchaininfo()
         assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
+        blockchaininfo = syn_node.getblockchaininfo()
+        assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
 
         self.stop_node(0)
         self.log.info("Restarting node with '-reindex'")
         self.start_node(0, extra_args=["-reindex"])
-        self.connectNodeAndCheck(1, expectedAggPubKeys)
+        connect_nodes(self.nodes[0], 1)
+        self.connectNodeAndCheck(2, expectedAggPubKeys)
 
         #B38 - B40 -- Generate 2 blocks - no aggpubkey -- chain becomes longer
         self.forkblocks += node.generate(3, self.aggprivkey_wif[4])
@@ -482,8 +515,9 @@ class FederationManagementTest(BitcoinTestFramework):
         ]
         blockchaininfo = node.getblockchaininfo()
         assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
-        self.connectNodeAndCheck(1, expectedAggPubKeys)
+        self.connectNodeAndCheck(2, expectedAggPubKeys)
         self.stop_node(0)
+        self.stop_node(1)
 
         self.log.info("Restarting node with '-loadblock'")
         shutil.copyfile(os.path.join(self.nodes[0].datadir, NetworkDirName(), 'blocks', 'blk00000.dat'), os.path.join(self.nodes[0].datadir, 'blk00000.dat'))
@@ -497,6 +531,12 @@ class FederationManagementTest(BitcoinTestFramework):
         self.start_node(1, ["-loadblock=%s" % os.path.join(self.nodes[1].datadir, 'blk00000.dat')])
         blockchaininfo = self.nodes[1].getblockchaininfo()
         assert_equal(blockchaininfo["aggregatePubkeys"], expectedAggPubKeys)
+
+        #finally add the new node to the newtork and check if it can synch
+        self.start_node(2)
+        self.start_node(3)
+        connect_nodes(self.nodes[1], 3)
+        self.sync_all([self.nodes[0:4]])
 
     def connectNodeAndCheck(self, n, expectedAggPubKeys):
         self.start_node(n)


### PR DESCRIPTION
 This PR fixes all issues reported in #237. These are the major changes made in v0.5 code:

 #### 1. Node restart Fix
 
Aggpubkey change was only in federation params and not persisted. So it was lost on restart. Now it is made persistent using blocks DB in level DB. **Key "1"** represents aggpubkey change. The value is a list of aggpubkey, height and block hash. There is no entry in the DB for genesis block. Only when the first federation block is accepted, it is changed. 
We do not allow reorg to remove a federation block in v0.5. This behaviour is not changed. So the aggpubkey list in levelDB is never removed. New entries maybe added to the list but never removed from the list.

#### 2. New node synch

Headers are validated by **`CheckBlockHeader`** during header verification(_HEADERS_ msg) and block verification(_BLOCK_ msg). The aggpubkey list was always fetched from federation params in both cases. Now this behaviour is changed to correctly process headers with aggpubkey changes. After a header is successfully verified in **`AcceptBlockHeader`**, if it contains a new xfield, it is added to a temp list created in **`ProcessNewBlockHeaders`**. This list is valid only until the headers message is processed. Later, if the block is accepted, the list is added to federation params and level DB following the old route.

### 3. Test

Federation management test case is enhanced to have 4 nodes. One node receives the blocks using submit block RPC. Node1 tests the p2p network synch, Node2 tests headers message at different important points in the test. Node3 simulates a new node in the network.