### PR TITLE
Refactor only - simplify AcceptToMempool argument list

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -119,8 +119,9 @@ static void AssembleBlock(benchmark::State& state)
         LOCK(::cs_main); // Required for ::AcceptToMemoryPool.
 
         for (const auto& txr : txs) {
-            CValidationState state;
-            bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, true /* bypass_limits */, /* nAbsurdFee */ 0)};
+            CTxMempoolAcceptanceOptions opt;
+            opt.flags = MempoolAcceptanceFlags::BYPASSS_LIMITS;
+            bool ret{::AcceptToMemoryPool(txr, opt)};
             assert(ret);
         }
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2214,7 +2214,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                         }
                         vEraseQueue.push_back(orphanHash);
                     }
-                    else if (opt2.missingInputs.size())
+                    else if (!opt2.missingInputs.size())
                     {
                         int nDos = 0;
                         if (opt2.state.IsInvalid(nDos) && nDos > 0)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2169,7 +2169,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         mapAlreadyAskedFor.erase(inv.hash);
 
         CTxMempoolAcceptanceOptions opt;
-        CValidationState& state = opt.state;
         if (!AlreadyHave(inv) &&
             AcceptToMemoryPool(ptx, opt)) {
             mempool.check(pcoinsTip.get());
@@ -2203,12 +2202,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     // Use a dummy CValidationState so someone can't setup nodes to counter-DoS based on orphan
                     // resolution (that is, feeding people an invalid transaction based on LegitTxX in order to get
                     // anyone relaying LegitTxX banned)
-                    CValidationState& stateDummy = opt.state;
 
                     if (setMisbehaving.count(fromPeer))
                         continue;
-                    CTxMempoolAcceptanceOptions opt;
-                    if (AcceptToMemoryPool(porphanTx, opt)) {
+                    CTxMempoolAcceptanceOptions opt2;
+                    if (AcceptToMemoryPool(porphanTx, opt2)) {
                         LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
                         RelayTransaction(orphanTx, connman);
                         for (unsigned int i = 0; i < orphanTx.vout.size(); i++) {
@@ -2216,10 +2214,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                         }
                         vEraseQueue.push_back(orphanHash);
                     }
-                    else if (opt.missingInputs.size())
+                    else if (opt2.missingInputs.size())
                     {
                         int nDos = 0;
-                        if (stateDummy.IsInvalid(nDos) && nDos > 0)
+                        if (opt2.state.IsInvalid(nDos) && nDos > 0)
                         {
                             // Punish peer that gave us an invalid orphan tx
                             Misbehaving(fromPeer, nDos);
@@ -2230,7 +2228,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                         // Probably non-standard or insufficient fee
                         LogPrint(BCLog::MEMPOOL, "   removed orphan tx %s\n", orphanHash.ToString());
                         vEraseQueue.push_back(orphanHash);
-                        if (!orphanTx.HasWitness() && !stateDummy.CorruptionPossible()) {
+                        if (!orphanTx.HasWitness() && !opt2.state.CorruptionPossible()) {
                             // Do not use rejection cache for witness transactions or
                             // witness-stripped transactions, as they can have been malleated.
                             // See https://github.com/bitcoin/bitcoin/issues/8279 for details.
@@ -2275,7 +2273,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 recentRejects->insert(tx.GetHashMalFix());
             }
         } else {
-            if (!tx.HasWitness() && !state.CorruptionPossible()) {
+            if (!tx.HasWitness() && !opt.state.CorruptionPossible()) {
                 // Do not use rejection cache for witness transactions or
                 // witness-stripped transactions, as they can have been malleated.
                 // See https://github.com/bitcoin/bitcoin/issues/8279 for details.
@@ -2298,11 +2296,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 // score for, as we expect peers to do the same with us in that
                 // case.
                 int nDoS = 0;
-                if (!state.IsInvalid(nDoS) || nDoS == 0) {
+                if (!opt.state.IsInvalid(nDoS) || nDoS == 0) {
                     LogPrintf("Force relaying tx %s from whitelisted peer=%d\n", tx.GetHashMalFix().ToString(), pfrom->GetId());
                     RelayTransaction(tx, connman);
                 } else {
-                    LogPrintf("Not relaying invalid transaction %s from whitelisted peer=%d (%s)\n", tx.GetHashMalFix().ToString(), pfrom->GetId(), FormatStateMessage(state));
+                    LogPrintf("Not relaying invalid transaction %s from whitelisted peer=%d (%s)\n", tx.GetHashMalFix().ToString(), pfrom->GetId(), FormatStateMessage(opt.state));
                 }
             }
         }
@@ -2315,10 +2313,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         {
             LogPrint(BCLog::MEMPOOLREJ, "%s from peer=%d was not accepted: %s\n", tx.GetHashMalFix().ToString(),
                 pfrom->GetId(),
-                FormatStateMessage(state));
-            if (state.GetRejectCode() > 0 && state.GetRejectCode() < REJECT_INTERNAL) { // Never send AcceptToMemoryPool's internal codes over P2P
-                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::REJECT, strCommand, (unsigned char)state.GetRejectCode(),
-                                   state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash));
+                FormatStateMessage(opt.state));
+            if (opt.state.GetRejectCode() > 0 && opt.state.GetRejectCode() < REJECT_INTERNAL) { // Never send AcceptToMemoryPool's internal codes over P2P
+                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::REJECT, strCommand, (unsigned char)opt.state.GetRejectCode(),
+                                   opt.state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash));
             }
             if (nDoS > 0) {
                 Misbehaving(pfrom->GetId(), nDoS);

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -29,9 +29,9 @@ ToMemPool(const CMutableTransaction& tx)
 {
     LOCK(cs_main);
 
-    CValidationState state;
-    return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), nullptr /* pfMissingInputs */,
-                              nullptr /* plTxnReplaced */, true /* bypass_limits */, 0 /* nAbsurdFee */);
+    CTxMempoolAcceptanceOptions opt;
+    opt.flags = MempoolAcceptanceFlags::BYPASSS_LIMITS;
+    return AcceptToMemoryPool(MakeTransactionRef(tx), opt);
 }
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChainSetup)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -21,6 +21,7 @@
 #include <primitives/transaction.h>
 #include <sync.h>
 #include <random.h>
+#include <consensus/validation.h>
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -128,6 +129,39 @@ public:
     int32_t GetSigOpCostWithAncestors() const { return nSigOpCostWithAncestors; }
 
     mutable size_t vTxHashesIdx; //!< Index in mempool's vTxHashes
+};
+
+/* is the tx validation stand alone or part of a bigger entity */
+enum class ValidationContext {
+    TRANSACTION,
+    BLOCK,
+    INDEX,
+    PACKAGE
+};
+
+/* Options to change the behaviour of Accept to mempool
+* these are intended to be consolidated in one integer as flag
+* int flags = BYPASSS_LIMITS | TEST_ONLY
+*/
+enum class MempoolAcceptanceFlags
+{
+    NONE = 0,
+    BYPASSS_LIMITS = 1,
+    TEST_ONLY = 2
+};
+
+/* All configurable inputs and outputs of accept to mempool are consolidated here for ease of use*/
+struct CTxMempoolAcceptanceOptions {
+    ValidationContext context;
+    MempoolAcceptanceFlags flags;
+    CAmount nAbsurdFee;
+    CValidationState state;
+    int64_t nAcceptTime;
+    std::vector<CTransactionRef> txnReplaced;
+    std::vector<COutPoint> coins_to_uncache;
+    std::vector<COutPoint> missingInputs;
+
+    CTxMempoolAcceptanceOptions():context(ValidationContext::TRANSACTION), flags(MempoolAcceptanceFlags::NONE),nAbsurdFee(0), nAcceptTime(0){}
 };
 
 // Helpers for modifying CTxMemPool::mapTx, which is a boost multi_index.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -438,9 +438,6 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp, bool 
     return EvaluateSequenceLocks(index, lockPair);
 }
 
