### PR TITLE
Security fix 1 - drop unknown getdata messages

### DIFF
--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test GETDATA processing behavior"""
+from collections import defaultdict
+
+from test_framework.messages import (
+    CInv,
+    msg_getdata,
+)
+from test_framework.mininode import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import wait_until
+
+
+class P2PStoreBlock(P2PInterface):
+    def __init__(self, time_to_connect):
+        super().__init__(time_to_connect)
+        self.blocks = defaultdict(int)
+        self.txs = defaultdict(int)
+
+    def on_block(self, message):
+        message.block.calc_sha256()
+        self.blocks[message.block.sha256] += 1
+
+    def on_tx(self, message):
+        message.tx.calc_sha256()
+        self.txs[message.tx.malfixsha256] += 1
+
+class GetdataTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+        p2p_block_store = self.nodes[0].add_p2p_connection(P2PStoreBlock(self.nodes[0].time_to_connect))
+
+        self.log.info("test that an invalid GETDATA doesn't prevent processing of future messages")
+
+        # Send invalid message and verify that node responds to later ping
+        invalid_getdata = msg_getdata()
+        invalid_getdata.inv.append(CInv(t=0, h=0))  # INV type 0 is invalid.
+        p2p_block_store.send_and_ping(invalid_getdata)
+
+        # Check getdata does not give tx which was not inv to us
+        txid = self.nodes[0].listunspent(10)[0]['txid']
+        good_getdatatx = msg_getdata()
+        good_getdatatx.inv.append(CInv(t=1, h=int(txid, 16)))
+        p2p_block_store.send_and_ping(good_getdatatx)
+        assert p2p_block_store.txs[txid] == 0
+
+        # Check getdata still works by fetching tip block
+        best_block = int(self.nodes[0].getbestblockhash(), 16)
+        good_getdata = msg_getdata()
+        good_getdata.inv.append(CInv(t=2, h=best_block))
+        p2p_block_store.send_and_ping(good_getdata)
+        wait_until(lambda: p2p_block_store.blocks[best_block] == 1)
+
+
+
+if __name__ == '__main__':
+    GetdataTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1398,6 +1398,21 @@ class msg_blocktxn():
     def __repr__(self):
         return "msg_blocktxn(block_transactions=%s)" % (repr(self.block_transactions))
 
+class msg_notfound():
+    command = b'notfound'
+    def __init__(self, inv=None):
+        self.inv = inv if inv != None else []
+
+    def deserialize(self, f):
+        self.inv = deser_vector(f, CInv)
+
+    def serialize(self):
+        return ser_vector(self.inv)
+
+    def __repr__(self):
+        return "msg_notfound(inv=%s)" % (repr(self.inv))
+
+
 class msg_witness_blocktxn(msg_blocktxn):
     def serialize(self):
         r = b""

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -22,7 +22,7 @@ import struct
 import sys
 import threading
 
-from test_framework.messages import CBlockHeader, MIN_VERSION_SUPPORTED, msg_addr, msg_block, MSG_BLOCK, msg_blocktxn, msg_cmpctblock, msg_feefilter, msg_getaddr, msg_getblocks, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_mempool, msg_ping, msg_pong, msg_reject, msg_sendcmpct, msg_sendheaders, msg_tx, MSG_TX, MSG_TYPE_MASK, msg_verack, msg_version, NODE_NETWORK, NODE_WITNESS, sha256, ToHex
+from test_framework.messages import CBlockHeader, MIN_VERSION_SUPPORTED, msg_addr, msg_block, MSG_BLOCK, msg_blocktxn, msg_cmpctblock, msg_feefilter, msg_getaddr, msg_getblocks, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_mempool, msg_ping, msg_pong, msg_reject, msg_sendcmpct, msg_sendheaders, msg_tx, MSG_TX, MSG_TYPE_MASK, msg_verack, msg_version, NODE_NETWORK, NODE_WITNESS, sha256, ToHex, msg_notfound
 from test_framework.util import wait_until, NetworkDirName, MagicBytes
 
 logger = logging.getLogger("TestFramework.mininode")
@@ -49,6 +49,7 @@ MESSAGEMAP = {
     b"tx": msg_tx,
     b"verack": msg_verack,
     b"version": msg_version,
+    b'notfound': msg_notfound,
 }
 
 class P2PConnection(asyncio.Protocol):
@@ -298,6 +299,7 @@ class P2PInterface(P2PConnection):
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
     def on_tx(self, message): pass
+    #def on_notfound(self, message): pass
 
     def on_inv(self, message):
         want = msg_getdata()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -299,7 +299,6 @@ class P2PInterface(P2PConnection):
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
     def on_tx(self, message): pass
-    #def on_notfound(self, message): pass
 
     def on_inv(self, message):
         want = msg_getdata()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -449,7 +449,7 @@ def run_tests(test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=Fal
             logging.debug("\n%s%s%s passed, Duration: %s s" % (BOLD[1], test_result.name, BOLD[0], test_result.time))
         elif test_result.status == "Skipped":
             logging.debug("\n%s%s%s skipped" % (BOLD[1], test_result.name, BOLD[0]))
-        elif test_result.status == "Timeout":
+        elif test_result.status == "Timeout" and not retry :
             logging.debug("\n%s%s%s timeout" % (BOLD[1], test_result.name, BOLD[0]))
             retry_list.append(test_result.name)
         else:

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -180,6 +180,7 @@ BASE_SCRIPTS = [
     'feature_blocksdir.py',
     'feature_config_args.py',
     'rpc_help.py',
+    'p2p_getdata.py',
     'feature_help.py',
     'feature_help.py --usecli',
     'feature_coloredcoin.py'


### PR DESCRIPTION
Port fixes from bitcoin:
PR 18808 - Drop unknown types in getdata
PR 19109 - Only allow getdata of recently announced invs
Add functional test to verify that unknown get data does not halt the peer and transitions that were not in recently announced invs are not replied