### PR TITLE
security fix 2 - Only send a getheaders for one block in an INV

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1900,6 +1900,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             fBlocksOnly = false;
 
         LOCK(cs_main);
+        uint256* best_block{nullptr};
 
         for (CInv &inv : vInv)
         {
@@ -1913,13 +1914,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             if (inv.type == MSG_BLOCK) {
                 UpdateBlockAvailability(pfrom->GetId(), inv.hash);
                 if (!fAlreadyHave && !fImporting && !fReindex && !mapBlocksInFlight.count(inv.hash)) {
-                    // We used to request the full block here, but since headers-announcements are now the
-                    // primary method of announcement on the network, and since, in the case that a node
-                    // fell back to inv we probably have a reorg which we should get the headers for first,
-                    // we now only provide a getheaders response here. When we receive the headers, we will
-                    // then ask for the blocks we need.
-                    connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), inv.hash));
-                    LogPrint(BCLog::NET, "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, inv.hash.ToString(), pfrom->GetId());
+                    // Headers-first is the primary method of announcement on
+                    // the network. If a node fell back to sending blocks by inv,
+                    // it's probably for a re-org. The final block hash
+                    // provided should be the highest, so send a getheaders and
+                    // then fetch the blocks we need to catch up.
+                    best_block = &inv.hash;
                 }
             }
             else
@@ -1932,6 +1932,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 }
             }
         }
+
+        if (best_block != nullptr) {
+            connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), *best_block));
+            LogPrint(BCLog::NET, "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, best_block->ToString(), pfrom->GetId());
+        }
+
+        return true;
     }
 
 

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -159,7 +159,6 @@ class BIP68_112_113Test(BitcoinTestFramework):
         if not success and reject_code == 16:
             #reconnect as this node is disconnected for sending the invalid block.
             self.nodes[0].add_p2p_connection(P2PDataStore(self.nodes[0].time_to_connect))
-            self.nodes[0].p2p.wait_for_getheaders(timeout=5)
 
     def run_test(self):
         SCHEME = self.options.scheme

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test getheaders sent in response to block announced in INV
+
+Test that a block announcement using INV results in each peer receiving a getheaders message with its best block.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.messages import (
+    CInv,
+    MSG_BLOCK,
+    msg_headers,
+    msg_inv,
+)
+from test_framework.mininode import (
+    mininode_lock,
+    P2PInterface
+)
+from test_framework.util import (
+    assert_equal,
+    wait_until
+)
+import random
+
+class HeadersSyncTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def announce_random_block(self, peers):
+        last_block = random.randrange(1<<256)
+        new_block_announcement = msg_inv(inv=[CInv(MSG_BLOCK, random.randrange(1<<256)), CInv(MSG_BLOCK, last_block)])
+        for p in peers:
+            p.send_and_ping(new_block_announcement)
+        return last_block
+
+    def run_test(self):
+        self.log.info("Adding a peer to node0")
+        peer1 = self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
+        best_block_hash = int(self.nodes[0].getbestblockhash(), 16)
+
+        # Wait for peer1 to receive a getheaders
+        # If no block hash is provided, checks whether any getheaders message has been received by the node."""
+        def test_function():
+            last_getheaders = peer1.last_message.pop("getheaders", None)
+            if last_getheaders is None:
+                return False
+            return best_block_hash == last_getheaders.locator.vHave[0]
+
+        wait_until(test_function, timeout=10)
+        # An empty reply will clear the outstanding getheaders request,
+        # allowing additional getheaders requests to be sent to this peer in
+        # the future.
+        peer1.send_message(msg_headers())
+
+        self.log.info("Connecting two more peers to node0")
+        # Connect 2 more peers; they should not receive a getheaders yet
+        peer2 = self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
+        peer3 = self.nodes[0].add_p2p_connection(P2PInterface(self.nodes[0].time_to_connect))
+
+        all_peers = [peer1, peer2, peer3]
+
+        self.log.info("Verify that peer2 and peer3 don't receive a getheaders after connecting")
+        for p in all_peers:
+            p.sync_with_ping()
+        with mininode_lock:
+            assert "getheaders" in peer2.last_message
+            assert "getheaders" in peer3.last_message
+
+        self.log.info("Have all peers announce a new block")
+        last_block = self.announce_random_block(all_peers)
+
+        self.log.info("Check that peer1 receives a getheaders in response")
+        best_block_hash = int(self.nodes[0].getbestblockhash(), 16)
+        wait_until(test_function, timeout=10)
+        peer1.send_message(msg_headers()) # Send empty response, see above
+
+        self.log.info("Check that peer2 and peer3 received a getheaders in response")
+        count = 0
+        peer_receiving_getheaders = None
+        for p in [peer2, peer3]:
+            with mininode_lock:
+                if "getheaders" in p.last_message:
+                    count += 1
+                    peer_receiving_getheaders = p
+                    p.send_message(msg_headers()) # Send empty response, see above
+
+        assert_equal(count, 2)
+
+        self.log.info("Announce another new block, from all peers")
+        last_block = self.announce_random_block(all_peers)
+
+        self.log.info("Check that peer1 receives a getheaders in response")
+        best_block_hash = int(self.nodes[0].getbestblockhash(), 16)
+        wait_until(test_function, timeout=10)
+
+        self.log.info("Success!")
+
+if __name__ == '__main__':
+    HeadersSyncTest().main()
+

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -43,13 +43,7 @@ class HeadersSyncTest(BitcoinTestFramework):
 
         # Wait for peer1 to receive a getheaders
         # If no block hash is provided, checks whether any getheaders message has been received by the node."""
