### PR TITLE
Fix progress bar in tapyrus-qt

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -108,3 +108,9 @@ void SelectParams(const TAPYRUS_OP_MODE mode)
 {
     globalChainParams = CreateChainParams(mode);
 }
+
+void UpdateChainTxData(const ChainTxData& data)
+{
+    assert(globalChainParams);
+    globalChainParams->SetChainTxData(data);
+}

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -69,6 +69,7 @@ public:
     bool IsFallbackFeeEnabled() const { return m_fallback_fee_enabled; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     const ChainTxData& TxData() const { return chainTxData; }
+    void SetChainTxData(const ChainTxData& data) { chainTxData = data; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     int GetRPCPort() const { return rpcPort; }
     int GetDefaultPort() const { return nDefaultPort; }
@@ -108,5 +109,7 @@ const CChainParams &Params();
  */
 void SelectParams(const TAPYRUS_OP_MODE mode);
 
+/** Update ChainTxData for IBD progress estimation after genesis block is loaded. */
+void UpdateChainTxData(const ChainTxData& data);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainstate.h>
+#include <chainparams.h>
 
 #include <consensus/tx_verify.h>
 #include <index/txindex.h>
@@ -18,6 +19,10 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <ranges>
 
+// Defined in validation.cpp; declared here to avoid pulling in validation.h
+// (which includes chainstate.h, creating an indirect self-inclusion).
+void RefreshChainTxDataFromTip(const CBlockIndex* pindexNew);
+
 static int64_t nTimeCheck = 0;
 static int64_t nTimeForks = 0;
 static int64_t nTimeVerify = 0;
@@ -28,6 +33,7 @@ static int64_t nTimeTotal = 0;
 static int64_t nBlocksTotal = 0;
 
 static int64_t nTimeReadFromDisk = 0;
+
 static int64_t nTimeConnectTotal = 0;
 static int64_t nTimeFlush = 0;
 static int64_t nTimeChainState = 0;
@@ -385,6 +391,8 @@ void static UpdateTip(const CBlockIndex *pindexNew)
         g_best_block = pindexNew->GetBlockHash();
         g_best_block_cv.notify_all();
     }
+
+    RefreshChainTxDataFromTip(pindexNew);
 
     LogPrintf("%s: new best=%s height=%d version=0x%08x tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__, /* Continued */
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nFeatures,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1239,6 +1239,19 @@ bool AppInitMain()
     }
     LogPrintf("Genesis Block [%s] of Tapyrus network [%s] Loaded successfully\n", FederationParams().GenesisBlock().GetHash().ToString(), FederationParams().NetworkIDString());
 
+    // Initialise ChainTxData from the genesis block timestamp so that
+    // GuessVerificationProgress produces meaningful values during IBD.
+    // nTime is wall-clock time (so nNow - nTime ≈ 0 and fTxTotal ≈ nTxCount),
+    // and nTxCount is the expected total transactions from genesis to now.
+    if (!FederationParams().GenesisBlock().vtx.empty()) {
+        const int64_t genesisTime = FederationParams().GenesisBlock().nTime;
+        const double dTxRate = 1.0 / Params().GetConsensus().nExpectedBlockTime;
+        const int64_t nNow = time(nullptr);
+        const int64_t nTxCount = std::max(int64_t(1),
+            static_cast<int64_t>((nNow - genesisTime) * dTxRate));
+        UpdateChainTxData({nNow, nTxCount, dTxRate});
+    }
+
     InitSignatureCache();
     InitScriptExecutionCache();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -104,6 +104,58 @@ std::set<CBlockIndex*> setDirtyBlockIndex;
 /** Dirty block file entries. */
 std::set<int> setDirtyFileInfo;
 
+// Minimum number of blocks in the sampling window for ChainTxData refresh.
+static constexpr int64_t MIN_CHAIN_TX_WINDOW = 100;
+
+/**
+ * Refresh ChainTxData with the observed tx rate from recently connected blocks.
+ * Called from UpdateTip every windowSize blocks.
+ *
+ * Window size is 1% of chain height (minimum 100 blocks), so the rate estimate
+ * becomes more stable as the chain grows. Triggered by height modulo so no
+ * extra state is needed; rate is computed via pprev walk over the window.
+ *
+ * nTxCount is estimated using pindexBestHeader (the furthest header known from
+ * peers) so that during IBD, progress = nChainTx / nTxCount tracks
+ * height / bestHeaderHeight rather than extrapolating years of empty time.
+ */
+void RefreshChainTxDataFromTip(const CBlockIndex* pindexNew)
+{
+    if (!pindexNew || pindexNew->nHeight == 0)
+        return;
+
+    const int64_t windowSize = std::max(MIN_CHAIN_TX_WINDOW,
+        static_cast<int64_t>(pindexNew->nHeight) / 100);
+
+    if (pindexNew->nHeight % windowSize != 0)
+        return;
+
+    const CBlockIndex* pWindow = pindexNew;
+    for (int64_t i = 0; i < windowSize && pWindow->pprev; i++)
+        pWindow = pWindow->pprev;
+
+    const int64_t dt = pindexNew->GetBlockTime() - pWindow->GetBlockTime();
+    if (dt <= 0)
+        return;
+
+    const double rate = static_cast<double>(
+        static_cast<int64_t>(pindexNew->nChainTx) - static_cast<int64_t>(pWindow->nChainTx)) / dt;
+
+    const int64_t bestHeight =
+        (pindexBestHeader && pindexBestHeader->nHeight > pindexNew->nHeight)
+        ? static_cast<int64_t>(pindexBestHeader->nHeight)
+        : static_cast<int64_t>(pindexNew->nHeight);
+
+    const double txPerBlock = static_cast<double>(pindexNew->nChainTx) /
+        pindexNew->nHeight;
+
+    const int64_t nTxCount = std::max(
+        static_cast<int64_t>(pindexNew->nChainTx),
+        static_cast<int64_t>(txPerBlock * bestHeight));
+
+    UpdateChainTxData({time(nullptr), nTxCount, rate});
+}
+
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {
     AssertLockHeld(cs_main);


### PR DESCRIPTION
Fix progress bar, time remaining estimates 
- progress is calculated using global constants in bitcoin core. This is not possible in tapyrus as we do not have one main net, we may have multiple networks with different networks. This PR make the update dynamic, updating the  last block time, rate of download and number of transactions from the information in the blockchain. It is updated every 100 blocks so that the progress bar moves steadily.