-// Returns the script flags which should be checked for a given block
-static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex);
-
 static void LimitMempoolSize(CTxMemPool& pool, size_t limit, unsigned long age) {
     int expired = pool.Expire(GetTime() - age);
     if (expired != 0) {
@@ -500,10 +497,10 @@ static void UpdateMempoolForReorg(DisconnectedBlockTransactions &disconnectpool,
     auto it = disconnectpool.queuedTx.get<insertion_order>().rbegin();
     while (it != disconnectpool.queuedTx.get<insertion_order>().rend()) {
         // ignore validation errors in resurrected transactions
-        CValidationState stateDummy;
+        CTxMempoolAcceptanceOptions opt;
+        opt.flags = MempoolAcceptanceFlags::BYPASSS_LIMITS;
         if (!fAddToMempool || (*it)->IsCoinBase() ||
-            !AcceptToMemoryPool(mempool, stateDummy, *it, nullptr /* pfMissingInputs */,
-                                nullptr /* plTxnReplaced */, true /* bypass_limits */, 0 /* nAbsurdFee */)) {
+            !AcceptToMemoryPool(*it, opt) ){
             // If the transaction doesn't make it in to the mempool, remove any
             // transactions that depend on it (which would now be orphans).
             mempool.removeRecursive(**it, MemPoolRemovalReason::REORG);
@@ -631,17 +628,19 @@ bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& stat
     return true;
 }
 
-static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const CTransactionRef& ptx,
-                              bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                              bool bypass_limits, const CAmount& nAbsurdFee, std::vector<COutPoint>& coins_to_uncache, bool test_accept)
+static bool AcceptToMemoryPoolWorker(const CTransactionRef &ptx, CTxMempoolAcceptanceOptions& opt)
 {
     const CTransaction& tx = *ptx;
     const uint256 hash = tx.GetHashMalFix();
     AssertLockHeld(cs_main);
+
+    //ref to variables in opt
+    CValidationState& state = opt.state;
+    CTxMemPool& pool = mempool;
     LOCK(pool.cs); // mempool "read lock" (held through GetMainSignals().TransactionAddedToMempool())
-    if (pfMissingInputs) {
-        *pfMissingInputs = false;
-    }
+
+    // missing inputs is a vector for package validation
+    opt.missingInputs.clear();
 
     if (!CheckTransaction(tx, state))
         return false; // state filled in by CheckTransaction
@@ -729,7 +728,7 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
         // do all inputs exist?
         for (const CTxIn& txin : tx.vin) {
             if (!pcoinsTip->HaveCoinInCache(txin.prevout)) {
-                coins_to_uncache.push_back(txin.prevout);
+                opt.coins_to_uncache.push_back(txin.prevout);
             }
             if (!view.HaveCoin(txin.prevout)) {
                 // Are inputs missing because we already have the tx?
@@ -740,9 +739,8 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
                     }
                 }
                 // Otherwise assume this might be an orphan tx for which we just haven't seen parents yet
-                if (pfMissingInputs) {
-                    *pfMissingInputs = true;
-                }
+                opt.missingInputs.push_back(txin.prevout);
+
                 return false; // fMissingInputs and !state.IsInvalid() is used to detect this condition, don't set state.Invalid()
             }
         }
@@ -802,7 +800,7 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
             }
         }
 
