### PR TITLE
Add extra logging to identify crash in reindex xfield

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4236,7 +4236,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
                     }
 
                     // process in case the block isn't known yet
-                    LogPrint(BCLog::REINDEX, "%s: before LookupBlockIndex", __func__);
+                    LogPrint(BCLog::REINDEX, "%s: before LookupBlockIndex\n", __func__);
                     CBlockIndex* pindex = LookupBlockIndex(hash);
                     if (!pindex || (pindex->nStatus & BLOCK_HAVE_DATA) == 0) {
                         CValidationState state;
@@ -4244,14 +4244,14 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
                             nLoaded++;
                         }
                         if (state.IsError()) {
-                            LogPrint(BCLog::REINDEX, "%s: AcceptBlock state: %s-%s", __func__, state.GetRejectReason(), state.GetDebugMessage());
+                            LogPrint(BCLog::REINDEX, "%s: AcceptBlock state: %s-%s\n", __func__, state.GetRejectReason(), state.GetDebugMessage());
                           break;
                       }
                     } else if (hash != FederationParams().GenesisBlock().GetHash() && pindex->nHeight % 1000 == 0) {
                       LogPrint(BCLog::REINDEX, "%s Block Import: already had block %s at height %d\n", __func__, hash.ToString(), pindex->nHeight);
                     }
                     else
-                    LogPrint(BCLog::REINDEX, "%s: LookupBlockIndex returned null", __func__);
+                    LogPrint(BCLog::REINDEX, "%s: LookupBlockIndex returned null\n", __func__);
                 }
 
                 // Activate the genesis block so normal node progress can continue

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4236,7 +4236,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
                     }
 
                     // process in case the block isn't known yet
-                    LogPrint(BCLog::REINDEX, "%s: before LookupBlockIndex");
+                    LogPrint(BCLog::REINDEX, "%s: before LookupBlockIndex", __func__);
                     CBlockIndex* pindex = LookupBlockIndex(hash);
                     if (!pindex || (pindex->nStatus & BLOCK_HAVE_DATA) == 0) {
                         CValidationState state;
@@ -4244,14 +4244,14 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
                             nLoaded++;
                         }
                         if (state.IsError()) {
-                            LogPrint(BCLog::REINDEX, "%s: AcceptBlock state: %s-%s", state.GetRejectReason(), state.GetDebugMessage());
+                            LogPrint(BCLog::REINDEX, "%s: AcceptBlock state: %s-%s", __func__, state.GetRejectReason(), state.GetDebugMessage());
                           break;
                       }
                     } else if (hash != FederationParams().GenesisBlock().GetHash() && pindex->nHeight % 1000 == 0) {
-                      LogPrint(BCLog::REINDEX, "Block Import: already had block %s at height %d\n", hash.ToString(), pindex->nHeight);
+                      LogPrint(BCLog::REINDEX, "%s Block Import: already had block %s at height %d\n", __func__, hash.ToString(), pindex->nHeight);
                     }
                     else
-                    LogPrint(BCLog::REINDEX, "%s: LookupBlockIndex returned null");
+                    LogPrint(BCLog::REINDEX, "%s: LookupBlockIndex returned null", __func__);
                 }
 
                 // Activate the genesis block so normal node progress can continue

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4178,6 +4178,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
     int64_t nStart = GetTimeMillis();
 
     int nLoaded = 0;
+    bool outOfOrder = false;
     try {
         // This takes over fileIn and calls fclose() on it in the CBufferedFile destructor
         CBufferedFile blkdat(fileIn, 2*GetCurrentMaxBlockSize(), GetCurrentMaxBlockSize()+8, SER_DISK, CLIENT_VERSION);
@@ -4185,6 +4186,8 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
         while (!blkdat.eof()) {
             boost::this_thread::interruption_point();
 
+            LogPrint(BCLog::REINDEX, "%s: nRewind : %d (%s out of order)\n", __func__, nRewind,
+                             outOfOrder ? "after" : "before");
             blkdat.SetPos(nRewind);
             nRewind++; // start one byte further next time, in case of failure
             blkdat.SetLimit(); // remove former limit
@@ -4213,9 +4216,11 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
                 blkdat.SetLimit(nBlockPos + nSize);
                 blkdat.SetPos(nBlockPos);
                 std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
+                LogPrint(BCLog::REINDEX, "%s: trying to read block %s\n", __func__, pblock->GetHash().ToString());
                 CBlock& block = *pblock;
                 blkdat >> block;
                 nRewind = blkdat.GetPos();
+                LogPrint(BCLog::REINDEX, "%s: Read ok. nRewind = %d\n", __func__, nRewind);
 
                 uint256 hash = block.GetHash();
                 {
@@ -4224,12 +4229,14 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
                     if (hash != FederationParams().GenesisBlock().GetHash() && !LookupBlockIndex(block.hashPrevBlock)) {
                         LogPrint(BCLog::REINDEX, "%s: Out of order block %s, parent %s not known\n", __func__, hash.ToString(),
                                 block.hashPrevBlock.ToString());
+                        outOfOrder = true;
                         if (dbp)
                             mapBlocksUnknownParent.insert(std::make_pair(block.hashPrevBlock, *dbp));
                         continue;
                     }
 
                     // process in case the block isn't known yet
+                    LogPrint(BCLog::REINDEX, "%s: before LookupBlockIndex");
                     CBlockIndex* pindex = LookupBlockIndex(hash);
                     if (!pindex || (pindex->nStatus & BLOCK_HAVE_DATA) == 0) {
                         CValidationState state;
@@ -4237,11 +4244,14 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
                             nLoaded++;
                         }
                         if (state.IsError()) {
+                            LogPrint(BCLog::REINDEX, "%s: AcceptBlock state: %s-%s", state.GetRejectReason(), state.GetDebugMessage());
                           break;
                       }
                     } else if (hash != FederationParams().GenesisBlock().GetHash() && pindex->nHeight % 1000 == 0) {
                       LogPrint(BCLog::REINDEX, "Block Import: already had block %s at height %d\n", hash.ToString(), pindex->nHeight);
                     }
+                    else
+                    LogPrint(BCLog::REINDEX, "%s: LookupBlockIndex returned null");
                 }
 
                 // Activate the genesis block so normal node progress can continue


### PR DESCRIPTION
#254 is not replicated after all dependencies are upgraded. these logs should give more clue when it happens again