### PR TITLE
Cmake unit tests are failing because of very subtle errors

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -1,11 +1,158 @@
+// Copyright (c) 2017-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <fs.h>
+
+#ifndef WIN32
+#include <cstring>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+#else
+#include <codecvt>
+#include <limits>
+#include <windows.h>
+#include <tinyformat.h>
+#endif
+
+#include <cassert>
+#include <cerrno>
+#include <string>
+#include <sstream>
 
 namespace fsbridge {
 
 FILE *fopen(const fs::path& p, const char *mode)
 {
-    return ::fopen(p.string().c_str(), mode);
+#ifndef WIN32
+    return ::fopen(p.c_str(), mode);
+#else
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t> utf8_cvt;
+    return ::_wfopen(p.wstring().c_str(), utf8_cvt.from_bytes(mode).c_str());
+#endif
 }
 
+fs::path AbsPathJoin(const fs::path& base, const fs::path& path)
+{
+    assert(base.is_absolute());
+    return path.empty() ? base : fs::path(base / path);
+}
 
-} // fsbridge
+#ifndef WIN32
+std::string SysErrorString(int err)
+{
+    char buf[1024];
+    /* Too bad there are three incompatible implementations of the
+     * thread-safe strerror. */
+    const char *s = nullptr;
+#ifdef WIN32
+    if (strerror_s(buf, sizeof(buf), err) == 0) s = buf;
+#else
+#ifdef STRERROR_R_CHAR_P /* GNU variant can return a pointer outside the passed buffer */
+    s = strerror_r(err, buf, sizeof(buf));
+#else /* POSIX variant always returns message in buffer */
+    if (strerror_r(err, buf, sizeof(buf)) == 0) s = buf;
+#endif
+#endif
+    std::stringstream ss;
+    if (s != nullptr) {
+        ss << s << " (" << err << ")";
+        return ss.str();
+    } else {
+        ss << "Unknown error (" << err << ")";
+        return ss.str();
+    }
+}
+
+static std::string GetErrorReason()
+{
+    return SysErrorString(errno);
+}
+
+FileLock::FileLock(const fs::path& file)
+{
+    fd = open(file.c_str(), O_RDWR);
+    if (fd == -1) {
+        reason = GetErrorReason();
+    }
+}
+
+FileLock::~FileLock()
+{
+    if (fd != -1) {
+        close(fd);
+    }
+}
+
+bool FileLock::TryLock()
+{
+    if (fd == -1) {
+        return false;
+    }
+
+    struct flock lock;
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    if (fcntl(fd, F_SETLK, &lock) == -1) {
+        reason = GetErrorReason();
+        return false;
+    }
+
+    return true;
+}
+#else
+std::string Win32ErrorString(int err)
+{
+    wchar_t buf[256];
+    buf[0] = 0;
+    if(FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+                       nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                       buf, ARRAYSIZE(buf), nullptr))
+    {
+        return strprintf("%s (%d)", std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().to_bytes(buf), err);
+    }
+    else
+    {
+        return strprintf("Unknown error (%d)", err);
+    }
+}
+
+static std::string GetErrorReason() {
+    return Win32ErrorString(GetLastError());
+}
+
+FileLock::FileLock(const fs::path& file)
+{
+    hFile = CreateFileW(file.wstring().c_str(),  GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        reason = GetErrorReason();
+    }
+}
+
+FileLock::~FileLock()
+{
+    if (hFile != INVALID_HANDLE_VALUE) {
+        CloseHandle(hFile);
+    }
+}
+
+bool FileLock::TryLock()
+{
+    if (hFile == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+    _OVERLAPPED overlapped = {};
+    if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
+        reason = GetErrorReason();
+        return false;
+    }
+    return true;
+}
+#endif
+
+} // namespace fsbridge

--- a/src/fs.h
+++ b/src/fs.h
@@ -15,6 +15,36 @@ namespace fs = std::filesystem;
 /** Bridge operations to C stdio */
 namespace fsbridge {
     FILE *fopen(const fs::path& p, const char *mode);
-};
 