-        def test_function():
-            last_getheaders = peer1.last_message.pop("getheaders", None)
-            if last_getheaders is None:
-                return False
-            return best_block_hash == last_getheaders.locator.vHave[0]
-
-        wait_until(test_function, timeout=10)
+        peer1.wait_for_getheaders(block_hash=best_block_hash)
         # An empty reply will clear the outstanding getheaders request,
         # allowing additional getheaders requests to be sent to this peer in
         # the future.
@@ -74,7 +68,7 @@ class HeadersSyncTest(BitcoinTestFramework):
 
         self.log.info("Check that peer1 receives a getheaders in response")
         best_block_hash = int(self.nodes[0].getbestblockhash(), 16)
-        wait_until(test_function, timeout=10)
+        peer1.wait_for_getheaders(block_hash=best_block_hash)
         peer1.send_message(msg_headers()) # Send empty response, see above
 
         self.log.info("Check that peer2 and peer3 received a getheaders in response")
@@ -94,7 +88,7 @@ class HeadersSyncTest(BitcoinTestFramework):
 
         self.log.info("Check that peer1 receives a getheaders in response")
         best_block_hash = int(self.nodes[0].getbestblockhash(), 16)
-        wait_until(test_function, timeout=10)
+        peer1.wait_for_getheaders(block_hash=best_block_hash)
 
         self.log.info("Success!")
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -163,6 +163,7 @@ BASE_SCRIPTS = [
     'wallet_coloredcoin.py --scheme SCHNORR',
     'wallet_coloredcoin.py --usecli',
     'wallet_coloredcoin.py --usecli --scheme SCHNORR',
+    'p2p_initial_headers_sync.py',
     'feature_dersig.py',
     'rpc_uptime.py',
     'wallet_resendwallettransactions.py',


### PR DESCRIPTION
Port fixes from bitcoin: 18962 - Only send a getheaders for one block in an INV

Functional test for this is ported from bitcoin. But the expected results are different from the same test in bitcoin. This is because of the protocol changes made in bitcoin regarding the number of peers to get headers from during IBD.  In papyrus there is no restriction. so all peers get and send the headers message.