### PR TITLE
Fix guix builds

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -494,9 +494,9 @@ inspecting signatures in Mach-O binaries.")
         pkg-config
         bison
         cmake-minimal
-        ;; Native GCC 10 toolchain
-        gcc-toolchain-10
-        (list gcc-toolchain-10 "static")
+        ;; Native GCC 11 toolchain
+        gcc-toolchain-11
+        (list gcc-toolchain-11 "static")
         ;; Scripting
         python-minimal ;; (3.10)
         perl

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -17,6 +17,8 @@ NO_WALLET ?=
 NO_UPNP ?=
 NO_USDT ?=
 FALLBACK_DOWNLOAD_PATH ?= https://s3-ap-northeast-1.amazonaws.com/repo.tapyrus.chaintope.com
+C_STANDARD ?= c11
+CXX_STANDARD ?= c++20
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)
@@ -85,6 +87,8 @@ build_id_string:=$(BUILD_ID_SALT)
 build_id_string+=$(shell $(build_CC) --version 2>/dev/null)
 build_id_string+=$(shell $(build_AR) --version 2>/dev/null)
 build_id_string+=$(shell $(build_CXX) --version 2>/dev/null)
+build_id_string+=$(C_STANDARD)
+build_id_string+=$(CXX_STANDARD)
 build_id_string+=$(shell $(build_RANLIB) --version 2>/dev/null)
 build_id_string+=$(shell $(build_STRIP) --version 2>/dev/null)
 
@@ -92,6 +96,8 @@ $(host_arch)_$(host_os)_id_string:=$(HOST_ID_SALT)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_CC) --version 2>/dev/null)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_AR) --version 2>/dev/null)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_CXX) --version 2>/dev/null)
+$(host_arch)_$(host_os)_id_string+=$(C_STANDARD)
+$(host_arch)_$(host_os)_id_string+=$(CXX_STANDARD)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_RANLIB) --version 2>/dev/null)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_STRIP) --version 2>/dev/null)
 

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -74,22 +74,23 @@ ifeq ($(build_os),darwin)
 # Native macOS build - simpler flags
 darwin_CC=$(clang_prog) -mmacosx-version-min=$(OSX_MIN_VERSION) -isysroot $(OSX_SDK)
 darwin_CXX=$(clangxx_prog) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ -isysroot $(OSX_SDK)
-darwin_CFLAGS=-pipe -std=c11
-darwin_CXXFLAGS=-pipe -std=c++17
+darwin_CFLAGS=-pipe -std=$(C_STANDARD)
+darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
 darwin_LDFLAGS=-Wl,-platform_version,macos,$(OSX_MIN_VERSION),$(OSX_SDK_VERSION)
 else
-# Cross-compilation build - full flags with target specification
-darwin_CC=$(clang_prog) --target=$(host) \
-              -isysroot $(OSX_SDK) --stdlib=libc++ \
+# Cross-compilation build - keep CC/CXX simple, put all flags in CFLAGS/CXXFLAGS
+darwin_CC=$(clang_prog)
+darwin_CXX=$(clangxx_prog)
+
+darwin_CFLAGS=-pipe -std=$(C_STANDARD) -mmacos-version-min=$(OSX_MIN_VERSION) --target=$(host) \
+              -isysroot $(OSX_SDK) \
               -iwithsysroot/usr/include -iframeworkwithsysroot/System/Library/Frameworks
 
-darwin_CXX=$(clangxx_prog) --target=$(host) \
-               -isysroot $(OSX_SDK) --stdlib=libc++ \
-               -iwithsysroot/usr/include/c++/v1 \
-               -iwithsysroot/usr/include -iframeworkwithsysroot/System/Library/Frameworks
+darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD) -mmacos-version-min=$(OSX_MIN_VERSION) --target=$(host) \
+                -isysroot $(OSX_SDK) --stdlib=libc++ \
+                -iwithsysroot/usr/include/c++/v1 \
+                -iwithsysroot/usr/include -iframeworkwithsysroot/System/Library/Frameworks
 