-        CTxMemPoolEntry entry(ptx, nFees, nAcceptTime, chainActive.Height(),
+        CTxMemPoolEntry entry(ptx, nFees, opt.nAcceptTime, chainActive.Height(),
                               fSpendsCoinbase, nSigOps, lp);
         unsigned int nSize = entry.GetTxSize();
 
@@ -816,19 +814,22 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
                 strprintf("%d", nSigOps));
 
         CAmount mempoolRejectFee = pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nSize);
-        if (!bypass_limits && mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee) {
+        if (opt.flags != MempoolAcceptanceFlags::BYPASSS_LIMITS
+          && mempoolRejectFee > 0
+          && nModifiedFees < mempoolRejectFee) {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool min fee not met", false, strprintf("%d < %d", nModifiedFees, mempoolRejectFee));
         }
 
         // No transactions are allowed below minRelayTxFee except from disconnected blocks
-        if (!bypass_limits && nModifiedFees < ::minRelayTxFee.GetFee(nSize)) {
+        if (opt.flags != MempoolAcceptanceFlags::BYPASSS_LIMITS
+          && nModifiedFees < ::minRelayTxFee.GetFee(nSize)) {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "min relay fee not met", false, strprintf("%d < %d", nModifiedFees, ::minRelayTxFee.GetFee(nSize)));
         }
 
-        if (nAbsurdFee && nFees > nAbsurdFee)
+        if (opt.nAbsurdFee && nFees > opt.nAbsurdFee)
             return state.Invalid(false,
                 REJECT_HIGHFEE, "absurdly-high-fee",
-                strprintf("%d > %d", nFees, nAbsurdFee));
+                strprintf("%d > %d", nFees, opt.nAbsurdFee));
 
         // Calculate in-mempool ancestors, up to a limit.
         CTxMemPool::setEntries setAncestors;
