### PR TITLE
Fix test framework retry on timeout

### DIFF
--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -556,6 +556,8 @@ class FederationManagementTest(BitcoinTestFramework):
         self.start_node(3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)
+        #initial block download and synch takes time. wait before checking blockchain info
+        time.sleep(15)
         self.sync_all([self.nodes[0:4]])
         self.stop_node(3)
 

--- a/test/functional/feature_xfield_maxblocksize.py
+++ b/test/functional/feature_xfield_maxblocksize.py
@@ -494,7 +494,7 @@ class MaxBloxkSizeInXFieldTest(BitcoinTestFramework):
         self.block_time += 1
         blocknew = self.new_block(48, spend=self.unspent[21])
         blocknew.solve(self.aggprivkey[1])
-        node.p2p.send_blocks_and_test([blocknew], node, success=False, request_block=False, timeout=300)
+        node.p2p.send_blocks_and_test([blocknew], node, success=True, request_block=False, timeout=300)
         self.tip = blocknew.hash
         assert_equal(self.tip, node.getbestblockhash())
 

--- a/test/functional/feature_xfield_maxblocksize.py
+++ b/test/functional/feature_xfield_maxblocksize.py
@@ -496,7 +496,7 @@ class MaxBloxkSizeInXFieldTest(BitcoinTestFramework):
         self.block_time += 1
         blocknew = self.new_block(48, spend=self.unspent[21])
         blocknew.solve(self.aggprivkey[1])
-        node.p2p.send_blocks_and_test([blocknew], node, success=False, request_block=False, timeout=240)
+        node.p2p.send_blocks_and_test([blocknew], node, success=False, request_block=False, timeout=300)
         self.tip = blocknew.hash
         assert_equal(self.tip, node.getbestblockhash())
 

--- a/test/functional/feature_xfield_maxblocksize.py
+++ b/test/functional/feature_xfield_maxblocksize.py
@@ -17,8 +17,7 @@ Simulate Blockchain Reorg  - After the last federation block and Before the last
 
 Test the output of RPC Getblockchaininfo before reorg and after reorg. Verify block aggpubkey and maxblock size changes against block height
 
-During reorg, the max block size from a block removed block is removed from the list. IF the same block comes back the same 
-Restart the node with -reindex, -reindex-chainstate and -loadblock options. This triggers a full rewind of block index. Verify that the tip reaches B51 at the end.
+Restart the node with -reindex, -reindex-chainstate, -reloadxfield and -loadblock options. This triggers a full rewind of block index. Verify that the tip reaches B51 at the end.
 """
 import time
 import shutil, os
@@ -458,12 +457,11 @@ class MaxBloxkSizeInXFieldTest(BitcoinTestFramework):
         self.connectNodeAndCheck(2, expectedAggPubKeys, expectedblockheights)
 
         #B45 - B47 -- Generate 3 blocks - no change in aggpubkey or block size -- chain becomes longer
-        self.reconnect_p2p(node)
-
         chaintips = node.getchaintips()
         assert_equal(len(chaintips), 1)
         self.unspent = self.unspent + generate_blocks(3, node, self.coinbase_pubkey, self.aggprivkey[1])
         tip_before_reorg = node.getbestblockhash()
+        time.sleep(30)
 
         self.log.info("Simulate Blockchain Reorg  - After the last block size change")
         self.block_time += 1

--- a/test/functional/feature_xfield_maxblocksize.py
+++ b/test/functional/feature_xfield_maxblocksize.py
@@ -496,8 +496,7 @@ class MaxBloxkSizeInXFieldTest(BitcoinTestFramework):
         self.block_time += 1
         blocknew = self.new_block(48, spend=self.unspent[21])
         blocknew.solve(self.aggprivkey[1])
-        node.p2p.send_blocks_and_test([blocknew], node, success=False, request_block=False, timeout=80)
-        time.sleep(30) #wait for the reorg to complete
+        node.p2p.send_blocks_and_test([blocknew], node, success=False, request_block=False, timeout=240)
         self.tip = blocknew.hash
         assert_equal(self.tip, node.getbestblockhash())
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -368,7 +368,7 @@ def main():
         config["environment"]["SRCDIR"],
         config["environment"]["BUILDDIR"],
         tmpdir,
-        jobs=args.jobs,
+        jobs=1,
         enable_coverage=args.coverage,
         args=passon_args,
         combined_logs_len=args.combinedlogslen,

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -427,8 +427,10 @@ def run_tests(test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=Fal
     max_len_name = len(max(test_list, key=len))
 
     for _ in range(len(test_list)):
-        test_result, testdir, stdout, stderr = job_queue.get_next()
+        test_result, testdir, stdout, stderr, retry = job_queue.get_next()
         test_results.append(test_result)
+        if retry is not None:
+            retry_list.append(retry)
 
         if test_result.status == "Passed":
             logging.debug("\n%s%s%s passed, Duration: %s s" % (BOLD[1], test_result.name, BOLD[0], test_result.time))
@@ -513,6 +515,7 @@ class TestHandler:
         self.retry = None
 
     def get_next(self):
+        self.retry = None
         while self.num_running < self.num_jobs and self.test_list:
             # Add tests
             self.num_running += 1
@@ -552,13 +555,15 @@ class TestHandler:
                     elif proc.returncode == TEST_EXIT_SKIPPED:
                         status = "Skipped"
                     elif proc.returncode == TEST_EXIT_TIMEOUT:
+                        self.retry = name
                         status = "Timeout"
+                        proc.send_signal(signal.SIGINT)
                     else:
                         status = "Failed"
                     self.num_running -= 1
                     self.jobs.remove(job)
 
-                    return TestResult(name, status, int(time.time() - start_time)), testdir, stdout, stderr
+                    return TestResult(name, status, int(time.time() - start_time)), testdir, stdout, stderr, self.retry
             print('.', end='', flush=True)
 
     def kill_and_join(self):


### PR DESCRIPTION
When a test fails because of timeout, tapyrusd should be stopped. otherwise the same test cannot be restarted.
Fix retry test case list bug causing the same test being tried being more than once

Add extra timeout in reorg of max block size test case