+    /**
+     * Helper function for joining two paths
+     *
+     * @param[in] base  Base path
+     * @param[in] path  Path to combine with base
+     * @returns path unchanged if it is an absolute path, otherwise returns base joined with path. Returns base unchanged if path is empty.
+     * @pre  Base path must be absolute
+     * @post Returned path will always be absolute
+     */
+    fs::path AbsPathJoin(const fs::path& base, const fs::path& path);
+
+    class FileLock
+    {
+    public:
+        FileLock() = delete;
+        FileLock(const FileLock&) = delete;
+        FileLock(FileLock&&) = delete;
+        explicit FileLock(const fs::path& file);
+        ~FileLock();
+        bool TryLock();
+        std::string GetReason() { return reason; }
+
+    private:
+        std::string reason;
+#ifndef WIN32
+        int fd = -1;
+#else
+        void* hFile = (void*)-1; // INVALID_HANDLE_VALUE
+#endif
+    };
+};
 #endif // BITCOIN_FS_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -73,8 +73,7 @@ bool CBlockHeader::AbsorbBlockProof(const std::vector<unsigned char>& blockproof
 
     //add signatures to block
     proof = std::move(blockproof);
-    if(proof.size() != CPubKey::SCHNORR_SIGNATURE_SIZE)
-        return false;
+
     return true;
 
 }

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -73,6 +73,8 @@ bool CBlockHeader::AbsorbBlockProof(const std::vector<unsigned char>& blockproof
 
     //add signatures to block
     proof = std::move(blockproof);
+    if(proof.size() != CPubKey::SCHNORR_SIGNATURE_SIZE)
+        return false;
     return true;
 
 }

--- a/src/test/block_tests.cpp
+++ b/src/test/block_tests.cpp
@@ -264,9 +264,10 @@ BOOST_AUTO_TEST_CASE(blockHeaderWithxfieldType2_maxblocksize2)
 }
 
 
