### PR TITLE
Check uncompresses key in tapyrus-genesis.

### DIFF
--- a/src/tapyrus-genesis.cpp
+++ b/src/tapyrus-genesis.cpp
@@ -153,7 +153,7 @@ static int CommandLine()
             }
             if(!aggpubkey.IsCompressed())
             {
-                fprintf(stderr, "Error: Uncompressed Aggregate Public Keys are not supported.\n");
+                fprintf(stderr, "Error: Uncompressed Aggregate Public Key are not supported.\n");
                 return EXIT_FAILURE;
             }
         }

--- a/src/tapyrus-genesis.cpp
+++ b/src/tapyrus-genesis.cpp
@@ -151,6 +151,11 @@ static int CommandLine()
                 fprintf(stderr, "Error: Aggregate Public Key was invalid.\n");
                 return EXIT_FAILURE;
             }
+            if(!aggpubkey.IsCompressed())
+            {
+                fprintf(stderr, "Error: Uncompressed Aggregate Public Keys are not supported.\n");
+                return EXIT_FAILURE;
+            }
         }
     } catch (const std::exception& e) {
         fprintf(stderr, "Error: %s\n", e.what());

--- a/src/tapyrus-genesis.cpp
+++ b/src/tapyrus-genesis.cpp
@@ -153,7 +153,7 @@ static int CommandLine()
             }
             if(!aggpubkey.IsCompressed())
             {
-                fprintf(stderr, "Error: Uncompressed Aggregate Public Key are not supported.\n");
+                fprintf(stderr, "Error: Uncompressed Aggregate Public Keys are not supported.\n");
                 return EXIT_FAILURE;
             }
         }

--- a/src/tapyrus-genesis.cpp
+++ b/src/tapyrus-genesis.cpp
@@ -153,7 +153,7 @@ static int CommandLine()
             }
             if(!aggpubkey.IsCompressed())
             {
-                fprintf(stderr, "Error: Uncompressed Aggregate Public Keys are not supported.\n");
+                fprintf(stderr, "Error: Uncompressed Aggregate Public Key is not supported.\n");
                 return EXIT_FAILURE;
             }
         }

--- a/test/util/data/tapyrus-util-test.json
+++ b/test/util/data/tapyrus-util-test.json
@@ -775,7 +775,7 @@
     ],
     "return_code": 1,
     "error_txt": "Error: Aggregate private key does not correspond to given Aggregate public key",
-    "description": "Ensure aggregate pubkey and aggregate private correspond to each other."
+    "description": "Ensure aggregate pubkey and aggregate private key correspond to each other."
   },
   {
     "exec": "./tapyrus-genesis",

--- a/test/util/data/tapyrus-util-test.json
+++ b/test/util/data/tapyrus-util-test.json
@@ -765,7 +765,7 @@
     ],
     "return_code": 1,
     "error_txt": "Error: Uncompressed Aggregate Public Keys are not supported",
-    "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey in dev mode."
+    "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey."
   },
   {
     "exec": "./tapyrus-genesis",

--- a/test/util/data/tapyrus-util-test.json
+++ b/test/util/data/tapyrus-util-test.json
@@ -742,7 +742,7 @@
       "-signblockprivatekey=5KbckfYoaBR1a7PuR2JAE2E1jGZ4hMmmCT9nNwJ3rfqf78oWr92"
     ],
     "return_code": 1,
-    "error_txt": "Error: Uncompressed Aggregate Public Keys are not supported",
+    "error_txt": "Error: Uncompressed Aggregate Public Key is not supported",
     "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey."
   },
   {
@@ -751,10 +751,10 @@
       "-dev",
       "-time=1563342688",
       "-signblockpubkey=04473757a955a23f75379820f3071abf5b3343b78eb54e52373d06259ffa6c550bd0acc38ff1b182a5de0c795aa7109e8348ca5436d65a267ef134af595ec6c75e",
-      "-signblockprivatekey=L55noj9NZSxyX9E6M2ijiUQSDZeXK8ga5YRmHpeFcERmBnvc7bS3"
+      "-signblockprivatekey=cVSnGe9DzWfEgahMjSXs5nuVqnwvyanG9aaEQF6m7M5mSY2wfZzW"
     ],
     "return_code": 1,
-    "error_txt": "Error: Uncompressed Aggregate Public Keys are not supported",
+    "error_txt": "Error: Uncompressed Aggregate Public Key is not supported",
     "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey in dev mode."
   },
   {
@@ -764,7 +764,7 @@
       "-signblockprivatekey=5KSSJQ7UNfFGwVgpCZDSHm5rVNhMFcFtvWM3zQ8mW4qNDEN7LFd"
     ],
     "return_code": 1,
