### PR TITLE
Ci optimizations

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -96,38 +96,6 @@ jobs:
             enable_usdt: false
             enable_wallet: false
           # macOS configurations with feature combinations(NO USDT support)
-          - name: M-X86-Deb-GUI+Wallet
-            os: macos-13
-            arch: x86_64
-            platform: macos
-            build_type: Debug
-            enable_gui: true
-            enable_usdt: false
-            enable_wallet: true
-          - name: M-X86-Rel-GUI+Wallet
-            os: macos-13
-            arch: x86_64
-            platform: macos
-            build_type: RelWithDebInfo
-            enable_gui: true
-            enable_usdt: false
-            enable_wallet: true
-          - name: M-X86-Rel-GUI+No_Wallet
-            os: macos-13
-            arch: x86_64
-            platform: macos
-            build_type: RelWithDebInfo
-            enable_gui: true
-            enable_usdt: false
-            enable_wallet: false
-          - name: M-X86-Rel-No_GUI+No_Wallet
-            os: macos-13
-            arch: x86_64
-            platform: macos
-            build_type: RelWithDebInfo
-            enable_gui: false
-            enable_usdt: false
-            enable_wallet: false
           - name: M-ARM-Deb-GUI+Wallet
             os: macos-latest
             arch: arm64
@@ -219,8 +187,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.DEPENDS_DIR }}
-          key: depends-v3-${{ matrix.config.platform }}-${{ matrix.config.arch }}-gui${{ matrix.config.enable_gui }}-wallet${{ matrix.config.enable_wallet }}-usdt${{ matrix.config.enable_usdt }}-${{ hashFiles('depends/packages/*') }}
-          restore-keys: depends-v3-${{ matrix.config.platform }}-${{ matrix.config.arch }}-gui${{ matrix.config.enable_gui }}-wallet${{ matrix.config.enable_wallet }}-usdt${{ matrix.config.enable_usdt }}-
+          key: depends-v4-${{ matrix.config.platform }}-${{ matrix.config.arch }}-${{ hashFiles('depends/packages/*') }}
+          restore-keys: depends-v4-${{ matrix.config.platform }}-${{ matrix.config.arch }}-
 
       - name: Restore Benchmark History cache
         if: (matrix.config.platform == 'linux' && matrix.config.arch == 'x86_64') || (matrix.config.platform == 'macos' && matrix.config.arch == 'arm64')
@@ -473,10 +441,11 @@ jobs:
           echo "---------------- ----------------- --------------- ---------------- "
 
       - name: Save Depends cache
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.DEPENDS_DIR }}
-          key: depends-v3-${{ matrix.config.platform }}-${{ matrix.config.arch }}-gui${{ matrix.config.enable_gui }}-wallet${{ matrix.config.enable_wallet }}-usdt${{ matrix.config.enable_usdt }}-${{ hashFiles('depends/packages/*') }}
+          key: depends-v4-${{ matrix.config.platform }}-${{ matrix.config.arch }}-${{ hashFiles('depends/packages/*') }}
 
       - name: Save Benchmark History cache
         if: always() && ((matrix.config.platform == 'linux' && matrix.config.arch == 'x86_64') || (matrix.config.platform == 'macos' && matrix.config.arch == 'arm64'))
@@ -801,7 +770,7 @@ jobs:
 
       - name: Save Ccache cache
         uses: actions/cache/save@v4
-        if: steps.ccache-cache.outputs.cache-hit != 'true'
+        if: steps.ccache-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
         with:
           path: ${{ env.CCACHE_DIR }}
           key: daily-${{ matrix.config.platform }}-${{ matrix.config.arch }}-${{ matrix.config.build_type }}-${{ matrix.config.enable_gui }}-${{ matrix.config.enable_usdt }}-${{ matrix.config.enable_wallet }}-ccache-${{ github.run_id }}


### PR DESCRIPTION
Remove x86_64 from daily ci host list as it is not supported by GitHub actions anymore.
Reduce the cache usage by keeping only the fully build depends folder for supported builds in the cache
Keep only the last master branch daily Ci output in the cache