### PR TITLE
Gitian build in jammy

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -31,7 +31,7 @@ def setup():
     # if not os.path.isdir('bitcoin-detached-sigs'):
     #     subprocess.check_call(['git', 'clone', 'https://github.com/bitcoin-core/bitcoin-detached-sigs.git'])
     if not os.path.isdir('gitian-builder'):
-        subprocess.check_call(['git', 'clone', 'https://github.com/devrandom/gitian-builder.git'])
+        subprocess.check_call(['git', 'clone', 'https://github.com/Naviabheeman/gitian-builder.git'])
     if not os.path.isdir('tapyrus-core'):
         subprocess.check_call(['git', 'clone', 'https://github.com/chaintope/tapyrus-core.git'])
     os.chdir('gitian-builder')

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -35,14 +35,14 @@ def setup():
     if not os.path.isdir('tapyrus-core'):
         subprocess.check_call(['git', 'clone', 'https://github.com/chaintope/tapyrus-core.git'])
     os.chdir('gitian-builder')
-    make_image_prog = ['bin/make-base-vm', '--suite', 'bionic', '--arch', 'amd64']
+    make_image_prog = ['bin/make-base-vm', '--suite', 'jammy', '--arch', 'amd64']
     if args.docker:
         make_image_prog += ['--docker']
     elif not args.kvm:
         make_image_prog += ['--lxc']
     subprocess.check_call(make_image_prog)
     os.chdir(workdir)
-    if args.is_bionic and not args.kvm and not args.docker:
+    if args.is_jammy and not args.kvm and not args.docker:
         subprocess.check_call(['sudo', 'sed', '-i', 's/lxcbr0/br0/', '/etc/default/lxc-net'])
         print('Reboot is required')
         sys.exit(0)
@@ -176,7 +176,7 @@ def main():
     args = parser.parse_args()
     workdir = os.getcwd()
 
-    args.is_bionic = b'bionic' in subprocess.check_output(['lsb_release', '-cs'])
+    args.is_jammy = b'jammy' in subprocess.check_output(['lsb_release', '-cs'])
 
     if args.kvm and args.docker:
         raise Exception('Error: cannot have both kvm and docker')

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -2,7 +2,7 @@
 name: "tapyrus-core-linux-0.6"
 enable_cache: true
 suites:
-- "bionic"
+- "jammy"
 architectures:
 - "amd64"
 packages:

--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -1,7 +1,7 @@
 ---
 name: "tapyrus-core-dmg-signer"
 suites:
-- "bionic"
+- "jammy"
 architectures:
 - "amd64"
 packages:

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -2,7 +2,7 @@
 name: "tapyrus-core-osx-0.6"
 enable_cache: true
 suites:
-- "bionic"
+- "jammy"
 architectures:
 - "amd64"
 packages:

--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -1,7 +1,7 @@
 ---
 name: "tapyrus-core-win-signer"
 suites:
-- "bionic"
+- "jammy"
 architectures:
 - "amd64"
 packages:

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -2,7 +2,7 @@
 name: "tapyrus-core-win-0.6"
 enable_cache: true
 suites:
-- "bionic"
+- "jammy"
 architectures:
 - "amd64"
 packages:

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -26,7 +26,7 @@ Check out the source code in the following directory hierarchy.
 
     cd /path/to/your/toplevel/build
     git clone https://github.com/chaintope/tapyrus-gitian.sigs.git
-    git clone https://github.com/devrandom/gitian-builder.git
+    git clone https://github.com/Naviabheeman/gitian-builder.git
     git clone https://github.com/chaintope/tapyrus-core.git --recursive
 
 ### Bitcoin maintainers/release engineers, suggestion for writing release notes


### PR DESCRIPTION
Change ubuntu image used in Gitian builds from `bionic` to `jammy`. 
Change url of gitian-builder to  **_Naviabheeman/gitian-builder_** which has the modified [Vagrantfile](https://github.com/Naviabheeman/gitian-builder/blob/master/Vagrantfile) with all new ubuntu releases listed