-    "error_txt": "Error: Uncompressed Aggregate Public Keys are not supported",
+    "error_txt": "Error: Uncompressed Aggregate Public Key is not supported",
     "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey."
   },
   {

--- a/test/util/data/tapyrus-util-test.json
+++ b/test/util/data/tapyrus-util-test.json
@@ -733,5 +733,59 @@
     ],
     "check":"check_generateKey",
     "description": "Ensure generatekey is successful in dev mode"
+  },
+  {
+    "exec": "./tapyrus-genesis",
+    "args": [
+      "-time=1563342688",
+      "-signblockpubkey=04473757a955a23f75379820f3071abf5b3343b78eb54e52373d06259ffa6c550bd0acc38ff1b182a5de0c795aa7109e8348ca5436d65a267ef134af595ec6c75e",
+      "-signblockprivatekey=5KbckfYoaBR1a7PuR2JAE2E1jGZ4hMmmCT9nNwJ3rfqf78oWr92"
+    ],
+    "return_code": 1,
+    "error_txt": "Error: Uncompressed Aggregate Public Keys are not supported",
+    "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey."
+  },
+  {
+    "exec": "./tapyrus-genesis",
+    "args": [
+      "-dev",
+      "-time=1563342688",
+      "-signblockpubkey=04473757a955a23f75379820f3071abf5b3343b78eb54e52373d06259ffa6c550bd0acc38ff1b182a5de0c795aa7109e8348ca5436d65a267ef134af595ec6c75e",
+      "-signblockprivatekey=L55noj9NZSxyX9E6M2ijiUQSDZeXK8ga5YRmHpeFcERmBnvc7bS3"
+    ],
+    "return_code": 1,
+    "error_txt": "Error: Uncompressed Aggregate Public Keys are not supported",
+    "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey in dev mode."
+  },
+  {
+    "exec": "./tapyrus-genesis",
+    "args": [
+      "-signblockpubkey=04b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb25e01fc8fde47c96c98a4f3a8123e33a38a50cf9025cc8c4494a518f991792bb7",
+      "-signblockprivatekey=5KSSJQ7UNfFGwVgpCZDSHm5rVNhMFcFtvWM3zQ8mW4qNDEN7LFd"
+    ],
+    "return_code": 1,
+    "error_txt": "Error: Uncompressed Aggregate Public Keys are not supported",
+    "description": "Ensure uncompressed pubkeys are not accepted as aggregate pubkey in dev mode."
+  },
+  {
+    "exec": "./tapyrus-genesis",
+    "args": [
+      "-signblockpubkey=025700236c2890233592fcef262f4520d22af9160e3d9705855140eb2aa06c35d3",
+      "-signblockprivatekey=5KSSJQ7UNfFGwVgpCZDSHm5rVNhMFcFtvWM3zQ8mW4qNDEN7LFd"
+    ],
+    "return_code": 1,
+    "error_txt": "Error: Aggregate private key does not correspond to given Aggregate public key",
+    "description": "Ensure aggregate pubkey and aggregate private correspond to each other."
+  },
+  {
+    "exec": "./tapyrus-genesis",
+    "args": [
+      "-dev",
+      "-signblockpubkey=025700236c2890233592fcef262f4520d22af9160e3d9705855140eb2aa06c35d3",
+      "-signblockprivatekey=cUJN5RVzYWFoeY8rUztd47jzXCu1p57Ay8V7pqCzsBD3PEXN7Dd4"
+    ],
+    "return_code": 1,
+    "error_txt": "Error: Aggregate private key does not correspond to given Aggregate public key",
+    "description": "Ensure aggregate pubkey and aggregate private correspond to each other in dev mode."
   }
 ]

--- a/test/util/data/tapyrus-util-test.json
+++ b/test/util/data/tapyrus-util-test.json
@@ -786,6 +786,6 @@
     ],
     "return_code": 1,
     "error_txt": "Error: Aggregate private key does not correspond to given Aggregate public key",
-    "description": "Ensure aggregate pubkey and aggregate private correspond to each other in dev mode."
+    "description": "Ensure aggregate pubkey and aggregate private key correspond to each other in dev mode."
   }
 ]


### PR DESCRIPTION
Accepting uncompresses keys causes confusion as reported in #241 i.e Tapyrus-core can start with the genesis block created with uncompresses pub key. But new blocks cannot be created as proof verification expected only compresses pub key. So the chain cannot progress.