### PR TITLE
Change the working directory of tapyrus builder container

### DIFF
--- a/depends/Dockerfile
+++ b/depends/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /tapyrus-core
+WORKDIR /tapyrus-core/depends
 
-COPY depends .
+COPY . .
 RUN  if [ "$TARGETARCH" = "arm64" ]; then BUILD_HOST="aarch64-unknown-linux-gnu"; else BUILD_HOST="x86_64-pc-linux-gnu"; fi && \
      make HOST=$BUILD_HOST NO_QT=1 -j"$(($(nproc)+1))" install_cmake


### PR DESCRIPTION
CI job [Push Tapyrus Builder Image](https://github.com/chaintope/tapyrus-core/actions/runs/21668168917) fails to build because of the change in working directory. This PR fixes it.