### PR TITLE
Fix crash introduced in PR #318 (Security fix6 getblocktxn) 

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -430,9 +430,6 @@ static bool MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const CBlock
     CNodeState *state = State(nodeid);
     assert(state != nullptr);
 
-    if(mapBlocksInFlight.count(hash) >= MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK)
-        return false;
-
     // Short-circuit most stuff in case it is from the same node
     for (auto range = mapBlocksInFlight.equal_range(hash); range.first != range.second; range.first++) {
         if (range.first->second.first == nodeid) {


### PR DESCRIPTION
If 3 or more requests exist, return false WITHOUT setting pit which caused a crash due to null pointer dereference as discovered by Claude code:
Crash Scenario

  1. node1 receives cmpctblock for block B from peer0, peer1, peer2
     → mapBlocksInFlight[B] = 3 entries

  2. node1 receives cmpctblock for block B from peer2 again
     → requested_block_from_this_peer = true (already requested from peer2)
     → already_in_flight = 3

  3. Condition evaluation:
     (already_in_flight < 3 && ...) || requested_block_from_this_peer
     = (false && ...) || true
     = true  ← Enters the if block!

  4. MarkBlockAsInFlight() is called:
     → mapBlocksInFlight.count(B) = 3 >= MAX(3)
     → Returns false WITHOUT setting pit
     → queuedBlockIt remains nullptr

  5. Dereference queuedBlockIt:
     if (!(*queuedBlockIt)->partialBlock)  // ← nullptr dereference → CRASH!
     
       The calling code (lines 2581-2591) assumes that when MarkBlockAsInFlight returns false, pit is always set. However, when the MAX limit is reached, pit is not set, resulting in a nullptr dereference.
       
  ---
  Evidence from Logs

  node1 2025-12-05T07:16:00.423261Z More than 3 requests for this block b74aed8e...
  node1 2025-12-05T07:16:00.423340Z received: cmpctblock (292 bytes) peer=2
  (Logs stop here with no shutdown message → Crash)