### PR TITLE
Command line option "-reloadxfield" to add xfield to level db from block files

### DIFF
--- a/doc/man/tapyrusd.1
+++ b/doc/man/tapyrusd.1
@@ -123,7 +123,7 @@ Rebuild chain state from the currently indexed blocks
 .HP
 \fB\-reloadxfield\fR
 .IP
-Rebuild aggpubkey change list in blocktree db from xfield in block headers from the blk*.dat files on disk
+Rebuild xfield change list in blocktree db from xfield in block headers from the blk*.dat files on disk
 .HPv
 \fB\-sysperms\fR
 .IP

--- a/doc/man/tapyrusd.1
+++ b/doc/man/tapyrusd.1
@@ -121,6 +121,10 @@ Rebuild chain state and block index from the blk*.dat files on disk
 .IP
 Rebuild chain state from the currently indexed blocks
 .HP
+\fB\-reloadxfield\fR
+.IP
+Rebuild aggpubkey change list in blocktree db from xfield in block headers from the blk*.dat files on disk
+.HPv
 \fB\-sysperms\fR
 .IP
 Create new files with system default permissions, instead of umask 077

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1531,11 +1531,10 @@ bool AppInitMain()
                     if (!pindex)//block might not be in the best chain
                         continue;
 
-                    bool xFieldValid(false), xFieldEqual(false);
-                    xFieldEqual = pindex->GetBlockHeader().CheckXField(CPubKey(XFieldData.aggpubkey.begin(), XFieldData.aggpubkey.end()), xFieldValid);
 
-                    if(xFieldValid && xFieldEqual)
-                        FederationParams().ReadAggregatePubkey(XFieldData.aggpubkey, XFieldData.height);
+                    if(pindex->GetBlockHeader().isXFieldValid()
+                        && pindex->GetBlockHeader().isXFieldEqual(CPubKey(XFieldData.aggpubkey.begin(), XFieldData.aggpubkey.end())))
+                            FederationParams().ReadAggregatePubkey(XFieldData.aggpubkey, XFieldData.height);
                 }
                 if (!is_coinsview_empty) {
                     uiInterface.InitMessage(_("Verifying blocks..."));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -385,7 +385,7 @@ void SetupServerArgs()
             "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)", MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-reindex", "Rebuild chain state and block index from the blk*.dat files on disk", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-reindex-chainstate", "Rebuild chain state from the currently indexed blocks", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-reloadxfield", "Rebuild aggpubkey change list in blocktree db from xfield in block headers from the blk*.dat files on disk", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-reloadxfield", "Rebuild xfield change list in blocktree db from xfield in block headers from the blk*.dat files on disk", false, OptionsCategory::OPTIONS);
 #ifndef WIN32
     gArgs.AddArg("-sysperms", "Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)", false, OptionsCategory::OPTIONS);
 #else
@@ -645,7 +645,7 @@ static void ThreadImport(std::vector<fs::path> vImportFiles, bool fReloadxfield)
     std::vector<XFieldAggpubkey> xFieldList;
 
     // -reindex