-BOOST_AUTO_TEST_CASE(blockHeaderWithxfieldType2_maxxfieldtype)
+BOOST_AUTO_TEST_CASE(blockHeaderWithxfieldType3_maxxfieldtype)
 {
     CBlockHeader blockHeader;
+    BOOST_CHECK_EQUAL(blockHeader.proof.size(), 0);
     CDataStream stream(ParseHex("010000000000000000000000000000000000000000000000000000000000000000000000f007d2a56dbebbc2a04346e624f7dff2ee0605d6ffe9622569193fddbc9280dcf007d2a56dbebbc2a04346e624f7dff2ee0605d6ffe9622569193fddbc9280dc981a335c030041473045022100f434da668557be7a0c3dc366b2603c5a9706246d622050f633a082451d39249102201941554fdd618df3165269e3c855bbba8680e26defdd067ec97becfa1b296bef"), SER_NETWORK, PROTOCOL_VERSION);
     BOOST_CHECK_THROW(blockHeader.Unserialize(stream), BadXFieldException);
 

--- a/src/test/test_tapyrus.h
+++ b/src/test/test_tapyrus.h
@@ -21,6 +21,17 @@
 
 #include <test/test_keys_helper.h>
 
+/* CXFieldHistoryWithReset class is created to allow reset function in test_tapyrus
+ * this functionality is necessary in xfield history tests to reset the xfield history map to the genesis block state.
+ */
+class CXFieldHistoryWithReset : public CXFieldHistory {
+    const CBlock& genesis;
+public:
+    CXFieldHistoryWithReset(const CBlock& block) : CXFieldHistory(block), genesis(block) {}
+    void Reset();
+    virtual ~CXFieldHistoryWithReset() {}
+};
+
 extern uint256 insecure_rand_seed;
 extern FastRandomContext insecure_rand_ctx;
 
@@ -63,6 +74,8 @@ struct BasicTestingSetup {
     fs::path GetDataDir();
 private:
     const fs::path m_path_root;
+protected:
+    CXFieldHistoryWithReset* pxFieldHistory;
 };
 
 /** Testing setup that configures a complete environment.

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -342,6 +342,8 @@ BOOST_AUTO_TEST_CASE(test_Get)
 BOOST_AUTO_TEST_CASE(test_IsStandard)
 {
     LOCK(cs_main);
+    // Explicitly set dustRelayFee for this test, in case it's being reset elsewhere.
+    dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
     CBasicKeyStore keystore;
     CCoinsView coinsDummy;
     CCoinsViewCache coins(&coinsDummy);

--- a/src/test/xfieldhistory_tests.cpp
+++ b/src/test/xfieldhistory_tests.cpp
@@ -21,14 +21,18 @@
 
 struct XFieldHistorySetup : public TestingSetup {
     XFieldHistorySetup() : TestingSetup(TAPYRUS_MODES::DEV) {
-        CXFieldHistory history;
-        history.Add(TAPYRUS_XFIELDTYPES::AGGPUBKEY, XFieldChange(XFieldAggPubKey(CPubKey(ParseHex(ValidPubKeyStrings[10]))), 20, uint256()));
-        history.Add(TAPYRUS_XFIELDTYPES::AGGPUBKEY, XFieldChange(XFieldAggPubKey(CPubKey(ParseHex(ValidPubKeyStrings[11]))), 40, uint256()));
-        history.Add(TAPYRUS_XFIELDTYPES::AGGPUBKEY, XFieldChange(XFieldAggPubKey(CPubKey(ParseHex(ValidPubKeyStrings[12]))), 60, uint256()));
+        pxFieldHistory->Reset();
 
-        history.Add(TAPYRUS_XFIELDTYPES::MAXBLOCKSIZE, XFieldChange(4000000, 30, uint256()));
-        history.Add(TAPYRUS_XFIELDTYPES::MAXBLOCKSIZE, XFieldChange(8000000, 50, uint256()));
-        history.Add(TAPYRUS_XFIELDTYPES::MAXBLOCKSIZE, XFieldChange(16000000, 70, uint256()));
+        pxFieldHistory->Add(TAPYRUS_XFIELDTYPES::AGGPUBKEY, XFieldChange(XFieldAggPubKey(CPubKey(ParseHex(ValidPubKeyStrings[10]))), 20, uint256()));
+        pxFieldHistory->Add(TAPYRUS_XFIELDTYPES::AGGPUBKEY, XFieldChange(XFieldAggPubKey(CPubKey(ParseHex(ValidPubKeyStrings[11]))), 40, uint256()));
+        pxFieldHistory->Add(TAPYRUS_XFIELDTYPES::AGGPUBKEY, XFieldChange(XFieldAggPubKey(CPubKey(ParseHex(ValidPubKeyStrings[12]))), 60, uint256()));
+
+        pxFieldHistory->Add(TAPYRUS_XFIELDTYPES::MAXBLOCKSIZE, XFieldChange(4000000, 30, uint256()));
+        pxFieldHistory->Add(TAPYRUS_XFIELDTYPES::MAXBLOCKSIZE, XFieldChange(8000000, 50, uint256()));
+        pxFieldHistory->Add(TAPYRUS_XFIELDTYPES::MAXBLOCKSIZE, XFieldChange(16000000, 70, uint256()));
+    }
+    ~XFieldHistorySetup() {
+        pxFieldHistory->Reset();
     }
 };
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -103,7 +103,7 @@ LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_nam
 
     // If a lock for this directory already exists in the map, don't try to re-lock it
     if (dir_locks.count(pathLockFile.string())) {
-        return LockResult::Success;;
+        return LockResult::Success;
     }
 
     // Create empty lock file if it doesn't exist.
@@ -122,7 +122,7 @@ LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_nam
         dir_locks.emplace(pathLockFile.string(), std::move(lock));
     }
 
-    return LockResult::Success;;
+    return LockResult::Success;
 }
 
 std::ostream& operator<<(std::ostream& os, const LockResult& result) {

--- a/src/util.h
+++ b/src/util.h
@@ -84,7 +84,7 @@ enum class LockResult {
 // Define operator<< for LockResult
 std::ostream& operator<<(std::ostream& os, const LockResult& result);
 
-LockResult LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
+LockResult LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only=false);
 
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.


### PR DESCRIPTION
All unit tests pass in the automate CI. but in cmake there are some failures:
1. The problem is caused by the global xfieldHistory map not being reset between test runs in the CMake CI. So data added by one test  persists and affects subsequent tests.
2. Low fee making IsStandard test fail counting the output as dust
3. Block proof size was 0 instead of 64 in the constructor of TestingChainSetup making test_tapyrus exit 