-darwin_CFLAGS=-pipe -std=c11 -mmacos-version-min=$(OSX_MIN_VERSION) --target=$(host) -isysroot $(OSX_SDK)
-darwin_CXXFLAGS=-pipe -std=c++17 -mmacos-version-min=$(OSX_MIN_VERSION) --target=$(host) -isysroot $(OSX_SDK)
 darwin_LDFLAGS=-Wl,-platform_version,macos,$(OSX_MIN_VERSION),$(OSX_SDK_VERSION)
 endif
 

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,31 +1,25 @@
 package=miniupnpc
-$(package)_version=2.2.2
+$(package)_version=2.3.3
 $(package)_download_path=https://miniupnp.tuxfamily.org/files/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
-$(package)_patches=dont_leak_info.patch respect_mingw_cflags.patch no_libtool.patch
+$(package)_sha256_hash=d52a0afa614ad6c088cc9ddff1ae7d29c8c595ac5fdd321170a05f41e634bd1a
 
-# Next time this package is updated, ensure that _WIN32_WINNT is still properly set.
-# See discussion in https://github.com/bitcoin/bitcoin/pull/25964.
+# Version 2.3.3 has native CMake support with proper cross-compilation handling
 define $(package)_set_vars
-$(package)_build_opts=CC="$($(package)_cc)"
-$(package)_config_opts = --disable-static
-$(package)_build_opts_mingw32=-f Makefile.mingw CFLAGS="$($(package)_cflags) -D_WIN32_WINNT=0x0601"
-$(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
+$(package)_cmake_opts=-DUPNPC_BUILD_STATIC=ON -DUPNPC_BUILD_SHARED=OFF
+$(package)_cmake_opts+=-DUPNPC_BUILD_TESTS=OFF -DUPNPC_BUILD_SAMPLE=OFF
+$(package)_cmake_opts+=-DUPNPC_NO_INSTALL=OFF
+$(package)_cmake_opts_mingw32=-DMINIUPNPC_TARGET_WINDOWS_VERSION=0x0601
 endef
 
-define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/dont_leak_info.patch && \
-  patch -p1 < $($(package)_patch_dir)/respect_mingw_cflags.patch&& \
-  patch -p1 < $($(package)_patch_dir)/no_libtool.patch
+define $(package)_cmake_config_cmds
+  $($(package)_cmake) .
 endef
 
 define $(package)_build_cmds
-	$(MAKE) libminiupnpc.a $($(package)_build_opts)
+  $(MAKE)
 endef
 
 define $(package)_stage_cmds
-	mkdir -p $($(package)_staging_prefix_dir)/include/miniupnpc $($(package)_staging_prefix_dir)/lib &&\
-	install *.h $($(package)_staging_prefix_dir)/include/miniupnpc &&\
-	install libminiupnpc.a $($(package)_staging_prefix_dir)/lib
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -42,6 +42,9 @@ $(package)_config_opts_release += -silent
 $(package)_config_opts_debug = -debug
 $(package)_config_opts_debug += -optimized-tools
 $(package)_config_opts += -bindir $(build_prefix)/bin
+# Qt 5.15 only supports up to C++17
+# Filter out -std= from cxxflags since Qt's -c++std option will control the standard
+$(package)_cxxflags:=$(filter-out -std=%,$(host_CXXFLAGS))
 $(package)_config_opts += -c++std c++17
 $(package)_config_opts += -confirm-license
 $(package)_config_opts += -hostprefix $(build_prefix)


### PR DESCRIPTION
Qt 5 can only be built by c++17. But master branch is updated to build with c++20. So some dependencies of Qt were built with c++20 standard while Qt was built with c++17 standard. This caused segmentation fault in the compiler. This is fixed by hardcoding the c++17 standard in qt while using one common standard definition for the other dependencies. 