### PR TITLE
Refactor locale func

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <utilstrencodings.h>
 
 /** All alphanumeric characters except for "0", "I", "O", and "l" */
 static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -34,7 +34,7 @@ static const int8_t mapBase58[256] = {
 bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
 {
     // Skip leading spaces.
-    while (*psz && isspace(*psz))
+    while (*psz && IsSpace(*psz))
         psz++;
     // Skip and count leading '1's.
     int zeroes = 0;
@@ -48,7 +48,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
     std::vector<unsigned char> b256(size);
     // Process the characters.
     static_assert(sizeof(mapBase58)/sizeof(mapBase58[0]) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
-    while (*psz && !isspace(*psz)) {
+    while (*psz && !IsSpace(*psz)) {
         // Decode base58 character
         int carry = mapBase58[(uint8_t)*psz];
         if (carry == -1)  // Invalid b58 character
@@ -64,7 +64,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
         psz++;
     }
     // Skip trailing spaces.
-    while (isspace(*psz))
+    while (IsSpace(*psz))
         psz++;
     if (*psz != 0)
         return false;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -209,8 +209,11 @@ size_t CDBWrapper::DynamicMemoryUsage() const {
     auto ret = std::from_chars(memory.data(), memory.data() + memory.size(), result);
     if (ret.ec == std::errc() && ret.ptr == memory.data() + memory.size())
         return result;
-    else
+    else{
+        LogPrint(BCLog::LEVELDB, "Failed to parse memory usage value: %s, using default\n", memory);
         return 4 * 1024 * 1024;  //nMinDbCache = 4;
+    }
+        
 }
 
 // Prefixed with null character to avoid collisions with other keys

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -206,8 +206,11 @@ size_t CDBWrapper::DynamicMemoryUsage() const {
     }
     // Use std::from_chars for locale-independent conversion
     size_t result = 0;
-    std::from_chars(memory.data(), memory.data() + memory.size(), result);
-    return result;
+    auto ret = std::from_chars(memory.data(), memory.data() + memory.size(), result);
+    if (ret.ec == std::errc() && ret.ptr == memory.data() + memory.size())
+        return result;
+    else
+        return 4 * 1024 * 1024;  //nMinDbCache = 4;
 }
 
 // Prefixed with null character to avoid collisions with other keys

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -13,6 +13,7 @@
 #include <memenv.h>
 #include <stdint.h>
 #include <algorithm>
+#include <charconv>
 
 class CBitcoinLevelDBLogger : public leveldb::Logger {
 public:
@@ -203,7 +204,10 @@ size_t CDBWrapper::DynamicMemoryUsage() const {
         LogPrint(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
         return 0;
     }
-    return stoul(memory);
+    // Use std::from_chars for locale-independent conversion
+    size_t result = 0;
+    std::from_chars(memory.data(), memory.data() + memory.size(), result);
+    return result;
 }
 
 // Prefixed with null character to avoid collisions with other keys

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -139,7 +139,14 @@ static bool RPCAuthorized(const std::string& strAuth, std::string& strAuthUserna
     if (strAuth.substr(0, 6) != "Basic ")
         return false;
     std::string strUserPass64 = strAuth.substr(6);
-    boost::trim(strUserPass64);
+    // Trim left
+    strUserPass64.erase(strUserPass64.begin(),
+                        std::find_if(strUserPass64.begin(), strUserPass64.end(),
+                                    [](char c) { return !IsSpace(c); }));
+    // Trim right
+    strUserPass64.erase(std::find_if(strUserPass64.rbegin(), strUserPass64.rend(),
+                                     [](char c) { return !IsSpace(c); }).base(),
+                        strUserPass64.end());
     std::string strUserPass = DecodeBase64(strUserPass64);
 
     if (strUserPass.find(':') != std::string::npos)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -631,7 +631,12 @@ static void CleanupBlockRevFiles()
     for (const std::pair<const std::string, fs::path>& item : mapBlockFiles) {
         // Use std::from_chars for locale-independent conversion
         int fileIndex = 0;
-        std::from_chars(item.first.data(), item.first.data() + item.first.size(), fileIndex);
+        auto result = std::from_chars(item.first.data(), item.first.data() + item.first.size(), fileIndex);
+        // Skip files with invalid indices (parsing failed or didn't consume entire string)
+        if (result.ec != std::errc{} || result.ptr != item.first.data() + item.first.size()) {
+            remove(item.second);
+            continue;
+        }
         if (fileIndex == nContigCounter) {
             nContigCounter++;
             continue;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -60,6 +60,7 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 
+#include <charconv>
 #include <thread>
 
 #if ENABLE_ZMQ
@@ -628,7 +629,10 @@ static void CleanupBlockRevFiles()
     // start removing block files.
     int nContigCounter = 0;
     for (const std::pair<const std::string, fs::path>& item : mapBlockFiles) {
-        if (atoi(item.first) == nContigCounter) {
+        // Use std::from_chars for locale-independent conversion
+        int fileIndex = 0;
+        std::from_chars(item.first.data(), item.first.data() + item.first.size(), fileIndex);
+        if (fileIndex == nContigCounter) {
             nContigCounter++;
             continue;
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,10 +30,8 @@
 #include <util.h>
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
-#include <util.h>
 #include <trace.h>
-#include <validation.h>
-#include  <utiltime.h>
+#include <utiltime.h>
 #include <file_io.h>
 
 #include <deque>

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -36,8 +36,7 @@ static std::atomic<bool> interruptSocks5Recv(false);
 
 enum Network ParseNetwork(std::string net) {
     // Locale-independent lowercase conversion
-    std::transform(net.begin(), net.end(), net.begin(),
-                  [](unsigned char c) { return (c >= 'A' && c <= 'Z') ? c + 32 : c; });
+    std::transform(net.begin(), net.end(), net.begin(), ToLower);
     if (net == "ipv4") return NET_IPV4;
     if (net == "ipv6") return NET_IPV6;
     if (net == "onion") return NET_ONION;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -19,8 +19,6 @@
 #include <fcntl.h>
 #endif
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
-
 #if !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
 #endif
@@ -37,7 +35,9 @@ static const int SOCKS5_RECV_TIMEOUT = 20 * 1000;
 static std::atomic<bool> interruptSocks5Recv(false);
 
 enum Network ParseNetwork(std::string net) {
-    boost::to_lower(net);
+    // Locale-independent lowercase conversion
+    std::transform(net.begin(), net.end(), net.begin(),
+                  [](unsigned char c) { return (c >= 'A' && c <= 'Z') ? c + 32 : c; });
     if (net == "ipv4") return NET_IPV4;
     if (net == "ipv6") return NET_IPV6;
     if (net == "onion") return NET_ONION;

--- a/src/primitives/xfield.cpp
+++ b/src/primitives/xfield.cpp
@@ -18,7 +18,8 @@ inline std::string XFieldMaxBlockSize::ToString() const {
 template <typename T>
 bool GetXFieldValueFrom(XFieldData& xfieldValue, T& value) {
     value = std::get<T>(xfieldValue);
-    return std::atoi(value.BLOCKTREE_DB_KEY) == GetXFieldTypeFrom(xfieldValue);
+    // Convert character digit to integer without locale dependency
+    return (value.BLOCKTREE_DB_KEY - '0') == static_cast<int>(GetXFieldTypeFrom(xfieldValue));
 }
 
 std::string CXField::ToString() const {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -17,6 +17,7 @@
 #include <rpc/server.h>
 #include <rpc/client.h>
 #include <util.h>
+#include <utilstrencodings.h>
 
 #include <univalue.h>
 
@@ -228,7 +229,7 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                                 {
                                     // Check all characters are digits (locale-independent)
                                     for(char argch: curarg)
-                                        if (argch < '0' || argch > '9')
+                                        if (!IsDigit(argch))
                                             throw std::runtime_error("Invalid result query");
                                     // Use std::from_chars for locale-independent conversion
                                     int index = 0;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -20,6 +20,8 @@
 
 #include <univalue.h>
 
+#include <charconv>
+
 #if ENABLE_WALLET
 #include <db_cxx.h>
 #include <wallet/wallet.h>
@@ -224,10 +226,14 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                                 UniValue subelement;
                                 if (lastResult.isArray())
                                 {
+                                    // Check all characters are digits (locale-independent)
                                     for(char argch: curarg)
-                                        if (!std::isdigit(argch))
+                                        if (argch < '0' || argch > '9')
                                             throw std::runtime_error("Invalid result query");
-                                    subelement = lastResult[atoi(curarg.c_str())];
+                                    // Use std::from_chars for locale-independent conversion
+                                    int index = 0;
+                                    std::from_chars(curarg.data(), curarg.data() + curarg.size(), index);
+                                    subelement = lastResult[index];
                                 }
                                 else if (lastResult.isObject())
                                     subelement = lastResult.find_value(curarg);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -233,7 +233,9 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                                             throw std::runtime_error("Invalid result query");
                                     // Use std::from_chars for locale-independent conversion
                                     int index = 0;
-                                    std::from_chars(curarg.data(), curarg.data() + curarg.size(), index);
+                                    auto index_result = std::from_chars(curarg.data(), curarg.data() + curarg.size(), index);
+                                    if (index_result.ec != std::errc{} || index_result.ptr != curarg.data() + curarg.size())
+                                        throw std::runtime_error("Invalid result query");
                                     subelement = lastResult[index];
                                 }
                                 else if (lastResult.isObject())

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -23,6 +23,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <charconv>
 #include <univalue.h>
 
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
@@ -137,8 +138,10 @@ static bool rest_headers(HTTPRequest* req,
     if (path.size() != 2)
         return RESTERR(req, HTTP_BAD_REQUEST, "No header count specified. Use /rest/headers/<count>/<hash>.<ext>.");
 
-    long count = strtol(path[0].c_str(), nullptr, 10);
-    if (count < 1 || count > 2000)
+    // Use std::from_chars for locale-independent conversion
+    long count = 0;
+    auto result = std::from_chars(path[0].data(), path[0].data() + path[0].size(), count);
+    if (result.ec != std::errc() || count < 1 || count > 2000)
         return RESTERR(req, HTTP_BAD_REQUEST, "Header count out of range: " + path[0]);
 
     std::string hashStr = path[1];

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -141,7 +141,7 @@ static bool rest_headers(HTTPRequest* req,
     // Use std::from_chars for locale-independent conversion
     long count = 0;
     auto result = std::from_chars(path[0].data(), path[0].data() + path[0].size(), count);
-    if (result.ec != std::errc() || count < 1 || count > 2000)
+    if (result.ec != std::errc() || result.ptr != path[0].data() + path[0].size() || count < 1 || count > 2000)
         return RESTERR(req, HTTP_BAD_REQUEST, "Header count out of range: " + path[0]);
 
     std::string hashStr = path[1];

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -30,6 +30,7 @@
 
 #include <memory>
 #include <chrono>
+#include <charconv>
 
 #include <stdint.h>
 #include <policy/policy.h>
@@ -172,7 +173,14 @@ UniValue getnewblock(const JSONRPCRequest& request)
 
         //using lambda to avoid temp variables
         xfield.xfieldType = [xfieldParam](int splitAt, TAPYRUS_XFIELDTYPES max) -> TAPYRUS_XFIELDTYPES
-            { int x = splitAt > 0 ? atoi(xfieldParam.substr(0,splitAt)) : 0;
+            {
+            int x = 0;
+            if (splitAt > 0) {
+                // Use std::from_chars for locale-independent conversion
+                const char* start = xfieldParam.data();
+                const char* end = start + splitAt;
+                std::from_chars(start, end, x);
+            }
             return x > 0 && x <= int(max) ? TAPYRUS_XFIELDTYPES(x) : TAPYRUS_XFIELDTYPES::NONE;
             } (xfieldParam.find(':'), TAPYRUS_XFIELDTYPES::MAXBLOCKSIZE );
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -17,7 +17,6 @@
 #include <rpc/protocol.h>
 
 #include <boost/signals2/signal.hpp>
-#include <boost/algorithm/string/case_conv.hpp> // for to_upper()
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
@@ -206,7 +205,9 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
                         strRet += "\n";
                     category = pcmd->category;
                     std::string firstLetter = category.substr(0,1);
-                    boost::to_upper(firstLetter);
+                    // Locale-independent uppercase conversion
+                    std::transform(firstLetter.begin(), firstLetter.end(), firstLetter.begin(),
+                                  [](unsigned char c) { return (c >= 'a' && c <= 'z') ? c - 32 : c; });
                     strRet += "== " + firstLetter + category.substr(1) + " ==\n";
                 }
             }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -206,8 +206,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
                     category = pcmd->category;
                     std::string firstLetter = category.substr(0,1);
                     // Locale-independent uppercase conversion
-                    std::transform(firstLetter.begin(), firstLetter.end(), firstLetter.begin(),
-                                  [](unsigned char c) { return (c >= 'a' && c <= 'z') ? c - 32 : c; });
+                    std::transform(firstLetter.begin(), firstLetter.end(), firstLetter.begin(), ToUpper);
                     strRet += "== " + firstLetter + category.substr(1) + " ==\n";
                 }
             }

--- a/src/tapyrus-tx.cpp
+++ b/src/tapyrus-tx.cpp
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <stdio.h>
+#include <charconv>
 
 #include <boost/algorithm/string.hpp>
 
@@ -253,8 +254,11 @@ static void MutateTxAddInput(CMutableTransaction& tx, const std::string& strInpu
 
     // extract the optional sequence number
     uint32_t nSequenceIn=std::numeric_limits<unsigned int>::max();
-    if (vStrInputParts.size() > 2)
-        nSequenceIn = std::stoul(vStrInputParts[2]);
+    if (vStrInputParts.size() > 2) {
+        // Use std::from_chars for locale-independent conversion
+        const auto& str = vStrInputParts[2];
+        std::from_chars(str.data(), str.data() + str.size(), nSequenceIn);
+    }
 
     // append to transaction input list
     CTxIn txin(txid, vout, CScript(), nSequenceIn);
@@ -334,11 +338,13 @@ static void MutateTxAddOutMultiSig(CMutableTransaction& tx, const std::string& s
     // Extract and validate VALUE
     CAmount value = ExtractAndValidateValue(vStrInputParts[0]);
 
-    // Extract REQUIRED
-    uint32_t required = stoul(vStrInputParts[1]);
+    // Extract REQUIRED - use std::from_chars for locale-independent conversion
+    uint32_t required = 0;
+    std::from_chars(vStrInputParts[1].data(), vStrInputParts[1].data() + vStrInputParts[1].size(), required);
 
-    // Extract NUMKEYS
-    uint32_t numkeys = stoul(vStrInputParts[2]);
+    // Extract NUMKEYS - use std::from_chars for locale-independent conversion
+    uint32_t numkeys = 0;
+    std::from_chars(vStrInputParts[2].data(), vStrInputParts[2].data() + vStrInputParts[2].size(), numkeys);
 
     // Validate there are the correct number of pubkeys
     if (vStrInputParts.size() < numkeys + 3)
@@ -745,7 +751,12 @@ static std::string readStdin()
     if (ferror(stdin))
         throw std::runtime_error("error reading stdin");
 
-    boost::algorithm::trim_right(ret);
+    // Locale-independent trim_right
+    while (!ret.empty() && (ret.back() == ' ' || ret.back() == '\t' ||
+                            ret.back() == '\n' || ret.back() == '\r' ||
+                            ret.back() == '\v' || ret.back() == '\f')) {
+        ret.pop_back();
+    }
 
     return ret;
 }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -276,14 +276,13 @@ struct StringContentsSerializer {
 
 BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
-    char buf[10];
-
     fs::path ph = SetDataDir("iterator_string_ordering");
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {
-            snprintf(buf, sizeof(buf), "%d", x);
-            StringContentsSerializer key(buf);
+            // Use std::to_string for locale-independent conversion
+            std::string buf = std::to_string(x);
+            StringContentsSerializer key(buf.c_str());
             for (int z = 0; z < y; z++)
                 key += key;
             uint32_t value = x*x;
@@ -293,13 +292,14 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 
     std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper&>(dbw).NewIterator());
     for (int seek_start : {0, 5}) {
-        snprintf(buf, sizeof(buf), "%d", seek_start);
-        StringContentsSerializer seek_key(buf);
+        // Use std::to_string for locale-independent conversion
+        std::string buf_seek = std::to_string(seek_start);
+        StringContentsSerializer seek_key(buf_seek.c_str());
         it->Seek(seek_key);
         for (unsigned int x=seek_start; x<10; ++x) {
             for (int y = 0; y < 10; y++) {
-                snprintf(buf, sizeof(buf), "%d", x);
-                std::string exp_key(buf);
+                // Use std::to_string for locale-independent conversion
+                std::string exp_key = std::to_string(x);
                 for (int z = 0; z < y; z++)
                     exp_key += exp_key;
                 StringContentsSerializer key;

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -17,8 +17,9 @@ BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 static void ResetArgs(const std::string& strArg)
 {
     std::vector<std::string> vecArg;
-    if (strArg.size())
-      boost::split(vecArg, strArg, boost::is_space(), boost::token_compress_on);
+    if (strArg.size()) {
+      boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
+    }
 
     // Insert dummy executable name:
     vecArg.insert(vecArg.begin(), "testtapyrus");

--- a/src/test/timeoffsets_tests.cpp
+++ b/src/test/timeoffsets_tests.cpp
@@ -4,7 +4,7 @@
 //
 
 #include <timeoffsets.h>
-#include "test_tapyrus.h"
+#include <test_tapyrus.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -12,7 +12,6 @@
 #include <serialize.h>
 #include <streams.h>
 #include <random.h>
-#include <script/script.h>
 #include <test/test_tapyrus.h>
 #include <utilstrencodings.h>
 #include <util.h>

--- a/src/test/xfield_tests.cpp
+++ b/src/test/xfield_tests.cpp
@@ -8,8 +8,8 @@
 #include <xfieldhistory.h>
 #include <txdb.h>
 #include <univalue.h>
-#include <test_tapyrus.h>
-#include <test_keys_helper.h>
+#include <test/test_tapyrus.h>
+#include <test/test_keys_helper.h>
 
 /* 
  * xfield_tests  - serialize and deserialize xfieldchange anf CXField

--- a/src/test/xfield_tests.cpp
+++ b/src/test/xfield_tests.cpp
@@ -8,8 +8,8 @@
 #include <xfieldhistory.h>
 #include <txdb.h>
 #include <univalue.h>
-#include "test_tapyrus.h"
-#include "test_keys_helper.h"
+#include <test_tapyrus.h>
+#include <test_keys_helper.h>
 
 /* 
  * xfield_tests  - serialize and deserialize xfieldchange anf CXField

--- a/src/test/xfieldhistory_tests.cpp
+++ b/src/test/xfieldhistory_tests.cpp
@@ -8,8 +8,8 @@
 #include <xfieldhistory.h>
 #include <txdb.h>
 #include <univalue.h>
-#include "test_tapyrus.h"
-#include "test_keys_helper.h"
+#include <test_tapyrus.h>
+#include <test_keys_helper.h>
 
 /* 
  * As XFieldHistory is a global, the order of execution of test in this file seems to affect the results.

--- a/src/test/xfieldhistory_tests.cpp
+++ b/src/test/xfieldhistory_tests.cpp
@@ -8,8 +8,8 @@
 #include <xfieldhistory.h>
 #include <txdb.h>
 #include <univalue.h>
-#include <test_tapyrus.h>
-#include <test_keys_helper.h>
+#include <test/test_tapyrus.h>
+#include <test/test_keys_helper.h>
 
 /* 
  * As XFieldHistory is a global, the order of execution of test in this file seems to affect the results.

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <deque>
 #include <set>
+#include <charconv>
 #include <stdlib.h>
 
 #include <boost/signals2/signal.hpp>
@@ -145,7 +146,8 @@ void TorControlConnection::readcb(struct bufferevent *bev, void *ctx)
         if (s.size() < 4) // Short line
             continue;
         // <status>(-|+| )<data><CRLF>
-        self->message.code = atoi(s.substr(0,3));
+        // Use std::from_chars for locale-independent conversion
+        std::from_chars(s.data(), s.data() + 3, self->message.code);
         self->message.lines.push_back(s.substr(4));
         char ch = s[3]; // '-','+' or ' '
         if (ch == ' ') {
@@ -331,7 +333,10 @@ std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
                         if (j == 3 && value[i] > '3') {
                             j--;
                         }
-                        escaped_value.push_back(strtol(value.substr(i, j).c_str(), nullptr, 8));
+                        // Use std::from_chars for locale-independent octal conversion
+                        int octal_val = 0;
+                        std::from_chars(value.data() + i, value.data() + i + j, octal_val, 8);
+                        escaped_value.push_back(octal_val);
                         // Account for automatic incrementing at loop end
                         i += j - 1;
                     } else {

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -29,11 +29,11 @@ void base_blob<BITS>::SetHex(const char* psz)
     memset(data, 0, sizeof(data));
 
     // skip leading spaces
-    while (isspace(*psz))
+    while (IsSpace(*psz))
         psz++;
 
     // skip 0x
-    if (psz[0] == '0' && tolower(psz[1]) == 'x')
+    if (psz[0] == '0' && (psz[1] == 'x' || psz[1] == 'X'))
         psz += 2;
 
     // hex string to uint

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <stdint.h>
+#include <charconv>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
@@ -32,31 +33,22 @@ bool ParseInt32(const std::string& str, int32_t *out)
 {
     if (!ParsePrechecks(str))
         return false;
-    char *endp = NULL;
-    errno = 0; // strtol will not set errno if valid
-    long int n = strtol(str.c_str(), &endp, 10);
-    if(out) *out = (int32_t)n;
-    // Note that strtol returns a *long int*, so even if strtol doesn't report a over/underflow
-    // we still have to check that the returned value is within the range of an *int32_t*. On 64-bit
-    // platforms the size of these types may be different.
-    return endp && *endp == 0 && !errno &&
-        n >= std::numeric_limits<int32_t>::min() &&
-        n <= std::numeric_limits<int32_t>::max();
+    int32_t n = 0;
+    const char* data = str.data();
+    auto result = std::from_chars(data, data + str.size(), n);
+    if (out) *out = n;
+    return result.ec == std::errc() && result.ptr == data + str.size();
 }
 
 bool ParseInt64(const std::string& str, int64_t *out)
 {
     if (!ParsePrechecks(str))
         return false;
-    char *endp = NULL;
-    errno = 0; // strtoll will not set errno if valid
-    long long int n = strtoll(str.c_str(), &endp, 10);
-    if(out) *out = (int64_t)n;
-    // Note that strtoll returns a *long long int*, so even if strtol doesn't report a over/underflow
-    // we still have to check that the returned value is within the range of an *int64_t*.
-    return endp && *endp == 0 && !errno &&
-        n >= std::numeric_limits<int64_t>::min() &&
-        n <= std::numeric_limits<int64_t>::max();
+    int64_t n = 0;
+    const char* data = str.data();
+    auto result = std::from_chars(data, data + str.size(), n);
+    if (out) *out = n;
+    return result.ec == std::errc() && result.ptr == data + str.size();
 }
 
 bool ParseDouble(const std::string& str, double *out)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -379,8 +379,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
         }
 #ifdef WIN32
         // Convert to lowercase without locale dependency
-        std::transform(key.begin(), key.end(), key.begin(),
-                      [](unsigned char c) { return (c >= 'A' && c <= 'Z') ? c + 32 : c; });
+        std::transform(key.begin(), key.end(), key.begin(), ToLower);
         if (key[0] == '/')
             key[0] = '-';
 #endif

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -21,7 +21,7 @@ std::string FormatMoney(const CAmount& n)
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
     // Locale-independent digit check
-    for (int i = str.size()-1; (str[i] == '0' && str[i-2] >= '0' && str[i-2] <= '9'); --i)
+    for (int i = str.size()-1; (str[i] == '0' && IsDigit(str[i-2])); --i)
         ++nTrim;
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -20,7 +20,8 @@ std::string FormatMoney(const CAmount& n)
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
-    for (int i = str.size()-1; (str[i] == '0' && isdigit(str[i-2])); --i)
+    // Locale-independent digit check
+    for (int i = str.size()-1; (str[i] == '0' && str[i-2] >= '0' && str[i-2] <= '9'); --i)
         ++nTrim;
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);
@@ -41,7 +42,7 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
     std::string strWhole;
     int64_t nUnits = 0;
     const char* p = pszIn;
-    while (isspace(*p))
+    while (IsSpace(*p))
         p++;
     for (; *p; p++)
     {
@@ -49,21 +50,21 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
         {
             p++;
             int64_t nMult = CENT*10;
-            while (isdigit(*p) && (nMult > 0))
+            while (IsDigit(*p) && (nMult > 0))
             {
                 nUnits += nMult * (*p++ - '0');
                 nMult /= 10;
             }
             break;
         }
-        if (isspace(*p))
+        if (IsSpace(*p))
             break;
-        if (!isdigit(*p))
+        if (!IsDigit(*p))
             return false;
         strWhole.insert(strWhole.end(), *p);
     }
     for (; *p; p++)
-        if (!isspace(*p))
+        if (!IsSpace(*p))
             return false;
     if (strWhole.size() > 10) // guard against 63 bit overflow
         return false;

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -75,6 +75,16 @@ constexpr bool IsDigit(char c)
 }
 
 /**
+ * Tests if the given character is a whitespace character (locale-independent).
+ * @param[in] c     character to test
+ * @return          true if the argument is a whitespace character; otherwise false.
+ */
+constexpr bool IsSpace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f';
+}
+
+/**
  * Convert string to signed 32-bit integer with strict parse error feedback.
  * @returns true if the entire string could be parsed as valid integer,
  *   false if not the entire string could be parsed or when overflow or underflow occurred.

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -85,6 +85,26 @@ constexpr bool IsSpace(char c)
 }
 
 /**
+ * Converts a character to lowercase (locale-independent).
+ * @param[in] c     character to convert
+ * @return          lowercase version of the character if it's uppercase; otherwise unchanged.
+ */
+constexpr unsigned char ToLower(unsigned char c)
+{
+    return (c >= 'A' && c <= 'Z') ? c + 32 : c;
+}
+
+/**
+ * Converts a character to uppercase (locale-independent).
+ * @param[in] c     character to convert
+ * @return          uppercase version of the character if it's lowercase; otherwise unchanged.
+ */
+constexpr unsigned char ToUpper(unsigned char c)
+{
+    return (c >= 'a' && c <= 'z') ? c - 32 : c;
+}
+
+/**
  * Convert string to signed 32-bit integer with strict parse error feedback.
  * @returns true if the entire string could be parsed as valid integer,
  *   false if not the entire string could be parsed or when overflow or underflow occurred.

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -12,7 +12,7 @@
 #include <atomic>
 #include <ctime>
 #include <thread>
-#include <iomanip>
+#include <sstream>
 #include <tinyformat.h>
 
 static std::atomic<std::chrono::seconds> nMockTime{}; //!< For testing
@@ -89,21 +89,22 @@ std::tm fromTimePoint(int64_t nTime) {
 
 std::string FormatISO8601DateTime(int64_t nTime) {
     std::tm tm = fromTimePoint(nTime);
-    std::ostringstream oss;
-    oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
-    return oss.str();
+    // Manual formatting to avoid locale-dependent std::put_time
+    return strprintf("%04d-%02d-%02dT%02d:%02d:%02dZ",
+                     tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+                     tm.tm_hour, tm.tm_min, tm.tm_sec);
 }
 
 std::string FormatISO8601Date(int64_t nTime) {
     std::tm tm = fromTimePoint(nTime);
-    std::ostringstream oss;
-    oss << std::put_time(&tm, "%Y-%m-%d");
-    return oss.str();
+    // Manual formatting to avoid locale-dependent std::put_time
+    return strprintf("%04d-%02d-%02d",
+                     tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
 }
 
 std::string FormatISO8601Time(int64_t nTime) {
     std::tm tm = fromTimePoint(nTime);
-    std::ostringstream oss;
-    oss << std::put_time(&tm, "%H:%M:%SZ");
-    return oss.str();
+    // Manual formatting to avoid locale-dependent std::put_time
+    return strprintf("%02d:%02d:%02dZ",
+                     tm.tm_hour, tm.tm_min, tm.tm_sec);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -31,7 +31,6 @@
 #include <utilmoneystr.h>
 #include <warnings.h>
 #include <xfieldhistory.h>
-#include <core_io.h>
 
 #include <future>
 #include <thread>

--- a/test/lint/pending-lint-locale-dependence.sh
+++ b/test/lint/pending-lint-locale-dependence.sh
@@ -2,38 +2,9 @@
 
 export LC_ALL=C
 KNOWN_VIOLATIONS=(
-    "src/base58.cpp:.*isspace"
-    "src/tapyrus-tx.cpp.*stoul"
-    "src/tapyrus-tx.cpp.*trim_right"
-    "src/tapyrus-tx.cpp:.*atoi"
-    "src/core_read.cpp.*is_digit"
-    "src/dbwrapper.cpp.*stoul"
-    "src/dbwrapper.cpp:.*vsnprintf"
-    "src/httprpc.cpp.*trim"
-    "src/init.cpp:.*atoi"
-    "src/netbase.cpp.*to_lower"
-    "src/qt/rpcconsole.cpp:.*atoi"
-    "src/qt/rpcconsole.cpp:.*isdigit"
-    "src/rest.cpp:.*strtol"
-    "src/rpc/server.cpp.*to_upper"
-    "src/test/dbwrapper_tests.cpp:.*snprintf"
-    "src/test/getarg_tests.cpp.*split"
-    "src/torcontrol.cpp:.*atoi"
-    "src/torcontrol.cpp:.*strtol"
-    "src/uint256.cpp:.*isspace"
-    "src/uint256.cpp:.*tolower"
-    "src/util.cpp:.*atoi"
-    "src/util.cpp:.*fprintf"
-    "src/util.cpp:.*tolower"
-    "src/utilmoneystr.cpp:.*isdigit"
-    "src/utilmoneystr.cpp:.*isspace"
-    "src/utilstrencodings.cpp:.*atoi"
-    "src/utilstrencodings.cpp:.*isspace"
-    "src/utilstrencodings.cpp:.*strtol"
-    "src/utilstrencodings.cpp:.*strtoll"
-    "src/utilstrencodings.cpp:.*strtoul"
-    "src/utilstrencodings.cpp:.*strtoull"
-    "src/utilstrencodings.h:.*atoi"
+    "src/utilstrencodings.cpp:int atoi"  # Custom locale-independent wrapper using std::from_chars
+    "src/utilstrencodings.h:int atoi"    # Custom locale-independent wrapper declaration
+    "src/dbwrapper.cpp:.*vsnprintf"      # LevelDB logger adapter (see comment in file)
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"
@@ -199,11 +170,11 @@ REGEXP_IGNORE_KNOWN_VIOLATIONS=$(join_array "|" "${KNOWN_VIOLATIONS[@]}")
 
 # Invoke "git grep" only once in order to minimize run-time
 REGEXP_LOCALE_DEPENDENT_FUNCTIONS=$(join_array "|" "${LOCALE_DEPENDENT_FUNCTIONS[@]}")
-GIT_GREP_OUTPUT=$(git grep -E "[^a-zA-Z0-9_\`'\"<>](${REGEXP_LOCALE_DEPENDENT_FUNCTIONS}(|_r|_s))[^a-zA-Z0-9_\`'\"<>]" -- "*.cpp" "*.h")
+GIT_GREP_OUTPUT=$(git grep -E "[^a-zA-Z0-9_\`'\"<>](${REGEXP_LOCALE_DEPENDENT_FUNCTIONS})(_r|_s)?[^a-zA-Z0-9_\`'\"<>]" -- "*.cpp" "*.h" 2>/dev/null || true)
 
 EXIT_CODE=0
 for LOCALE_DEPENDENT_FUNCTION in "${LOCALE_DEPENDENT_FUNCTIONS[@]}"; do
-    MATCHES=$(grep -E "[^a-zA-Z0-9_\`'\"<>]${LOCALE_DEPENDENT_FUNCTION}(|_r|_s)[^a-zA-Z0-9_\`'\"<>]" <<< "${GIT_GREP_OUTPUT}" | \
+    MATCHES=$(grep -E "[^a-zA-Z0-9_]${LOCALE_DEPENDENT_FUNCTION}(_r|_s)?[^a-zA-Z0-9_]" <<< "${GIT_GREP_OUTPUT}" | \
         grep -vE "\.(c|cpp|h):\s*(//|\*|/\*|\").*${LOCALE_DEPENDENT_FUNCTION}" | \
         grep -vE 'fprintf\(.*(stdout|stderr)')
     if [[ ${REGEXP_IGNORE_EXTERNAL_DEPENDENCIES} != "" ]]; then


### PR DESCRIPTION
Remove all locale dependent function usages in tapyrus. Replacement code is standard library functions wherever possible.
Edit the lint checking script to update the list known violations. 