-    if (fReindex) {
+    if (fReindex || fReloadxfield) {
         int nFile = 0;
         while (true) {
             CDiskBlockPos pos(nFile, 0);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -79,15 +79,17 @@ public:
         return (int64_t)nTime;
     }
 
-    bool CheckXField(const CPubKey &value, bool& xFieldValid) const
+    inline bool isXFieldValid() const
     {
         if((TAPYRUS_XFIELDTYPES)this->xfieldType == TAPYRUS_XFIELDTYPES::AGGPUBKEY
             && this->xfield.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE)
-            {
-                xFieldValid = true;
-                return CPubKey(this->xfield.begin(), this->xfield.end()) == value;
-            }
+                return true;
         return false;
+    }
+
+    inline bool isXFieldEqual(const CPubKey &value) const
+    {
+        return CPubKey(this->xfield.begin(), this->xfield.end()) == value;
     }
 };
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -183,6 +183,9 @@ bool CBlockTreeDB::WriteXFieldAggpubkey(const XFieldAggpubkey& xFieldAggpubkey) 
 }
 
 bool CBlockTreeDB::ResetXFieldAggpubkeys(std::vector<XFieldAggpubkey>& xFieldList) {
+    std::sort(xFieldList.begin(), xFieldList.end(), [](XFieldAggpubkey const& i, XFieldAggpubkey const& j)-> bool{ return i.height < j.height; } );
+    auto lastUnique = std::unique(xFieldList.begin(), xFieldList.end(), [](XFieldAggpubkey const& i, XFieldAggpubkey const& j)-> bool{ return i.height == j.height; } );
+    xFieldList.erase(lastUnique, xFieldList.end());
     return Write(DB_XFIELD_AGGPUBKEY, xFieldList);
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -182,6 +182,10 @@ bool CBlockTreeDB::WriteXFieldAggpubkey(const XFieldAggpubkey& xFieldAggpubkey) 
     return Write(DB_XFIELD_AGGPUBKEY, xFieldList);
 }
 
