### PR TITLE
Updates in  synchronization mutex for Shared data

### DIFF
--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -29,7 +29,7 @@ class CCheckQueue
 {
 private:
     //! Mutex to protect the inner state
-    std::mutex mutex;
+    Mutex mutex;
 
     //! Worker threads block on this when out of work
     std::condition_variable condWorker;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -70,7 +70,7 @@ class WorkQueue
 {
 private:
     /** Mutex protects entire object */
-    std::mutex cs;
+    Mutex cs;
     std::condition_variable cond;
     std::deque<std::unique_ptr<WorkItem>> queue;
     bool running;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -187,7 +187,7 @@ void Interrupt()
 void Shutdown()
 {
     LogPrintf("%s: In progress...\n", __func__);
-    static CCriticalSection cs_Shutdown;
+    static Mutex cs_Shutdown;
     TRY_LOCK(cs_Shutdown, lockShutdown);
     if (!lockShutdown)
         return;
@@ -562,7 +562,7 @@ static void BlockNotifyCallback(bool initialSync, const CBlockIndex *pBlockIndex
 }
 
 static bool fHaveGenesis = false;
-static CWaitableCriticalSection cs_GenesisWait;
+static Mutex cs_GenesisWait;
 static CConditionVariable condvar_GenesisWait;
 
 static void BlockNotifyGenesisWait(bool, const CBlockIndex *pBlockIndex)

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -147,7 +147,7 @@ class NodeImpl : public Node
     }
     int64_t getTotalBytesRecv() override { return g_connman ? g_connman->GetTotalBytesRecv() : 0; }
     int64_t getTotalBytesSent() override { return g_connman ? g_connman->GetTotalBytesSent() : 0; }
-    size_t getMempoolSize() override { return ::mempool.size(); }
+    size_t getMempoolSize() override { LOCK(mempool.cs); return ::mempool.size(); }
     size_t getMempoolDynamicUsage() override { return ::mempool.DynamicMemoryUsage(); }
     bool getHeaderTip(int& height, int64_t& block_time) override
     {

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -60,6 +60,7 @@ public:
 //! Construct wallet tx struct.
 WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
 {
+    LOCK(wallet.cs_wallet);
     WalletTx result;
     result.tx = wtx.tx;
     result.txin_is_mine.reserve(wtx.tx->vin.size());

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -42,7 +42,7 @@ public:
 class CBasicKeyStore : public CKeyStore
 {
 protected:
-    mutable CCriticalSection cs_KeyStore;
+    mutable RecursiveMutex cs_KeyStore;
 
     using KeyMap = std::map<CKeyID, CKey>;
     using WatchKeyMap = std::map<CKeyID, CPubKey>;

--- a/src/leveldb/db/db_bench.cc
+++ b/src/leveldb/db/db_bench.cc
@@ -283,8 +283,8 @@ class Stats {
 // State shared by all concurrent executions of the same benchmark.
 struct SharedState {
   port::Mutex mu;
-  port::CondVar cv GUARDED_BY(mu);
-  int total GUARDED_BY(mu);
+  port::CondVar cv;
+  int total;
 
   // Each thread goes through the following states:
   //    (1) initializing
@@ -292,9 +292,9 @@ struct SharedState {
   //    (3) running
   //    (4) done
 
-  int num_initialized GUARDED_BY(mu);
-  int num_done GUARDED_BY(mu);
-  bool start GUARDED_BY(mu);
+  int num_initialized;
+  int num_done;
+  bool start;
 
   SharedState() : cv(&mu) { }
 };

--- a/src/leveldb/db/db_bench.cc
+++ b/src/leveldb/db/db_bench.cc
@@ -283,8 +283,8 @@ class Stats {
 // State shared by all concurrent executions of the same benchmark.
 struct SharedState {
   port::Mutex mu;
-  port::CondVar cv;
-  int total;
+  port::CondVar cv GUARDED_BY(mu);
+  int total GUARDED_BY(mu);
 
   // Each thread goes through the following states:
   //    (1) initializing
@@ -292,9 +292,9 @@ struct SharedState {
   //    (3) running
   //    (4) done
 
-  int num_initialized;
-  int num_done;
-  bool start;
+  int num_initialized GUARDED_BY(mu);
+  int num_done GUARDED_BY(mu);
+  bool start GUARDED_BY(mu);
 
   SharedState() : cv(&mu) { }
 };

--- a/src/leveldb/db/db_test.cc
+++ b/src/leveldb/db/db_test.cc
@@ -29,7 +29,7 @@ namespace {
 class AtomicCounter {
  private:
   port::Mutex mu_;
-  int count_ GUARDED_BY(mu_);
+  int count_;
  public:
   AtomicCounter() : count_(0) { }
   void Increment() {

--- a/src/leveldb/db/db_test.cc
+++ b/src/leveldb/db/db_test.cc
@@ -29,7 +29,7 @@ namespace {
 class AtomicCounter {
  private:
   port::Mutex mu_;
-  int count_;
+  int count_ GUARDED_BY(mu_);
  public:
   AtomicCounter() : count_(0) { }
   void Increment() {

--- a/src/leveldb/db/fault_injection_test.cc
+++ b/src/leveldb/db/fault_injection_test.cc
@@ -151,9 +151,9 @@ class FaultInjectionTestEnv : public EnvWrapper {
 
  private:
   port::Mutex mutex_;
-  std::map<std::string, FileState> db_file_state_;
-  std::set<std::string> new_files_since_last_dir_sync_;
-  bool filesystem_active_;  // Record flushes, syncs, writes
+  std::map<std::string, FileState> db_file_state_ GUARDED_BY(mutex_);
+  std::set<std::string> new_files_since_last_dir_sync_ GUARDED_BY(mutex_);
+  bool filesystem_active_ GUARDED_BY(mutex_);  // Record flushes, syncs, writes
 };
 
 TestWritableFile::TestWritableFile(const FileState& state,

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2052,10 +2052,7 @@ void CConnman::ThreadMessageHandler()
             if (flagInterruptMsgProc)
                 return;
             // Send messages
-            {
-                LOCK(pnode->cs_sendProcessing);
-                m_msgproc->SendMessages(pnode);
-            }
+            m_msgproc->SendMessages(pnode);
 
             if (flagInterruptMsgProc)
                 return;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2026,12 +2026,8 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     }
 }
 
-Mutex NetEventsInterface::g_msgproc_mutex;
-
 void CConnman::ThreadMessageHandler()
 {
-    LOCK(NetEventsInterface::g_msgproc_mutex);
-
     while (!flagInterruptMsgProc)
     {
         std::vector<CNode*> vNodesCopy;

--- a/src/net.h
+++ b/src/net.h
@@ -625,11 +625,11 @@ public:
     size_t nSendOffset; // offset inside the first vSendMsg already sent
     uint64_t nSendBytes;
     std::deque<std::vector<unsigned char>> vSendMsg;
-    RecursiveMutex cs_vSend;
-    RecursiveMutex cs_hSocket;
-    RecursiveMutex cs_vRecv;
+    Mutex cs_vSend;
+    Mutex cs_hSocket;
+    Mutex cs_vRecv;
 
-    RecursiveMutex cs_vProcessMsg;
+    Mutex cs_vProcessMsg;
     std::list<CNetMessage> vProcessMsg;
     size_t nProcessQueueSize;
 
@@ -670,7 +670,7 @@ public:
     bool fRelayTxes; //protected by cs_filter
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
-    RecursiveMutex cs_filter;
+   Mutex cs_filter;
     std::unique_ptr<CBloomFilter> pfilter;
     std::atomic<int> nRefCount;
 

--- a/src/net.h
+++ b/src/net.h
@@ -476,9 +476,6 @@ struct CombinerAll
 class NetEventsInterface
 {
 public:
-    /** Mutex for anything that is only accessed via the msg processing thread */
-    static Mutex g_msgproc_mutex;
-
     virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
     virtual bool SendMessages(CNode* pnode) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -394,7 +394,7 @@ private:
     std::vector<ListenSocket> vhListenSocket;
     std::atomic<bool> fNetworkActive;
     banmap_t setBanned;
-    Mutex cs_setBanned;
+    RecursiveMutex cs_setBanned;
     bool setBannedIsDirty;
     bool fAddressesInitialized;
     CAddrMan addrman;
@@ -629,10 +629,10 @@ public:
     uint64_t nSendBytes;
     std::deque<std::vector<unsigned char>> vSendMsg;
     RecursiveMutex cs_vSend;
-    Mutex cs_hSocket;
+    RecursiveMutex cs_hSocket;
     RecursiveMutex cs_vRecv;
 
-    Mutex cs_vProcessMsg;
+    RecursiveMutex cs_vProcessMsg;
     std::list<CNetMessage> vProcessMsg;
     size_t nProcessQueueSize;
 
@@ -673,7 +673,7 @@ public:
     bool fRelayTxes; //protected by cs_filter
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
-    Mutex cs_filter;
+    RecursiveMutex cs_filter;
     std::unique_ptr<CBloomFilter> pfilter;
     std::atomic<int> nRefCount;
 
@@ -706,7 +706,7 @@ public:
     // There is no final sorting before sending, as they are always sent immediately
     // and in the order requested.
     std::vector<uint256> vInventoryBlockToSend;
-    Mutex cs_inventory;
+    RecursiveMutex cs_inventory;
     std::set<uint256> setAskFor;
     std::multimap<int64_t, CInv> mapAskFor;
     int64_t nNextInvSend;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -57,7 +57,7 @@ public:
     * @param[in]   pto             The node which we are sending messages to.
     * @return                      True if there is more work to be done
     */
-    bool SendMessages(CNode* pto) override EXCLUSIVE_LOCKS_REQUIRED(pto->cs_sendProcessing);
+    bool SendMessages(CNode* pto) override;
 
     /** Consider evicting an outbound peer based on the amount of time they've been behind our tip */
     void ConsiderEviction(CNode *pto, int64_t time_in_seconds);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -26,9 +26,9 @@
 #endif
 
 // Settings
-static proxyType proxyInfo[NET_MAX];
-static proxyType nameProxy;
-static CCriticalSection cs_proxyInfos;
+static Mutex cs_proxyInfos;
+static proxyType proxyInfo[NET_MAX] GUARDED_BY(cs_proxyInfos);
+static proxyType nameProxy GUARDED_BY(cs_proxyInfos);
 int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 bool fNameLookup = DEFAULT_NAME_LOOKUP;
 

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -263,7 +263,7 @@ private:
     std::vector<double> buckets;              // The upper-bound of the range for the bucket (inclusive)
     std::map<double, unsigned int> bucketMap; // Map of bucket upper-bound to index into all vectors by bucket
 
-    mutable CCriticalSection cs_feeEstimator;
+    mutable RecursiveMutex cs_feeEstimator;
 
     /** Process a transaction confirmed in a block*/
     bool processBlockTx(unsigned int nBlockHeight, const CTxMemPoolEntry* entry);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -348,7 +348,7 @@ void GetOSRand(unsigned char *ent32)
 namespace {
 
 class RNGState {
-    CCriticalSection m_mutex;
+    Mutex m_mutex;
     /* The RNG state consists of 256 bits of entropy, taken from the output of
      * one operation's SHA512 output, and fed as input to the next one.
      * Carrying 256 bits of entropy should be sufficient to guarantee
@@ -361,7 +361,7 @@ class RNGState {
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;
 
-    CCriticalSection m_events_mutex;
+    Mutex m_events_mutex;
     CSHA256 m_events_hasher GUARDED_BY(m_events_mutex);
 
 public:

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -164,7 +164,7 @@ static UniValue getbestblockhash(const JSONRPCRequest& request)
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex * pindex)
 {
     if(pindex) {
-        std::lock_guard<std::mutex> lock(cs_blockchange);
+        LOCK(cs_blockchange);
         latestblock.hash = pindex->GetBlockHash();
         latestblock.height = pindex->nHeight;
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -657,14 +657,6 @@ static UniValue submitblock(const JSONRPCRequest& request)
         }
     }
 
-    {
-        LOCK(cs_main);
-        const CBlockIndex* pindex = LookupBlockIndex(block.hashPrevBlock);
-        if (pindex) {
-            UpdateUncommittedBlockStructures(block, pindex, Params().GetConsensus());
-        }
-    }
-
     bool new_block;
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -23,7 +23,7 @@
 #include <memory> // for unique_ptr
 #include <unordered_map>
 
-static CCriticalSection cs_rpcWarmup;
+static Mutex cs_rpcWarmup;
 static bool fRPCRunning = false;
 static bool fRPCInWarmup GUARDED_BY(cs_rpcWarmup) = true;
 static std::string rpcWarmupStatus GUARDED_BY(cs_rpcWarmup) = "RPC server started";

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -79,11 +79,11 @@ public:
 private:
     std::multimap<std::chrono::system_clock::time_point, Function> taskQueue;
     std::condition_variable newTaskScheduled;
-    mutable std::mutex newTaskMutex;
+    mutable Mutex newTaskMutex;
     int nThreadsServicingQueue;
     bool stopRequested;
     bool stopWhenEmpty;
-    bool shouldStop() const { return stopRequested || (stopWhenEmpty && taskQueue.empty()); }
+    bool shouldStop() const{ return stopRequested || (stopWhenEmpty && taskQueue.empty()); }
 };
 
 /**
@@ -100,9 +100,9 @@ class SingleThreadedSchedulerClient {
 private:
     CScheduler *m_pscheduler;
 
-    CCriticalSection m_cs_callbacks_pending;
-    std::list<std::function<void (void)>> m_callbacks_pending GUARDED_BY(m_cs_callbacks_pending);
-    bool m_are_callbacks_running GUARDED_BY(m_cs_callbacks_pending) = false;
+    Mutex m_cs_callbacks_pending;
+    std::list<std::function<void (void)>> m_callbacks_pending;
+    bool m_are_callbacks_running = false;
 
     void MaybeScheduleProcessQueue();
     void ProcessQueue();

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -64,7 +64,7 @@ typedef std::set<std::pair<void*, void*> > InvLockOrders;
 struct LockData {
     // Very ugly hack: as the global constructs and destructors run single
     // threaded, we use this boolean to know whether LockData still exists,
-    // as DeleteLock can get called by global CCriticalSection destructors
+    // as DeleteLock can get called by global Mutex destructors
     // after LockData disappears.
     bool available;
     LockData() : available(true) {}

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -41,16 +41,19 @@ public:
 
     CAddrInfo* Find(const CNetAddr& addr, int* pnId = nullptr)
     {
+        LOCK(cs);
         return CAddrMan::Find(addr, pnId);
     }
 
     CAddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId = nullptr)
     {
+        LOCK(cs);
         return CAddrMan::Create(addr, addrSource, pnId);
     }
 
     void Delete(int nId)
     {
+        LOCK(cs);
         CAddrMan::Delete(nId);
     }
 
@@ -58,7 +61,10 @@ public:
     void SimConnFail(CService& addr)
     {
          int64_t nLastSuccess = 1;
-         Good_(addr, true, nLastSuccess); // Set last good connection in the deep past.
+         {
+            LOCK(cs);
+            Good_(addr, true, nLastSuccess); // Set last good connection in the deep past.
+         }
 
          bool count_failure = false;
          int64_t nLastTry = GetAdjustedTime()-61;

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -76,7 +76,8 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
         peerLogic->SendMessages(&dummyNode1); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(cs_main);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
         dummyNode1.vSendMsg.clear();
     }
@@ -89,7 +90,8 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
         peerLogic->SendMessages(&dummyNode1); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(cs_main);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
     }
     // Wait 3 more minutes

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -56,6 +56,7 @@ BOOST_FIXTURE_TEST_SUITE(denialofservice_tests, TestingSetup)
 // work.
 BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 {
+    LOCK(NetEventsInterface::g_msgproc_mutex);
 
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -287,6 +288,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
+    LOCK(NetEventsInterface::g_msgproc_mutex);
 
     connman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -56,8 +56,6 @@ BOOST_FIXTURE_TEST_SUITE(denialofservice_tests, TestingSetup)
 // work.
 BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 {
-    LOCK(NetEventsInterface::g_msgproc_mutex);
-
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(id++, ServiceFlags(NODE_NETWORK|NODE_WITNESS), 0, INVALID_SOCKET, addr1, 0, 0, CAddress(), "", /*fInboundIn=*/ false);
@@ -288,8 +286,6 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
-    LOCK(NetEventsInterface::g_msgproc_mutex);
-
     connman->ClearBanned();
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -24,6 +24,7 @@ public:
     //! Ensure that bucket placement is always the same for testing purposes.
     void MakeDeterministic()
     {
+        LOCK(cs);
         nKey.SetNull();
         insecure_rand = FastRandomContext(true);
     }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -26,7 +26,7 @@ BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
 {
-    CCriticalSection cs;
+    Mutex cs;
 
     do {
         LOCK(cs);

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -16,7 +16,7 @@
 #include <warnings.h>
 
 
-static CCriticalSection cs_nTimeOffset;
+static Mutex cs_nTimeOffset;
 static int64_t nTimeOffset GUARDED_BY(cs_nTimeOffset) = 0;
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -444,12 +444,12 @@ private:
     unsigned int nTransactionsUpdated; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
     CBlockPolicyEstimator* minerPolicyEstimator;
 
-    uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
+    uint64_t totalTxSize GUARDED_BY(cs);      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
-    mutable int64_t lastRollingFeeUpdate;
-    mutable bool blockSinceLastRollingFeeBump;
-    mutable double rollingMinimumFeeRate; //!< minimum fee to get into the pool, decreases exponentially
+    mutable int64_t lastRollingFeeUpdate GUARDED_BY(cs);
+    mutable bool blockSinceLastRollingFeeBump GUARDED_BY(cs);
+    mutable double rollingMinimumFeeRate GUARDED_BY(cs); //!< minimum fee to get into the pool, decreases exponentially
 
     void trackPackageRemoved(const CFeeRate& rate) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
@@ -483,7 +483,7 @@ public:
         >
     > indexed_transaction_set;
 
-    mutable CCriticalSection cs;
+    mutable RecursiveMutex cs;
     indexed_transaction_set mapTx GUARDED_BY(cs);
 
     using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
@@ -516,7 +516,7 @@ private:
 
 public:
     indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
-    std::map<uint256, CAmount> mapDeltas;
+    std::map<uint256, CAmount> mapDeltas GUARDED_BY(cs);
 
     /** Create a new CTxMemPool.
      */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -176,7 +176,6 @@ public:
      *  See also comments around ArgsManager::ArgsManager() below. */
     static inline bool UseDefaultSection(const ArgsManager& am, const std::string& arg)
     {
-        LOCK(am.cs_args);
         return (am.m_network == TAPYRUS_MODES::PROD || am.m_network_only_args.count(arg) == 0);
     }
 
@@ -336,7 +335,6 @@ void ArgsManager::WarnForSectionOnlyArgs()
 
     // if it's okay to use the default section for this network, don't worry
     if (m_network == TAPYRUS_MODES::PROD) return;
-    LOCK(cs_args);
 
     for (const auto& arg : m_network_only_args) {
         std::pair<bool, std::string> found_result;
@@ -427,7 +425,6 @@ bool ArgsManager::IsArgKnown(const std::string& key) const
     } else {
         arg_no_net = std::string("-") + key.substr(option_index + 1, std::string::npos);
     }
-    LOCK(cs_args);
 
     for (const auto& arg_map : m_available_args) {
         if (arg_map.second.count(arg_no_net)) return true;
@@ -545,7 +542,6 @@ void ArgsManager::AddArg(const std::string& name, const std::string& help, const
     if (eq_index == std::string::npos) {
         eq_index = name.size();
     }
-    LOCK(cs_args);
     std::map<std::string, Arg>& arg_map = m_available_args[cat];
     auto ret = arg_map.emplace(name.substr(0, eq_index), Arg(name.substr(eq_index, name.size() - eq_index), help, debug_only));
     assert(ret.second); // Make sure an insertion actually happened
@@ -562,7 +558,6 @@ std::string ArgsManager::GetHelpMessage() const
 {
     const bool show_debug = gArgs.GetBoolArg("-help-debug", false);
 
-    LOCK(cs_args);
     std::string usage = "";
     for (const auto& arg_map : m_available_args) {
         switch(arg_map.first) {
@@ -876,7 +871,6 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
         }
         // if there is an -includeconf in the override args, but it is empty, that means the user
         // passed '-noincludeconf' on the command line, in which case we should not include anything
-            LOCK(cs_args);
             if (m_override_args.count("-includeconf") == 0) {
             std::string chain_id = TAPYRUS_MODES::GetChainName( GetChainMode());
             std::vector<std::string> includeconf(GetArgs("-includeconf"));
@@ -889,8 +883,11 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
 
             // Remove -includeconf from configuration, so we can warn about recursion
             // later
-            m_config_args.erase("-includeconf");
-            m_config_args.erase(std::string("-") + chain_id + ".includeconf");
+            {
+                LOCK(cs_args);
+                m_config_args.erase("-includeconf");
+                m_config_args.erase(std::string("-") + chain_id + ".includeconf");
+            }
 
 
             for (const std::string& to_include : includeconf) {

--- a/src/util.h
+++ b/src/util.h
@@ -158,11 +158,11 @@ protected:
     };
 
     mutable RecursiveMutex cs_args;
-    std::map<std::string, std::vector<std::string>> m_override_args GUARDED_BY(cs_args);
-    std::map<std::string, std::vector<std::string>> m_config_args GUARDED_BY(cs_args);
+    std::map<std::string, std::vector<std::string>> m_override_args;
+    std::map<std::string, std::vector<std::string>> m_config_args;
     std::string m_network;
-    std::set<std::string> m_network_only_args GUARDED_BY(cs_args);
-    std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
+    std::set<std::string> m_network_only_args;
+    std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args;
 
     bool ReadConfigStream(std::istream& stream, std::string& error, bool ignore_invalid_keys = false);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2700,8 +2700,6 @@ bool ActivateBestChain(CValidationState &state, std::shared_ptr<const CBlock> pb
 
 bool CChainState::PreciousBlock(CValidationState& state, CBlockIndex *pindex)
 {
-    AssertLockNotHeld(m_cs_chainstate);
-    AssertLockNotHeld(::cs_main);
     {
         LOCK(cs_main);
         if (pindex->nHeight < chainActive.Tip()->nHeight) {
@@ -2734,9 +2732,6 @@ bool PreciousBlock(CValidationState& state, CBlockIndex *pindex) {
 
 bool CChainState::InvalidateBlock(CValidationState& state, CBlockIndex *pindex)
 {
-    AssertLockNotHeld(m_cs_chainstate);
-    AssertLockNotHeld(::cs_main);
-
     // We first disconnect backwards and then mark the blocks as invalid.
     // This prevents a case where pruned nodes may fail to invalidateblock
     // and be left unable to start as they have no tip candidates (as there
@@ -3268,7 +3263,6 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
 // Exposed wrapper for AcceptBlockHeader
 bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidationState& state, const CBlockIndex** ppindex, CBlockHeader *first_invalid)
 {
-    AssertLockNotHeld(cs_main);
     // initialize temp xfield history with the global list
     // temp list is used until we finish processing this headers message
     CTempXFieldHistory tempFieldHistory;

--- a/src/validation.h
+++ b/src/validation.h
@@ -146,7 +146,7 @@ struct BlockHasher
 };
 
 extern CScript COINBASE_FLAGS;
-extern CCriticalSection cs_main;
+extern RecursiveMutex cs_main;
 extern CBlockPolicyEstimator feeEstimator;
 extern CTxMemPool mempool;
 extern std::atomic_bool g_is_mempool_loaded;
@@ -155,7 +155,7 @@ extern BlockMap& mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;
 extern const std::string strMessageMagic;
-extern CWaitableCriticalSection g_best_block_mutex;
+extern Mutex g_best_block_mutex;
 extern CConditionVariable g_best_block_cv;
 extern uint256 g_best_block;
 extern std::atomic_bool fImporting;
@@ -388,9 +388,6 @@ bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex
 
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex();
-
-/** Update uncommitted block structures (currently: only the witness reserved value). This is safe for submitted blocks. */
-void UpdateUncommittedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB {

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -52,7 +52,7 @@ void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filena
     }
 }
 
-Mutex cs_db;
+RecursiveMutex cs_db;
 std::map<std::string, BerkeleyEnvironment> g_dbenvs GUARDED_BY(cs_db); //!< Map from directory name to open db environment.
 } // namespace
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -52,7 +52,7 @@ void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filena
     }
 }
 
-CCriticalSection cs_db;
+Mutex cs_db;
 std::map<std::string, BerkeleyEnvironment> g_dbenvs GUARDED_BY(cs_db); //!< Map from directory name to open db environment.
 } // namespace
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -66,7 +66,7 @@ static std::string DecodeDumpString(const std::string &str) {
     return ret.str();
 }
 
-static bool GetWalletAddressesForKey(CWallet * const pwallet, const CKeyID &keyid, std::string &strAddr, std::string &strLabel)
+static bool GetWalletAddressesForKey(CWallet * const pwallet, const CKeyID &keyid, std::string &strAddr, std::string &strLabel) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     bool fLabelFound = false;
     CKey key;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -39,7 +39,7 @@
 
 static const size_t OUTPUT_GROUP_MAX_ENTRIES = 10;
 
-static CCriticalSection cs_wallets;
+static RecursiveMutex cs_wallets;
 static std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
 
 bool AddWallet(const std::shared_ptr<CWallet>& wallet)
@@ -1846,6 +1846,7 @@ bool CWalletTx::RelayWalletTransaction(CConnman* connman)
 
 std::set<uint256> CWalletTx::GetConflicts() const
 {
+    LOCK(pwallet->cs_wallet);
     std::set<uint256> result;
     if (pwallet != nullptr)
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -771,7 +771,7 @@ public:
      * Main wallet lock.
      * This lock protects all the fields added by CWallet.
      */
-    mutable CCriticalSection cs_wallet;
+    mutable RecursiveMutex cs_wallet;
 
     /** Get database handle used by this wallet. Ideally this function would
      * not be necessary.
@@ -939,7 +939,7 @@ public:
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
-    void LoadToWallet(const CWalletTx& wtxIn);
+    void LoadToWallet(const CWalletTx& wtxIn) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
@@ -1090,7 +1090,7 @@ public:
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
-    std::set<uint256> GetConflicts(const uint256& txid) const;
+    std::set<uint256> GetConflicts(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Check if a given transaction has any of its outputs spent by another transaction in the wallet
     bool HasWalletSpend(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -8,7 +8,7 @@
 #include <util.h>
 #include <warnings.h>
 
-CCriticalSection cs_warnings;
+Mutex cs_warnings;
 std::string strMiscWarning GUARDED_BY(cs_warnings);
 bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
 bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;


### PR DESCRIPTION
Changed CCriticalSections to Mutex and RecursiveMutex as in Bitcoin. 

Add GUARDED_BY and EXCLUSIVE_LOCK_REQUIRED annotations to some shared data only. 
  Adding them to all shared data and functions caused lots of build errors on macOS. Clang supports static analysis for thread safety with option -thread-safety-analysis. But this does not seem to be strong enough to identify scope. i.e. when lock is outside a class or a function where the data is accessed. As most of our data and locks are global, and locking is in the outer scope, it causes lots of false positives. Adding more LOCKS in the same scope to pass the compilation warning causes deadlock in our tests. 