### PR TITLE
Block height is changed to 32 bit from 64 bit

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -62,7 +62,7 @@ public:
 
     /** Default value for -checkmempool and -checkblockindex argument */
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
-    uint64_t PruneAfterHeight() const { return nPruneAfterHeight; }
+    uint32_t PruneAfterHeight() const { return nPruneAfterHeight; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** Return true if the fallback fee is by default enabled for this network */
@@ -79,7 +79,7 @@ protected:
     Consensus::Params consensus;
     int rpcPort;
     int nDefaultPort;
-    uint64_t nPruneAfterHeight;
+    uint32_t nPruneAfterHeight;
     bool fDefaultConsistencyChecks;
     bool fMineBlocksOnDemand;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -906,7 +906,7 @@ static UniValue pruneblockchain(const JSONRPCRequest& request)
     }
 
     PruneBlockFilesManual(height);
-    return uint64_t(height);
+    return UniValue(height);
 }
 
 static UniValue gettxoutsetinfo(const JSONRPCRequest& request)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -623,7 +623,7 @@ static UniValue getblockhash(const JSONRPCRequest& request)
 
     LOCK(cs_main);
 
-    int nHeight = request.params[0].get_int();
+    uint32_t nHeight = request.params[0].get_int();
     if (nHeight < 0 || nHeight > chainActive.Height())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -45,8 +45,8 @@ unsigned int ParseConfirmTarget(const UniValue& value)
 
 UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, bool keepScript, const CKey& privKey)
 {
-    int nHeightEnd = 0;
-    int nHeight = 0;
+    uint32_t nHeightEnd = 0;
+    uint32_t nHeight = 0;
 
     {   // Don't keep cs_main locked
         LOCK(cs_main);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -587,7 +587,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("sizelimit", (int64_t)GetCurrentMaxBlockSize());
     result.pushKV("curtime", pblock->GetBlockTime());
     result.pushKV("proof", HexStr(pblock->proof));
-    result.pushKV("height", (int64_t)(pindexPrev->nHeight+1));
+    result.pushKV("height", (pindexPrev->nHeight+1));
 
     if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {
         result.pushKV("default_witness_commitment", HexStr(pblocktemplate->vchCoinbaseCommitment.begin(), pblocktemplate->vchCoinbaseCommitment.end()));

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
         std::vector<uint256> vTxid(nTx, uint256());
         for (unsigned int j=0; j<nTx; j++)
             vTxid[j] = block.vtx[j]->GetHashMalFix();
-        int nHeight = 1, nTx_ = nTx;
+        uint32_t nHeight = 1, nTx_ = nTx;
         while (nTx_ > 1) {
             nTx_ = (nTx_+1)/2;
             nHeight++;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -627,7 +627,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     uint64_t innerUsage = 0;
 
     CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(pcoins));
-    const int64_t spendheight = GetSpendHeight(mempoolDuplicate);
+    const int32_t spendheight = GetSpendHeight(mempoolDuplicate);
 
     std::list<const CTxMemPoolEntry*> waitingOnDependants;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -34,6 +34,9 @@ public:
     UniValue(bool val_) {
         setBool(val_);
     }
+    UniValue(uint32_t val_) {
+        setInt((uint64_t)val_);
+    }
     UniValue(int val_) {
         setInt(val_);
     }

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -133,7 +133,11 @@ public:
         UniValue tmpVal((bool)val_);
         return pushKV(key, tmpVal);
     }
-    bool pushKV(const std::string& key, int val_) {
+    bool pushKV(const std::string& key, uint32_t val_) {
+        UniValue tmpVal((uint64_t)val_);
+        return pushKV(key, tmpVal);
+    }
+    bool pushKV(const std::string& key, int32_t val_) {
         UniValue tmpVal((int64_t)val_);
         return pushKV(key, tmpVal);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4653,7 +4653,7 @@ bool isBlockHeightInCoinbase(const CBlock& block)
     if(pindex->nHeight == 0)
         return true;
 
-    uint64_t blockHeight = block.GetHeight();
+    uint32_t blockHeight = block.GetHeight();
 
     if(block.GetHash() == pindex->GetBlockHash() && blockHeight != (uint32_t)pindex->nHeight)
         return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -310,7 +310,7 @@ enum class FlushStateMode {
 // See definition for documentation
 static bool FlushStateToDisk(CValidationState &state, FlushStateMode mode, int nManualPruneHeight=0);
 static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPruneHeight);
-static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight);
+static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint32_t nPruneAfterHeight);
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, TxColoredCoinBalancesMap& inColoredCoinBalances, std::vector<CScriptCheck> *pvChecks = nullptr);
 static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 
@@ -1232,7 +1232,7 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, int nHeight)
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex)
 {
     CDiskBlockPos blockPos;
-    uint64_t height = 0;
+    uint32_t height = 0;
     {
         LOCK(cs_main);
         blockPos = pindex->GetBlockPos();
@@ -3542,13 +3542,13 @@ void PruneBlockFilesManual(int nManualPruneHeight)
  *
  * @param[out]   setFilesToPrune   The set of file indices that can be unlinked will be returned
  */
-static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight)
+static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint32_t nPruneAfterHeight)
 {
     LOCK2(cs_main, cs_LastBlockFile);
     if (chainActive.Tip() == nullptr || nPruneTarget == 0) {
         return;
     }
-    if ((uint64_t)chainActive.Tip()->nHeight <= nPruneAfterHeight) {
+    if (chainActive.Tip()->nHeight <= nPruneAfterHeight) {
         return;
     }
 

--- a/src/xfieldhistory.cpp
+++ b/src/xfieldhistory.cpp
@@ -61,7 +61,7 @@ void CXFieldHistory::ToUniValue(TAPYRUS_XFIELDTYPES type, UniValue* xFieldChange
     {
         UniValue xFieldChangeObj(UniValue::VOBJ);
         std::string value = XFieldDataToString(xFieldChange.xfieldValue);
-        xFieldChangeObj.pushKV(value, (uint64_t)xFieldChange.height);
+        xFieldChangeObj.pushKV(value, xFieldChange.height);
         xFieldChangeUnival->push_back(xFieldChangeObj);
     }
 }


### PR DESCRIPTION
Only RPCs in Tapyrus-core use 64 bit block height This was because univalve supported only uint64_t and not uint32_t. Now this is updated 

Other layers like block index, utxo cache,  chain state and wallet refer to block height as "int". These are not changed. Height is initialised to -1 to identify that it's invalid. most logic in the block validation depends on this initial value. This part is not changed 