### PR TITLE
Fix #254  -  reloadxfield/ reindex crash 

### DIFF
--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -569,7 +569,10 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Setup the p2p connections again
         inv_node = self.nodes[0].add_p2p_connection(BaseNode(self.nodes[0].time_to_connect))
+        inv_node.sync_with_ping()
+
         test_node = self.nodes[0].add_p2p_connection(BaseNode(self.nodes[0].time_to_connect))
+        test_node.sync_with_ping()
 
         #repeat sequence  in 4a
         tip = self.mine_blocks(1)


### PR DESCRIPTION
A change introduced in commit 5769437e3f9db10601c1414c9aea18ba56e84fbc. It was probably unintentional.
But this caused the crash in out of order block as the pointer `pblockrecursive` being dereferenced was null