### PR TITLE
make the time conversion timezone aware in import wallet

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1647,6 +1647,11 @@ double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex *pin
     if (pindex == nullptr)
         return 0.0;
 
+    // If nChainTx is 0, the block hasn't been fully validated/connected yet.
+    // Return 0 to indicate no progress can be determined.
+    if (pindex->nChainTx == 0)
+        return 0.0;
+
     int64_t nNow = time(nullptr);
 
     double fTxTotal;


### PR DESCRIPTION
Fix these two errors:
Wallet test `importwallet_rescan` fails in non UTC timezones.
```
./cmake_mac/bin/test_tapyrus --run_test=wallet_tests/importwallet_rescan
Running 1 test case...
wallet/test/wallet_tests.cpp:180: error: in "wallet_tests/importwallet_rescan": check wallet->mapWallet.size() == 3U has failed [8 != 3]
wallet/test/wallet_tests.cpp:185: error: in "wallet_tests/importwallet_rescan": check found == expected has failed [true != false]
wallet/test/wallet_tests.cpp:185: error: in "wallet_tests/importwallet_rescan": check found == expected has failed [true != false]
wallet/test/wallet_tests.cpp:185: error: in "wallet_tests/importwallet_rescan": check found == expected has failed [true != false]
wallet/test/wallet_tests.cpp:185: error: in "wallet_tests/importwallet_rescan": check found == expected has failed [true != false]
wallet/test/wallet_tests.cpp:185: error: in "wallet_tests/importwallet_rescan": check found == expected has failed [true != false]

*** 6 failures are detected in the test module "Tapyrus Test Suite"
```
and there is valgring warning in the daily CI for the same test
```
./wallet/test/wallet_tests.cpp(134): Entering test case "importwallet_rescan"
==8277== Conditional jump or move depends on uninitialised value(s)
==8277==    at 0x64A1BA: GuessVerificationProgress (validation.cpp:1654)
==8277==    by 0x64A1BA: GuessVerificationProgress(ChainTxData const&, CBlockIndex const*) (validation.cpp:1646)
==8277==    by 0x776F85: CWallet::ScanForWalletTransactions(CBlockIndex*, CBlockIndex*, WalletRescanReserver const&, bool) (wallet.cpp:1738)
==8277==    by 0x777C1E: CWallet::RescanFromTime(long, WalletRescanReserver const&, bool) (wallet.cpp:1691)
==8277==    by 0x716F2B: RescanWallet(CWallet&, WalletRescanReserver const&, long, bool) (rpcdump.cpp:108)
==8277==    by 0x71C267: importwallet(JSONRPCRequest const&) (rpcdump.cpp:643)
==8277==    by 0x6D0C51: wallet_tests::importwallet_rescan::test_method() (wallet_tests.cpp:177)
==8277==    by 0x6D1AA5: wallet_tests::importwallet_rescan_invoker() (wallet_tests.cpp:134)
==8277==    by 0x57CF41: operator() (function_template.hpp:763)
==8277==    by 0x57CF41: operator() (execution_monitor.ipp:1388)
==8277==    by 0x57CF41: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:137)
==8277==    by 0x553ED4: operator() (function_template.hpp:763)
==8277==    by 0x553ED4: do_invoke<boost::shared_ptr<boost::detail::translator_holder_base>, boost::function<int()> > (execution_monitor.ipp:301)
==8277==    by 0x553ED4: boost::execution_monitor::catch_signals(boost::function<int ()> const&) (execution_monitor.ipp:903)
==8277==    by 0x553FCD: boost::execution_monitor::execute(boost::function<int ()> const&) (execution_monitor.ipp:1301)
==8277==    by 0x5540D4: boost::execution_monitor::vexecute(boost::function<void ()> const&) (execution_monitor.ipp:1397)
==8277==    by 0x55C685: boost::unit_test::unit_test_monitor_t::execute_and_translate(boost::function<void ()> const&, unsigned long) (unit_test_monitor.ipp:49)
==8277== 
==8277== Conditional jump or move depends on uninitialised value(s)
==8277==    at 0x64A1BA: GuessVerificationProgress (validation.cpp:1654)
==8277==    by 0x64A1BA: GuessVerificationProgress(ChainTxData const&, CBlockIndex const*) (validation.cpp:1646)
==8277==    by 0x777824: CWallet::ScanForWalletTransactions(CBlockIndex*, CBlockIndex*, WalletRescanReserver const&, bool) (wallet.cpp:1741)
==8277==    by 0x777C1E: CWallet::RescanFromTime(long, WalletRescanReserver const&, bool) (wallet.cpp:1691)
==8277==    by 0x716F2B: RescanWallet(CWallet&, WalletRescanReserver const&, long, bool) (rpcdump.cpp:108)
==8277==    by 0x71C267: importwallet(JSONRPCRequest const&) (rpcdump.cpp:643)
==8277==    by 0x6D0C51: wallet_tests::importwallet_rescan::test_method() (wallet_tests.cpp:177)
==8277==    by 0x6D1AA5: wallet_tests::importwallet_rescan_invoker() (wallet_tests.cpp:134)
==8277==    by 0x57CF41: operator() (function_template.hpp:763)
==8277==    by 0x57CF41: operator() (execution_monitor.ipp:1388)
==8277==    by 0x57CF41: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:137)
==8277==    by 0x553ED4: operator() (function_template.hpp:763)
==8277==    by 0x553ED4: do_invoke<boost::shared_ptr<boost::detail::translator_holder_base>, boost::function<int()> > (execution_monitor.ipp:301)
==8277==    by 0x553ED4: boost::execution_monitor::catch_signals(boost::function<int ()> const&) (execution_monitor.ipp:903)
==8277==    by 0x553FCD: boost::execution_monitor::execute(boost::function<int ()> const&) (execution_monitor.ipp:1301)
==8277==    by 0x5540D4: boost::execution_monitor::vexecute(boost::function<void ()> const&) (execution_monitor.ipp:1397)
==8277==    by 0x55C685: boost::unit_test::unit_test_monitor_t::execute_and_translate(boost::function<void ()> const&, unsigned long) (unit_test_monitor.ipp:49)
==8277== 
==8277== Conditional jump or move depends on uninitialised value(s)
==8277==    at 0x64A1BA: GuessVerificationProgress (validation.cpp:1654)
==8277==    by 0x64A1BA: GuessVerificationProgress(ChainTxData const&, CBlockIndex const*) (validation.cpp:1646)
==8277==    by 0x777345: CWallet::ScanForWalletTransactions(CBlockIndex*, CBlockIndex*, WalletRescanReserver const&, bool) (wallet.cpp:1778)
==8277==    by 0x777C1E: CWallet::RescanFromTime(long, WalletRescanReserver const&, bool) (wallet.cpp:1691)
==8277==    by 0x716F2B: RescanWallet(CWallet&, WalletRescanReserver const&, long, bool) (rpcdump.cpp:108)
==8277==    by 0x71C267: importwallet(JSONRPCRequest const&) (rpcdump.cpp:643)
==8277==    by 0x6D0C51: wallet_tests::importwallet_rescan::test_method() (wallet_tests.cpp:177)
==8277==    by 0x6D1AA5: wallet_tests::importwallet_rescan_invoker() (wallet_tests.cpp:134)
==8277==    by 0x57CF41: operator() (function_template.hpp:763)
==8277==    by 0x57CF41: operator() (execution_monitor.ipp:1388)
==8277==    by 0x57CF41: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:137)
==8277==    by 0x553ED4: operator() (function_template.hpp:763)
==8277==    by 0x553ED4: do_invoke<boost::shared_ptr<boost::detail::translator_holder_base>, boost::function<int()> > (execution_monitor.ipp:301)
==8277==    by 0x553ED4: boost::execution_monitor::catch_signals(boost::function<int ()> const&) (execution_monitor.ipp:903)
==8277==    by 0x553FCD: boost::execution_monitor::execute(boost::function<int ()> const&) (execution_monitor.ipp:1301)
==8277==    by 0x5540D4: boost::execution_monitor::vexecute(boost::function<void ()> const&) (execution_monitor.ipp:1397)
==8277==    by 0x55C685: boost::unit_test::unit_test_monitor_t::execute_and_translate(boost::function<void ()> const&, unsigned long) (unit_test_monitor.ipp:49)
==8277== 
./wallet/test/wallet_tests.cpp(134): Leaving test case "importwallet_rescan"; testing time: 469410us
```