### PR TITLE
Fix GUIX linux cross compilation

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -75,15 +75,6 @@ host_prefix=$($(host_arch)_$(host_os)_prefix)
 build_prefix=$(host_prefix)/native
 build_host=$(build)
 
-# Cross-compilation detection using arch+os only, without Darwin version suffix.
-# config.guess returns e.g. arm64-apple-darwin24.5.0 while HOST is arm64-apple-darwin,
-# so a direct $(host) vs $(build) comparison incorrectly treats native macOS as cross.
-ifeq ($(host_arch)-$(host_os),$(build_arch)-$(build_os))
-  is_native_build=TRUE
-else
-  is_native_build=FALSE
-endif
-
 all: install
 
 include hosts/$(host_os).mk
@@ -167,7 +158,7 @@ $(host_prefix)/.stamp_cmake_$(cmake_build_id): $(native_packages) $(packages)
 	echo To build Tapyrus Core with these packages, pass \'--toolchain $(@D)/toolchain.cmake\' to the first CMake invocation.
 	touch $@
 
-ifeq ($(is_native_build),TRUE)
+ifeq ($(host),$(build))
   crosscompiling=FALSE
 else
   crosscompiling=TRUE

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -1,3 +1,8 @@
+# Strip Darwin version suffix from build triplet so native-build detection works.
+# config.guess returns e.g. arm64-apple-darwin24.5.0 while HOST is arm64-apple-darwin,
+# so strip the trailing version to make the $(host) == $(build) comparison succeed.
+build:=$(shell echo "$(build)" | sed 's/\(.*-apple-darwin\)[0-9.]*$$/\1/')
+
 build_darwin_CC:=$(shell xcrun -f clang) -isysroot$(shell xcrun --show-sdk-path)
 build_darwin_CXX:=$(shell xcrun -f clang++) -isysroot$(shell xcrun --show-sdk-path)
 build_darwin_AR:=$(shell xcrun -f ar)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -4,7 +4,7 @@ $(package)_version=$(qt_details_version)
 $(package)_download_path=$(qt_details_download_path)
 $(package)_file_name=$(qt_details_qtbase_file_name)
 $(package)_sha256_hash=$(qt_details_qtbase_sha256_hash)
-ifneq ($(is_native_build),TRUE)
+ifneq ($(host),$(build))
 $(package)_dependencies := native_$(package)
 endif
 $(package)_linux_dependencies := freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_cursor libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
@@ -74,7 +74,7 @@ $(package)_config_opts += -nomake tests
 $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-doubleconversion
 $(package)_config_opts += -qt-harfbuzz
-ifneq ($(is_native_build),TRUE)
+ifneq ($(host),$(build))
 $(package)_config_opts += -qt-host-path $(build_prefix)
 endif
 $(package)_config_opts += -qt-libpng
@@ -115,7 +115,7 @@ $(package)_config_opts += -no-feature-macdeployqt
 $(package)_config_opts += -no-feature-qmake
 $(package)_config_opts += -no-feature-windeployqt
 
-ifeq ($(is_native_build),TRUE)
+ifeq ($(host),$(build))
 # Qt Tools module.
 $(package)_config_opts += -feature-linguist
 $(package)_config_opts += -no-feature-assistant
@@ -184,7 +184,7 @@ $(package)_cmake_opts += -DCMAKE_EXE_LINKER_FLAGS="$$($$($(package)_type)_LDFLAG
 $(package)_cmake_opts += -DCMAKE_EXE_LINKER_FLAGS_RELEASE="$$($$($(package)_type)_release_LDFLAGS)"
 $(package)_cmake_opts += -DCMAKE_EXE_LINKER_FLAGS_DEBUG="$$($$($(package)_type)_debug_LDFLAGS)"
 
-ifneq ($(is_native_build),TRUE)
+ifneq ($(host),$(build))
 $(package)_cmake_opts += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system_name)
 $(package)_cmake_opts += -DCMAKE_SYSTEM_VERSION=$($(host_os)_cmake_system_version)
 $(package)_cmake_opts += -DCMAKE_SYSTEM_PROCESSOR=$(host_arch)
@@ -219,7 +219,7 @@ $(call fetch_file,$(package),$($(package)_top_cmake_download_path),$($(package)_
 $(call fetch_file,$(package),$($(package)_top_cmake_download_path),$($(package)_top_cmake_qttoplevelhelpers_download_file),$($(package)_top_cmake_qttoplevelhelpers_file_name)-$($(package)_version),$($(package)_top_cmake_qttoplevelhelpers_sha256_hash))
 endef
 
-ifeq ($(is_native_build),TRUE)
+ifeq ($(host),$(build))
 define $(package)_extract_cmds
   mkdir -p $($(package)_extract_dir) && \
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
@@ -265,14 +265,14 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/skip_xcode_version_check.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_qnetconmonitor_cross_compile.patch
 endef
-ifeq ($(is_native_build),TRUE)
+ifeq ($(host),$(build))
   $(package)_preprocess_cmds += && patch -p1 -i $($(package)_patch_dir)/qttools_skip_dependencies.patch
 endif
 # Fix CGDisplayCreateImageForRect obsoleted in macOS 15.0
 # Comment out the call and return empty pixmap (screen grab will fail gracefully)
 # Only needed for cross-compilation (native macOS builds use BSD sed which requires -i '')
 ifeq ($(host_os),darwin)
-ifneq ($(is_native_build),TRUE)
+ifneq ($(host),$(build))
   $(package)_preprocess_cmds += && sed -i 's/CGDisplayCreateImageForRect(displayId, grabRect.toCGRect())/nullptr \/* CGDisplayCreateImageForRect obsoleted in macOS 15 *\//' qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
 endif
 endif


### PR DESCRIPTION
Rollback commit d2075ffaab which fixed macos native build in the Ci but broke linux cross compilation in guix.
To fix the macOS native build, remove version suffix from config.guess output when it is a macOS builder. then 
```ifneq ($(host),$(build))```
works correctly.