+bool CBlockTreeDB::ResetXFieldAggpubkeys(std::vector<XFieldAggpubkey>& xFieldList) {
+    return Write(DB_XFIELD_AGGPUBKEY, xFieldList);
+}
+
 CCoinsViewCursor *CCoinsViewDB::Cursor() const
 {
     CCoinsViewDBCursor *i = new CCoinsViewDBCursor(const_cast<CDBWrapper&>(db).NewIterator(), GetBestBlock());

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -136,6 +136,7 @@ public:
     bool LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
     bool ReadXFieldAggpubkeys(std::vector<XFieldAggpubkey> & xFieldList);
     bool WriteXFieldAggpubkey(const XFieldAggpubkey & XFieldAggpubkey);
+    bool ResetXFieldAggpubkeys(std::vector<XFieldAggpubkey>& xFieldList);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -134,18 +134,8 @@ public:
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
-<<<<<<< HEAD
-<<<<<<< HEAD
     bool ReadXFieldAggpubkeys(std::vector<XFieldAggpubkey> & xFieldList);
     bool WriteXFieldAggpubkey(const XFieldAggpubkey & XFieldAggpubkey);
-=======
-    bool ReadXFieldAggpubkeys(std::vector<XFieldEntry> & xFieldList);
-    bool AddXFieldAggpubkey(XFieldEntry & xFieldEntry);
->>>>>>> 1cd816256 (make aggpubkey persistent upon node restart)
-=======
-    bool ReadXFieldAggpubkeys(std::vector<XFieldAggpubkey> & xFieldList);
-    bool WriteXFieldAggpubkey(XFieldAggpubkey & XFieldAggpubkey);
->>>>>>> f2e36a401 (review feedback - fixed names and comments)
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -134,8 +134,13 @@ public:
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
+<<<<<<< HEAD
     bool ReadXFieldAggpubkeys(std::vector<XFieldAggpubkey> & xFieldList);
     bool WriteXFieldAggpubkey(const XFieldAggpubkey & XFieldAggpubkey);
+=======
+    bool ReadXFieldAggpubkeys(std::vector<XFieldEntry> & xFieldList);
+    bool AddXFieldAggpubkey(XFieldEntry & xFieldEntry);
+>>>>>>> 1cd816256 (make aggpubkey persistent upon node restart)
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -135,12 +135,17 @@ public:
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
 <<<<<<< HEAD
+<<<<<<< HEAD
     bool ReadXFieldAggpubkeys(std::vector<XFieldAggpubkey> & xFieldList);
     bool WriteXFieldAggpubkey(const XFieldAggpubkey & XFieldAggpubkey);
 =======
     bool ReadXFieldAggpubkeys(std::vector<XFieldEntry> & xFieldList);
     bool AddXFieldAggpubkey(XFieldEntry & xFieldEntry);
 >>>>>>> 1cd816256 (make aggpubkey persistent upon node restart)
+=======
+    bool ReadXFieldAggpubkeys(std::vector<XFieldAggpubkey> & xFieldList);
+    bool WriteXFieldAggpubkey(XFieldAggpubkey & XFieldAggpubkey);
+>>>>>>> f2e36a401 (review feedback - fixed names and comments)
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4257,7 +4257,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, std::vector<XFieldA
                           // the purpose of this reindexing may be to correct xfield aggpubkey in leveldb if xFieldList is not null
                           if(xFieldList && (TAPYRUS_XFIELDTYPES)pblock->xfieldType == TAPYRUS_XFIELDTYPES::AGGPUBKEY)
                           {
-                            XFieldAggpubkey newXfield(pblock->xfield, pblock->GetHeight(), hash);
+                            XFieldAggpubkey newXfield(pblock->xfield, pblock->GetHeight() + 1, hash);
                             if(std::find(xFieldList->begin(), xFieldList->end(), newXfield) == xFieldList->end())
                                 xFieldList->push_back(newXfield);
                           }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4255,7 +4255,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, std::vector<XFieldA
                           nLoaded++;
 
                           // the purpose of this reindexing may be to correct xfield aggpubkey in leveldb if xFieldList is not null
-                          if(xFieldList && (TAPYRUS_XFIELDTYPES)pblock->xfieldType == TAPYRUS_XFIELDTYPES::AGGPUBKEY)
+                          if(xFieldList && (TAPYRUS_XFIELDTYPES)pblock->xfieldType == TAPYRUS_XFIELDTYPES::AGGPUBKEY && pblock->GetHeight() > 0)
                           {
                             XFieldAggpubkey newXfield(pblock->xfield, pblock->GetHeight() + 1, hash);
                             if(std::find(xFieldList->begin(), xFieldList->end(), newXfield) == xFieldList->end())

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3236,17 +3236,6 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
         if (!CheckBlockHeader(block, state, aggPubkeys))
             return error("%s: Consensus::CheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
 
-        //if this header was valid and has an aggpubkey change remember it until we finish processing the headers message
-        if(aggPubkeys && (TAPYRUS_XFIELDTYPES)block.xfieldType == TAPYRUS_XFIELDTYPES::AGGPUBKEY
-          && block.xfield.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE
-          && CPubKey(block.xfield.begin(), block.xfield.end()) != aggPubkeys->rbegin()->aggpubkey)
-        {
-            AggPubkeyAndHeight x;
-            x.aggpubkey = CPubKey(block.xfield.begin(), block.xfield.end());
-            x.height = -1;
-            aggPubkeys->push_back(x);
-        }
-
         // Get prev block index
         CBlockIndex* pindexPrev = nullptr;
         BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3241,7 +3241,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
           && block.xfield.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE
           && CPubKey(block.xfield.begin(), block.xfield.end()) != aggPubkeys->rbegin()->aggpubkey)
         {
-            aggPubkeyAndHeight x;
+            AggPubkeyAndHeight x;
             x.aggpubkey = CPubKey(block.xfield.begin(), block.xfield.end());
             x.height = -1;
             aggPubkeys->push_back(x);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2366,10 +2366,8 @@ bool CChainState::ConnectTip(CValidationState& state, CBlockIndex* pindexNew, co
 
         // if the block was added successfully and it is a federation block,
         // make sure that the aggregatepubkey from this block is added to CFederationParams
-        bool xFieldValid(false), xFieldEqual(false);
-        xFieldEqual = blockConnecting.CheckXField(FederationParams().GetLatestAggregatePubkey(), xFieldValid);
-
-        if(xFieldValid && !xFieldEqual)
+        if(blockConnecting.isXFieldValid()
+            && !blockConnecting.isXFieldEqual(FederationParams().GetLatestAggregatePubkey()))
         {
             FederationParams().ReadAggregatePubkey(blockConnecting.xfield, blockConnecting.GetHeight() + 1);
             XFieldAggpubkey XFieldAggpubkey(blockConnecting.xfield, blockConnecting.GetHeight() + 1, blockConnecting.GetHash());
@@ -3269,11 +3267,9 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
         pindex = AddToBlockIndex(block);
 
     //if this header was valid and has an aggpubkey change remember it until we finish processing the headers message
-    bool xFieldValid(false), xFieldEqual(false);
-    if(aggPubkeys)
-       xFieldEqual = block.CheckXField(aggPubkeys->rbegin()->aggpubkey, xFieldValid);
-
-    if(xFieldValid && !xFieldEqual)
+    if(aggPubkeys
+        && block.isXFieldValid()
+        && !block.isXFieldEqual(aggPubkeys->rbegin()->aggpubkey))
     {
         AggPubkeyAndHeight x;
         x.aggpubkey = CPubKey(block.xfield.begin(), block.xfield.end());

--- a/src/validation.h
+++ b/src/validation.h
@@ -44,6 +44,7 @@ class CBlockPolicyEstimator;
 class CTxMemPool;
 class CValidationState;
 struct ChainTxData;
+struct XFieldAggpubkey;
 
 struct PrecomputedTransactionData;
 struct LockPoints;
@@ -253,7 +254,7 @@ FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
 fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
 /** Import blocks from an external file */
-bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp = nullptr);
+bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp = nullptr,  std::vector<XFieldAggpubkey>* xFieldList = nullptr);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
 bool LoadGenesisBlock();
 /** Load the block tree and coins database from disk,

--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -302,8 +302,10 @@ class FederationManagementTest(BitcoinTestFramework):
         self.start_node(0)
         connect_nodes(self.nodes[0], 1)
 
+        #restarting node0 to test presistance of aggpubkey change
         self.stop_node(0)
         self.start_node(0)
+        connect_nodes(self.nodes[0], 1)
 
         self.log.info("Simulate Blockchain Reorg  - After the last federation block")
         #B27 -- Create block with previous block hash = B26 - sign with aggpubkey3 -- success - block is accepted but there is no re-org
@@ -484,7 +486,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.stop_node(0)
         self.log.info("Restarting node with '-reindex'")
         self.start_node(0, extra_args=["-reindex"])
-        self.connectNodeAndCheck(1, expectedAggPubKeys)
+        connect_nodes(self.nodes[0], 1)
+        self.connectNodeAndCheck(2, expectedAggPubKeys)
 
         #B38 - B40 -- Generate 2 blocks - no aggpubkey -- chain becomes longer
         self.forkblocks += node.generate(3, self.aggprivkey_wif[4])

--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -302,6 +302,9 @@ class FederationManagementTest(BitcoinTestFramework):
         self.start_node(0)
         connect_nodes(self.nodes[0], 1)
 
+        self.stop_node(0)
+        self.start_node(0)
+
         self.log.info("Simulate Blockchain Reorg  - After the last federation block")
         #B27 -- Create block with previous block hash = B26 - sign with aggpubkey3 -- success - block is accepted but there is no re-org
         block_time += 1
@@ -458,6 +461,11 @@ class FederationManagementTest(BitcoinTestFramework):
         assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
+        self.stop_node(0)
+        self.log.info("Restarting node with '-reindex'")
+        self.start_node(0, extra_args=["-reindex"])
+        #self.connectNodeAndCheck(1, expectedAggPubKeys)
+
         self.log.info("Verifying getblockchaininfo")
         #getblockchaininfo
         expectedAggPubKeys = [
@@ -482,6 +490,11 @@ class FederationManagementTest(BitcoinTestFramework):
         self.forkblocks += node.generate(3, self.aggprivkey_wif[4])
         self.tip = node.getbestblockhash()
         best_block = node.getblock(self.tip)
+
+        self.stop_node(0)
+        self.log.info("Restarting node with '-reindex-chainstate'")
+        self.start_node(0, extra_args=["-reindex-chainstate"])
+        #self.connectNodeAndCheck(1, expectedAggPubKeys)
 
         self.log.info("Test Repeated aggpubkeys in Federation Block")
         #B41 -- Create block with aggpubkey0 - sign using aggpubkey5 -- success - aggpubkey0 is added to the list

--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -627,7 +627,8 @@ class FederationManagementTest(BitcoinTestFramework):
         assert(node.getblock(self.tip))
 
         os.mkdir(os.path.join(self.nodes[3].datadir, 'blocks'))
-        shutil.copyfile(os.path.join(self.nodes[1].datadir, NetworkDirName(), 'blocks', 'blk00000.dat'), os.path.join(self.nodes[3].datadir, 'blocks', 'blk00000.dat'))
+        shutil.copyfile(os.path.join(self.nodes[1].datadir, NetworkDirName(), 'blocks', 'blk00000.dat'), os.path.join(self.nodes[3].datadir, 'blk00000.dat'))
+        shutil.copyfile(os.path.join(self.nodes[1].datadir, NetworkDirName(), 'blocks', 'blk00000.dat'), os.path.join(self.nodes[3].datadir,  NetworkDirName(), 'bootstrap.dat'))
 
         #B51 -- Create block with aggpubkey5 - sign using aggpubkey1 -- success - aggpubkey5 is added to the list
         block_time += 10
@@ -644,7 +645,7 @@ class FederationManagementTest(BitcoinTestFramework):
         best_block = self.nodes[1].getblock(self.tip)
         self.sync_all([self.nodes[0:3]])
 
-        self.start_node(3, ["-reloadxfield"])
+        self.start_node(3, ["-reloadxfield", "-loadblock=%s" % os.path.join(self.nodes[3].datadir, 'blk00000.dat')])
         #reindex takes time. wait before checking blockchain info
         time.sleep(5)
         connect_nodes(self.nodes[3], 0)

--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -461,11 +461,6 @@ class FederationManagementTest(BitcoinTestFramework):
         assert_equal(self.tip, syn_node.getbestblockhash())
         assert(node.getblock(self.tip))
 
-        self.stop_node(0)
-        self.log.info("Restarting node with '-reindex'")
-        self.start_node(0, extra_args=["-reindex"])
-        #self.connectNodeAndCheck(1, expectedAggPubKeys)
-
         self.log.info("Verifying getblockchaininfo")
         #getblockchaininfo
         expectedAggPubKeys = [
@@ -486,15 +481,15 @@ class FederationManagementTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 1)
         self.connectNodeAndCheck(2, expectedAggPubKeys)
 
+        self.stop_node(0)
+        self.log.info("Restarting node with '-reindex'")
+        self.start_node(0, extra_args=["-reindex"])
+        self.connectNodeAndCheck(1, expectedAggPubKeys)
+
         #B38 - B40 -- Generate 2 blocks - no aggpubkey -- chain becomes longer
         self.forkblocks += node.generate(3, self.aggprivkey_wif[4])
         self.tip = node.getbestblockhash()
         best_block = node.getblock(self.tip)
-
-        self.stop_node(0)
-        self.log.info("Restarting node with '-reindex-chainstate'")
-        self.start_node(0, extra_args=["-reindex-chainstate"])
-        #self.connectNodeAndCheck(1, expectedAggPubKeys)
 
         self.log.info("Test Repeated aggpubkeys in Federation Block")
         #B41 -- Create block with aggpubkey0 - sign using aggpubkey5 -- success - aggpubkey0 is added to the list


### PR DESCRIPTION
Add Command line option `-reloadxfield`. It behaves like `-reindex` and re-creates the block index from block files. The presence of xfields and its value is cached during reindexing and the final list is written to block tree db. 

Test: 
Federation management test is extended to start one dormant node with  `-reloadxfield` to check that the blockchain can continue without any 