### PR TITLE
NotifyBlockTip connectors to fix compilation error in Boost 1.83

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1619,13 +1619,13 @@ bool AppInitMain()
     // Either install a handler to notify us when genesis activates, or set fHaveGenesis directly.
     // No locking, as this happens before any background thread is started.
     if (chainActive.Tip() == nullptr) {
-        uiInterface.NotifyBlockTip.connect(BlockNotifyGenesisWait);
+        uiInterface.NotifyBlockTip.connect(&BlockNotifyGenesisWait);
     } else {
         fHaveGenesis = true;
     }
 
     if (gArgs.IsArgSet("-blocknotify"))
-        uiInterface.NotifyBlockTip.connect(BlockNotifyCallback);
+        uiInterface.NotifyBlockTip.connect(&BlockNotifyCallback);
 
     std::vector<fs::path> vImportFiles;
     for (const std::string& strFile : gArgs.GetArgs("-loadblock")) {
@@ -1643,7 +1643,7 @@ bool AppInitMain()
         while (!fHaveGenesis && !ShutdownRequested()) {
             condvar_GenesisWait.wait_for(lock, std::chrono::milliseconds(500));
         }
-        uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
+        uiInterface.NotifyBlockTip.disconnect(&BlockNotifyGenesisWait);
     }
 
     if (ShutdownRequested()) {


### PR DESCRIPTION
Add '&' operator to NotifyBlockTip connectors to fix compilation of boost::signals2 in version 1.83. 
This change is based on other usages of the same call `uiInterface.NotifyBlockTip.connect` which do not result in compilation errors. Fixes #310 

init.cpp:1622:53:   required from here
/usr/include/c++/11/functional:739:43: error: static assertion failed: Wrong number of arguments for function
  739 |       static_assert(sizeof...(_BoundArgs) == sizeof...(_Args),
      |                     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/usr/include/c++/11/functional:739:43: note: ‘(1 == 2)’ evaluates to fals

init.cpp:1646:46:   required from here
/tapyrus-core/depends/aarch64-unknown-linux-gnu/share/../include/boost/function/function_base.hpp:651:14: error: invalid ‘static_cast’ from type ‘boost::detail::function::function_buffer_members::obj_ptr_t’ {aka ‘void*’} to type ‘void (*)(bool, const CBlockIndex*)’
  651 |       return static_cast<const Functor*>(type_result.members.obj_ptr);
      |             