### PR TITLE
Tapyrusd container upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM tapyrus/builder:v0.2.0 as builder
+FROM --platform=$TARGETPLATFORM tapyrus/builder:v0.3.0 as builder
 ARG TARGETARCH
 
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
 Tapyrus builder container v0.3.0 is now built.  Use it to build all new tapyrusd docker containers