### PR TITLE
Update build-osx.md

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -29,7 +29,7 @@ To build tapyrus-qt GUI install the following along with the above
 
 If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
 
-    brew install librsvg xorriso
+    brew install librsvg
 
 See [dependencies.md](dependencies.md) for a complete overview.
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -29,7 +29,7 @@ To build tapyrus-qt GUI install the following along with the above
 
 If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
 
-    brew install librsvg xorrisofs
+    brew install librsvg xorriso
 
 See [dependencies.md](dependencies.md) for a complete overview.
 


### PR DESCRIPTION
Reason: In my mac show this warning.

```
tapyrus-core % brew install librsvg xorriso xorrisofs
Warning: No available formula with the name "xorrisofs". Did you mean xorriso?
==> Searching for similarly named formulae and casks...
==> Formulae
xorriso

To install xorriso, run:
  brew install xorriso
```