### PR TITLE
Add missing includes to fix gcc-13 compile error

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -23,6 +23,7 @@
 #include <sys/mman.h> // for mmap
 #include <sys/resource.h> // for getrlimit
 #include <limits.h> // for PAGESIZE
+#include <stdexcept>
 #include <unistd.h> // for sysconf
 #endif
 


### PR DESCRIPTION
In my environment(gcc 13.2.0), the following error occurs:

```
support/lockedpool.cpp:321:16: error: ‘runtime_error’ is not a member of ‘std’
  321 |     throw std::runtime_error("LockedPool: invalid address not pointing to any arena");
```
