### PR TITLE
Fix build errors in c++20 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ add_subdirectory(src/secp256k1)
 
 # Then enable C++ for the rest of the project
 enable_language(CXX)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -83,7 +83,7 @@ static inline int CountBits(I val, int max = 64) {
 #if defined(__cpp_lib_int_pow2) && __cpp_lib_int_pow2 >= 202002L
     // c++20 impl
     (void)max;
-    return std::bit_width(val);
+    return std::bit_width(static_cast<std::make_unsigned_t<I>>(val));
 #elif defined(_MSC_VER)
     (void)max;
     unsigned long index;

--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -837,7 +837,7 @@ class SingletonEnv {
  public:
   SingletonEnv() {
 #if !defined(NDEBUG)
-    env_initialized_.store(true, std::memory_order::memory_order_relaxed);
+    env_initialized_.store(true, std::memory_order_relaxed);
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
@@ -854,7 +854,7 @@ class SingletonEnv {
 
   static void AssertEnvNotInitialized() {
 #if !defined(NDEBUG)
-    assert(!env_initialized_.load(std::memory_order::memory_order_relaxed));
+    assert(!env_initialized_.load(std::memory_order_relaxed));
 #endif  // !defined(NDEBUG)
   }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -812,12 +812,24 @@ void setClipboard(const QString& str)
 
 fs::path qstringToPath(const QString &path)
 {
+#if __cplusplus >= 202002L
+    // In C++20, u8path is deprecated, use path constructor with u8string
+    auto str = path.toStdString();
+    return fs::path(std::u8string(str.begin(), str.end()));
+#else
     return fs::u8path(path.toStdString());
+#endif
 }
 
 QString pathToQString(const fs::path &path)
 {
+#if __cplusplus >= 202002L
+    // In C++20, u8string() returns std::u8string, need to convert to std::string
+    auto u8str = path.u8string();
+    return QString::fromStdString(std::string(u8str.begin(), u8str.end()));
+#else
     return QString::fromStdString(path.u8string());
+#endif
 }
 
 QString formatDurationStr(int secs)

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +9,7 @@
 #include <support/lockedpool.h>
 #include <support/cleanse.h>
 
+#include <memory>
 #include <string>
 
 //
@@ -16,31 +17,20 @@
 // out of memory and clears its contents before deletion.
 //
 template <typename T>
-struct secure_allocator : public std::allocator<T> {
-    // MSVC8 default copy constructor is broken
-    typedef std::allocator<T> base;
-    typedef typename base::size_type size_type;
-    typedef typename base::difference_type difference_type;
-    typedef typename base::pointer pointer;
-    typedef typename base::const_pointer const_pointer;
-    typedef typename base::reference reference;
-    typedef typename base::const_reference const_reference;
-    typedef typename base::value_type value_type;
-    secure_allocator() noexcept {}
-    secure_allocator(const secure_allocator& a) noexcept : base(a) {}
-    template <typename U>
-    secure_allocator(const secure_allocator<U>& a) noexcept : base(a)
-    {
-    }
-    ~secure_allocator() noexcept {}
-    template <typename _Other>
-    struct rebind {
-        typedef secure_allocator<_Other> other;
-    };
+struct secure_allocator {
+    using value_type = T;
 
-    T* allocate(std::size_t n, const void* hint = 0)
+    secure_allocator() = default;
+    template <typename U>
+    secure_allocator(const secure_allocator<U>&) noexcept {}
+
+    T* allocate(std::size_t n)
     {
-        return static_cast<T*>(LockedPoolManager::Instance().alloc(sizeof(T) * n));
+        T* allocation = static_cast<T*>(LockedPoolManager::Instance().alloc(sizeof(T) * n));
+        if (!allocation) {
+            throw std::bad_alloc();
+        }
+        return allocation;
     }
 
     void deallocate(T* p, std::size_t n)
@@ -50,9 +40,45 @@ struct secure_allocator : public std::allocator<T> {
         }
         LockedPoolManager::Instance().free(p);
     }
+
+    template <typename U>
+    friend bool operator==(const secure_allocator&, const secure_allocator<U>&) noexcept
+    {
+        return true;
+    }
+    template <typename U>
+    friend bool operator!=(const secure_allocator&, const secure_allocator<U>&) noexcept
+    {
+        return false;
+    }
 };
 
 // This is exactly like std::string, but with a custom allocator.
+// TODO: Consider finding a way to make incoming RPC request.params[i] mlock()ed as well
 typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char> > SecureString;
+
+template<typename T>
+struct SecureUniqueDeleter {
+    void operator()(T* t) noexcept {
+        secure_allocator<T>().deallocate(t, 1);
+    }
+};
+
+template<typename T>
+using secure_unique_ptr = std::unique_ptr<T, SecureUniqueDeleter<T>>;
+
+template<typename T, typename... Args>
+secure_unique_ptr<T> make_secure_unique(Args&&... as)
+{
+    T* p = secure_allocator<T>().allocate(1);
+
+    // initialize in place, and return as secure_unique_ptr
+    try {
+        return secure_unique_ptr<T>(new (p) T(std::forward<Args>(as)...));
+    } catch (...) {
+        secure_allocator<T>().deallocate(p, 1);
+        throw;
+    }
+}
 
 #endif // BITCOIN_SUPPORT_ALLOCATORS_SECURE_H

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,37 +12,42 @@
 #include <vector>
 
 template <typename T>
-struct zero_after_free_allocator : public std::allocator<T> {
-    // MSVC8 default copy constructor is broken
-    typedef std::allocator<T> base;
-    typedef typename base::size_type size_type;
-    typedef typename base::difference_type difference_type;
-    typedef typename base::pointer pointer;
-    typedef typename base::const_pointer const_pointer;
-    typedef typename base::reference reference;
-    typedef typename base::const_reference const_reference;
-    typedef typename base::value_type value_type;
-    zero_after_free_allocator() noexcept {}
-    zero_after_free_allocator(const zero_after_free_allocator& a) noexcept : base(a) {}
+struct zero_after_free_allocator {
+    using value_type = T;
+
+    zero_after_free_allocator() noexcept = default;
     template <typename U>
-    zero_after_free_allocator(const zero_after_free_allocator<U>& a) noexcept : base(a)
+    zero_after_free_allocator(const zero_after_free_allocator<U>&) noexcept
     {
     }
-    ~zero_after_free_allocator() noexcept {}
-    template <typename _Other>
-    struct rebind {
-        typedef zero_after_free_allocator<_Other> other;
-    };
+
+    T* allocate(std::size_t n)
+    {
+        return std::allocator<T>{}.allocate(n);
+    }
 
     void deallocate(T* p, std::size_t n)
     {
         if (p != nullptr)
             memory_cleanse(p, sizeof(T) * n);
-        std::allocator<T>::deallocate(p, n);
+        std::allocator<T>{}.deallocate(p, n);
+    }
+
+    template <typename U>
+    friend bool operator==(const zero_after_free_allocator&, const zero_after_free_allocator<U>&) noexcept
+    {
+        return true;
+    }
+    template <typename U>
+    friend bool operator!=(const zero_after_free_allocator&, const zero_after_free_allocator<U>&) noexcept
+    {
+        return false;
     }
 };
 
-// Byte-vector that clears its contents before deletion.
-typedef std::vector<char, zero_after_free_allocator<char> > CSerializeData;
+/** Byte-vector that clears its contents before deletion. */
+using SerializeData = std::vector<char, zero_after_free_allocator<char>>;
+// Backward compatibility typedef
+using CSerializeData = SerializeData;
 
 #endif // BITCOIN_SUPPORT_ALLOCATORS_ZEROAFTERFREE_H


### PR DESCRIPTION
Tapyrus compilation uses c++17. With some minimal changes in this PR, it can compile with c++20. This would allow us to use the newer features and make porting from bitcoin core straightforward. The changes in this PR do match the same classes in bitcoin core.