@@ -990,7 +991,6 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
         TxColoredCoinBalancesMap inColoredCoinBalances;
         if (!CheckInputs(tx, state, view, true, scriptVerifyFlags, true, false, txdata, inColoredCoinBalances)) {
 
-
             return false; // state filled in by CheckInputs
         }
 
@@ -1009,8 +1009,7 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
         // There is a similar check in CreateNewBlock() to prevent creating
         // invalid blocks (using TestBlockValidity), however allowing such
         // transactions into the mempool can be exploited as a DoS attack.
-        unsigned int currentBlockScriptVerifyFlags = GetBlockScriptFlags(chainActive.Tip());
-        if (!CheckInputsFromMempoolAndCache(tx, state, view, pool, currentBlockScriptVerifyFlags, true, txdata)) {
+        if (!CheckInputsFromMempoolAndCache(tx, state, view, pool, SCRIPT_VERIFY_NONE, true, txdata)) {
             return error("%s: BUG! PLEASE REPORT THIS! CheckInputs failed against latest-block but not STANDARD flags %s, %s",
                     __func__, hash.ToString(), FormatStateMessage(state));
         }
@@ -1066,7 +1065,8 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
 
         }
 
-        if (test_accept) {
+
+        if (opt.flags == MempoolAcceptanceFlags::TEST_ONLY) {
             // Tx was accepted, but not added
             return true;
         }
@@ -1098,13 +1098,13 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
         // - it's not being re-added during a reorg which bypasses typical mempool fee limits
         // - the node is not behind
         // - the transaction is not dependent on any other transactions in the mempool
-        bool validForFeeEstimation = !fReplacementTransaction && !bypass_limits && IsCurrentForFeeEstimation() && pool.HasNoInputsOf(tx);
+        bool validForFeeEstimation = !fReplacementTransaction && (opt.flags != MempoolAcceptanceFlags::BYPASSS_LIMITS) && IsCurrentForFeeEstimation() && pool.HasNoInputsOf(tx);
 
         // Store transaction in memory
         pool.addUnchecked(hash, entry, setAncestors, validForFeeEstimation);
 
         // trim mempool and check if tx was trimmed
-        if (!bypass_limits) {
+        if (opt.flags != MempoolAcceptanceFlags::BYPASSS_LIMITS) {
             LimitMempoolSize(pool, gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000, gArgs.GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
             if (!pool.exists(hash))
                 return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
@@ -1117,14 +1117,12 @@ static bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, 
 }
 
 /** (try to) add transaction to memory pool with a specified acceptance time **/
-static bool AcceptToMemoryPoolWithTime(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
-                        bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept)
+bool AcceptToMemoryPool(const CTransactionRef &tx, CTxMempoolAcceptanceOptions& opt)
 {
-    std::vector<COutPoint> coins_to_uncache;
-    bool res = AcceptToMemoryPoolWorker(pool, state, tx, pfMissingInputs, nAcceptTime, plTxnReplaced, bypass_limits, nAbsurdFee, coins_to_uncache, test_accept);
+    opt.nAcceptTime = GetTime();
+    bool res = AcceptToMemoryPoolWorker(tx, opt);
     if (!res) {
-        for (const COutPoint& hashTx : coins_to_uncache)
+        for (const COutPoint& hashTx : opt.coins_to_uncache)
             pcoinsTip->Uncache(hashTx);
             TRACE2(mempool, rejected,
                 tx->GetHashMalFix().begin(),
@@ -1135,13 +1133,6 @@ static bool AcceptToMemoryPoolWithTime(CTxMemPool& pool, CValidationState &state
     CValidationState stateDummy;
     FlushStateToDisk(stateDummy, FlushStateMode::PERIODIC);
     return res;
-}
-
-bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
-                        bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept)
-{
-    return AcceptToMemoryPoolWithTime(pool, state, tx, pfMissingInputs, GetTime(), plTxnReplaced, bypass_limits, nAbsurdFee, test_accept);
 }
 
 /**
@@ -1839,14 +1830,6 @@ void StartScriptCheckWorkerThreads(int threads_num)
     g_chainstate.scriptcheckqueue = std::make_unique< CCheckQueue<CScriptCheck> >(128, threads_num);
 }
 
-static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex) {
-    AssertLockHeld(cs_main);
-
-    unsigned int flags = SCRIPT_VERIFY_NONE;
-
-    return flags;
-}
-
 
 
 static int64_t nTimeCheck = 0;
@@ -1937,9 +1920,6 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     int nLockTimeFlags = LOCKTIME_VERIFY_SEQUENCE;
 
-    // Get the script flags for this block
-    unsigned int flags = GetBlockScriptFlags(pindex);
-
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint(BCLog::BENCH, "    - Fork checks: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime2 - nTime1), nTimeForks * MICRO, nTimeForks * MILLI / nBlocksTotal);
 
@@ -1991,7 +1971,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         // * legacy (always)
         // * p2sh (when P2SH enabled in flags and excludes coinbase)
         // * witness (when witness enabled in flags and excludes coinbase)
-        nSigOpsCost += GetTransactionSigOps(tx, view, flags);
+        nSigOpsCost += GetTransactionSigOps(tx, view, SCRIPT_VERIFY_NONE);
         if (nSigOpsCost > GetMaxBlockSigops())
             return state.DoS(100, error("ConnectBlock(): too many sigops"),
                              REJECT_INVALID, "bad-blk-sigops");
@@ -2001,7 +1981,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         {
             std::vector<CScriptCheck> vChecks;
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
-            if (!CheckInputs(tx, state, view, fScriptChecks, flags, fCacheResults, fCacheResults, txdata[i], inColoredCoinBalances, nScriptCheckThreads ? &vChecks : nullptr))
+            if (!CheckInputs(tx, state, view, fScriptChecks, SCRIPT_VERIFY_NONE, fCacheResults, fCacheResults, txdata[i], inColoredCoinBalances, nScriptCheckThreads ? &vChecks : nullptr))
                 return error("ConnectBlock(): CheckInputs on %s failed with %s",
                     tx.GetHashMalFix().ToString(), FormatStateMessage(state));
             control.Add(std::move(vChecks));
@@ -4559,13 +4539,12 @@ bool LoadMempool(void)
             if (amountdelta) {
                 mempool.PrioritiseTransaction(tx->GetHashMalFix(), amountdelta);
             }
-            CValidationState state;
+            CTxMempoolAcceptanceOptions opt;
             if (nTime + nExpiryTimeout > nNow) {
                 LOCK(cs_main);
-                AcceptToMemoryPoolWithTime(mempool, state, tx, nullptr /* pfMissingInputs */, nTime,
-                                           nullptr /* plTxnReplaced */, false /* bypass_limits */, 0 /* nAbsurdFee */,
-                                           false /* test_accept */);
-                if (state.IsValid()) {
+                opt.nAcceptTime = nTime;
+                AcceptToMemoryPoolWorker(tx, opt);
+                if (opt.state.IsValid()) {
                     ++count;
                 } else {
                     // mempool may contain the transaction already, e.g. from

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1105,9 +1105,9 @@ static bool AcceptToMemoryPoolWorker(const CTransactionRef &ptx, CTxMempoolAccep
                 hash.begin(),
                 tx.GetTotalSize(),
                 nConflictingFees
-            );
-            if (plTxnReplaced)
-                plTxnReplaced->push_back(it->GetSharedTx());
+            )
+
+            opt.txnReplaced.push_back(it->GetSharedTx());
         }
         pool.RemoveStaged(allConflicting, false, MemPoolRemovalReason::REPLACED);
 
@@ -1144,7 +1144,7 @@ bool AcceptToMemoryPool(const CTransactionRef &tx, CTxMempoolAcceptanceOptions& 
             pcoinsTip->Uncache(hashTx);
             TRACE2(mempool, rejected,
                 tx->GetHashMalFix().begin(),
-                state.GetRejectReason().c_str()
+                opt.state.GetRejectReason().c_str()
         );
     }
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -564,6 +564,7 @@ static bool CheckConflictsInMempool(const CTransaction& tx, std::set<uint256>& s
 {
     for (const CTxIn &txin : tx.vin)
     {
+        AssertLockHeld(mempool.cs);
         auto itConflicting = mempool.mapNextTx.find(txin.prevout);
         if (itConflicting != mempool.mapNextTx.end())
         {
@@ -1105,7 +1106,7 @@ static bool AcceptToMemoryPoolWorker(const CTransactionRef &ptx, CTxMempoolAccep
                 hash.begin(),
                 tx.GetTotalSize(),
                 nConflictingFees
-            )
+            );
 
             opt.txnReplaced.push_back(it->GetSharedTx());
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -21,6 +21,7 @@
 #include <chainparams.h>
 #include <chain.h>
 #include <xfieldhistory.h>
+#include <txmempool.h>
 
 #include <algorithm>
 #include <exception>
@@ -302,9 +303,7 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
-bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
-                        bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false);
+bool AcceptToMemoryPool(const CTransactionRef &tx, CTxMempoolAcceptanceOptions &opt);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);

--- a/src/wallet/test/test_tapyrus_wallet.cpp
+++ b/src/wallet/test/test_tapyrus_wallet.cpp
@@ -61,7 +61,6 @@ void TestWalletSetup::initWallet()
 
 bool TestWalletSetup::ProcessBlockAndScanForWalletTxns(const CTransactionRef tx) {
     CTxMempoolAcceptanceOptions opt;
-    bool pfMissingInputs;
     {
         LOCK(cs_main);
         if(!AcceptToMemoryPool(tx, opt)) {

--- a/src/wallet/test/test_tapyrus_wallet.cpp
+++ b/src/wallet/test/test_tapyrus_wallet.cpp
@@ -60,11 +60,11 @@ void TestWalletSetup::initWallet()
 }
 
 bool TestWalletSetup::ProcessBlockAndScanForWalletTxns(const CTransactionRef tx) {
-    CValidationState state;
+    CTxMempoolAcceptanceOptions opt;
     bool pfMissingInputs;
     {
         LOCK(cs_main);
-        if(!AcceptToMemoryPool(mempool, state, tx, &pfMissingInputs, nullptr, true, 0)) {
+        if(!AcceptToMemoryPool(tx, opt)) {
             return false;
         }
     }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -511,11 +511,11 @@ public:
     }
 
     bool ProcessBlockAndScanForWalletTxns(const CTransactionRef tx) {
-        CValidationState state;
+        CTxMempoolAcceptanceOptions opt;
         bool pfMissingInputs;
         {
             LOCK(cs_main);
-            AcceptToMemoryPool(mempool, state, tx, &pfMissingInputs, nullptr, true, 0);
+            AcceptToMemoryPool(tx, opt);
         }
         CreateAndProcessBlock({ CMutableTransaction(*tx) }, CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG);
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -512,7 +512,6 @@ public:
 
     bool ProcessBlockAndScanForWalletTxns(const CTransactionRef tx) {
         CTxMempoolAcceptanceOptions opt;
-        bool pfMissingInputs;
         {
             LOCK(cs_main);
             AcceptToMemoryPool(tx, opt);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4451,8 +4451,9 @@ bool CWalletTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& 
     // user could call sendmoney in a loop and hit spurious out of funds errors
     // because we think that this newly generated transaction's change is
     // unavailable as we're not yet aware that it is in the mempool.
-    bool ret = ::AcceptToMemoryPool(mempool, state, tx, nullptr /* pfMissingInputs */,
-                                nullptr /* plTxnReplaced */, false /* bypass_limits */, nAbsurdFee);
+    CTxMempoolAcceptanceOptions opt;
+    opt.nAbsurdFee = nAbsurdFee;
+    bool ret = ::AcceptToMemoryPool(tx, opt);
     fInMempool |= ret;
     return ret;
 }


### PR DESCRIPTION
refactoring: 
remove argument mempool as it is a global
add test and bypass limit flags to enum MempoolAcceptanceFlags
add state and all other outputs in the same struct CTxMempoolAcceptanceOptions
make smaller function calls for some of the checks in AcceptToMempoolWorker