### PR TITLE
Token send and receive

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -369,6 +369,10 @@ public:
     {
         return m_wallet.GetAvailableBalance(&coin_control)[ColorIdentifier()];
     }
+    CAmount getAvailableBalance(const CCoinControl& coin_control, const ColorIdentifier& colorId) override
+    {
+        return m_wallet.GetAvailableBalance(&coin_control)[colorId];
+    }
     TokenIssuanceResult issueNewReissuableToken(CAmount value) override
     {
         TokenIssuanceResult result;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -204,6 +204,7 @@ public:
 
     //! Get available balance.
     virtual CAmount getAvailableBalance(const CCoinControl& coin_control) = 0;
+    virtual CAmount getAvailableBalance(const CCoinControl& coin_control, const ColorIdentifier& colorId) = 0;
 
     //! Issue a new REISSUABLE token; generates address and script internally.
     virtual TokenIssuanceResult issueNewReissuableToken(CAmount value) = 0;

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -74,6 +74,81 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="labelToken">
+          <property name="text">
+           <string>What?</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>reqToken</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <layout class="QHBoxLayout" name="tokenSelectionLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="radioTPC">
+            <property name="text">
+             <string>TPC</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="radioToken">
+            <property name="text">
+             <string>Token</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="reqToken">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Select a token to generate a colored receiving address for</string>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="tokenSelectionSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
         <item row="4" column="0">
          <widget class="QLabel" name="label_2">
           <property name="toolTip">

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -149,7 +149,55 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="0">
+    <item row="2" column="0" colspan="2">
+     <widget class="QWidget" name="tokenRowSpacer">
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>8</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>8</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="labelToken">
+      <property name="text">
+       <string>&amp;Token:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>labelTokenName</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QLabel" name="labelTokenName">
+      <property name="text">
+       <string>&amp;</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>labelToken</cstring>
+      </property>
+      <property name="toolTip">
+       <string>Token type of the address</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
      <widget class="QLabel" name="amountLabel">
       <property name="text">
        <string>A&amp;mount:</string>
@@ -162,7 +210,7 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="1">
+    <item row="4" column="1">
      <layout class="QHBoxLayout" name="horizontalLayoutAmount" stretch="0,1,0">
       <item>
        <widget class="BitcoinAmountField" name="payAmount"/>
@@ -173,7 +221,7 @@
          <string>The fee will be deducted from the amount being sent. The recipient will receive less tpc than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
         </property>
         <property name="text">
-         <string>S&amp;ubtract fee from amount</string>
+         <string>Subtract fee from amount</string>
         </property>
        </widget>
       </item>
@@ -186,7 +234,7 @@
       </item>
      </layout>
     </item>
-    <item row="3" column="0">
+    <item row="5" column="0">
      <widget class="QLabel" name="messageLabel">
       <property name="text">
        <string>Message:</string>
@@ -196,7 +244,7 @@
       </property>
      </widget>
     </item>
-    <item row="3" column="1">
+    <item row="5" column="1">
      <widget class="QLabel" name="messageTextLabel">
       <property name="toolTip">
        <string>A message that was attached to the tapyrus coin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Tapyrus network.</string>
@@ -206,7 +254,7 @@
       </property>
      </widget>
     </item>
-    <item row="4" column="0" colspan="2">
+    <item row="6" column="0" colspan="2">
      <widget class="Line" name="line">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -16,6 +16,10 @@
 #include <qt/recentrequeststablemodel.h>
 #include <qt/walletmodel.h>
 
+#include <coloridentifier.h>
+#include <key_io.h>
+#include <utilstrencodings.h>
+
 #include <QAction>
 #include <QCursor>
 #include <QMessageBox>
@@ -66,6 +70,41 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
     connect(ui->clearButton, &QPushButton::clicked, this, &ReceiveCoinsDialog::clear);
 }
 
+void ReceiveCoinsDialog::refreshTokenCombo()
+{
+    if (!model) return;
+
+    ui->reqToken->blockSignals(true);
+    int prevIndex = ui->reqToken->currentIndex();
+    QString prevColorId;
+    if (prevIndex >= 0 && prevIndex < m_tokenRecords.size())
+        prevColorId = m_tokenRecords[prevIndex].colorId;
+
+    ui->reqToken->clear();
+
+    static const QMap<QString, QString> typeIcons = {
+        {"REISSUABLE",     ":/icons/token_reissuable"},
+        {"NON_REISSUABLE", ":/icons/token_nonreissuable"},
+        {"NFT",            ":/icons/token_nft"},
+    };
+
+    m_tokenRecords = model->getIssuedTokens();
+    for (const WalletModel::IssuedTokenRecord& rec : m_tokenRecords) {
+        QIcon icon(typeIcons.value(rec.tokenType));
+        ui->reqToken->addItem(icon, rec.colorId, rec.colorId);
+    }
+
+    ui->reqToken->blockSignals(false);
+
+    // Restore previous selection if possible
+    int restoreIndex = 0;
+    if (!prevColorId.isEmpty()) {
+        int found = ui->reqToken->findData(prevColorId);
+        if (found >= 0) restoreIndex = found;
+    }
+    ui->reqToken->setCurrentIndex(restoreIndex);
+}
+
 void ReceiveCoinsDialog::setModel(WalletModel *_model)
 {
     this->model = _model;
@@ -74,6 +113,11 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
     {
         _model->getRecentRequestsTableModel()->sort(RecentRequestsTableModel::Date, Qt::DescendingOrder);
         connect(_model->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &ReceiveCoinsDialog::updateDisplayUnit);
+        connect(_model, &WalletModel::tokenAddressBookChanged, this, &ReceiveCoinsDialog::refreshTokenCombo);
+        connect(ui->radioToken, &QRadioButton::toggled, this, &ReceiveCoinsDialog::on_radioToken_toggled);
+        connect(ui->reqToken, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, &ReceiveCoinsDialog::on_reqToken_currentIndexChanged);
+        refreshTokenCombo();
         updateDisplayUnit();
 
         QTableView* tableView = ui->recentRequestsView;
@@ -86,6 +130,7 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
         tableView->setSelectionMode(QAbstractItemView::ContiguousSelection);
         tableView->setColumnWidth(RecentRequestsTableModel::Date, DATE_COLUMN_WIDTH);
         tableView->setColumnWidth(RecentRequestsTableModel::Label, LABEL_COLUMN_WIDTH);
+        tableView->setColumnWidth(RecentRequestsTableModel::Token, TOKEN_COLUMN_WIDTH);
         tableView->setColumnWidth(RecentRequestsTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
 
         connect(tableView->selectionModel(),
@@ -107,9 +152,17 @@ ReceiveCoinsDialog::~ReceiveCoinsDialog()
 
 void ReceiveCoinsDialog::clear()
 {
+    ui->radioTPC->setChecked(true);
+    ui->reqToken->setCurrentIndex(0);
+    ui->reqToken->setEnabled(false);
+    ui->reqAmount->setTokenMode(false);
+    ui->reqAmount->setEnabled(true);
     ui->reqAmount->clear();
     ui->reqLabel->setText("");
     ui->reqMessage->setText("");
+    if (model)
+        ui->receiveButton->setEnabled(!model->privateKeysDisabled());
+    ui->receiveButton->setToolTip(QString());
     updateDisplayUnit();
 }
 
@@ -123,12 +176,47 @@ void ReceiveCoinsDialog::accept()
     clear();
 }
 
+void ReceiveCoinsDialog::on_radioToken_toggled(bool checked)
+{
+    ui->reqToken->setEnabled(checked);
+    ui->reqAmount->setTokenMode(checked);
+    if (!checked) {
+        ui->reqToken->setCurrentIndex(0);
+        ui->reqAmount->setEnabled(true);
+        ui->receiveButton->setEnabled(!model->privateKeysDisabled());
+        ui->receiveButton->setToolTip(QString());
+    } else {
+        on_reqToken_currentIndexChanged(ui->reqToken->currentIndex());
+    }
+}
+
+void ReceiveCoinsDialog::on_reqToken_currentIndexChanged(int index)
+{
+    if (!ui->radioToken->isChecked() || index < 0 || index >= m_tokenRecords.size())
+        return;
+
+    const WalletModel::IssuedTokenRecord& rec = m_tokenRecords[index];
+    if (rec.tokenType == "NFT") {
+        // NFT: fixed amount of 1, no more requests if already holding 1
+        ui->reqAmount->setValue(1);
+        ui->reqAmount->setEnabled(false);
+        bool alreadyOwned = (rec.balance + rec.unconfirmedBalance) >= 1;
+        bool canRequest = !alreadyOwned && !model->privateKeysDisabled();
+        ui->receiveButton->setEnabled(canRequest);
+        ui->receiveButton->setToolTip(alreadyOwned
+            ? tr("This NFT token is already in your wallet. Only one can exist in the network.")
+            : QString());
+    } else {
+        ui->reqAmount->setEnabled(true);
+        ui->receiveButton->setEnabled(!model->privateKeysDisabled());
+        ui->receiveButton->setToolTip(QString());
+    }
+}
+
 void ReceiveCoinsDialog::updateDisplayUnit()
 {
     if(model && model->getOptionsModel())
-    {
         ui->reqAmount->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
-    }
 }
 
 void ReceiveCoinsDialog::on_receiveButton_clicked()
@@ -138,12 +226,35 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
 
     QString address;
     QString label = ui->reqLabel->text();
-    /* Generate new receiving address */
-    OutputType address_type = model->wallet().getDefaultAddressType();
+    int tokenIndex = ui->reqToken->currentIndex();
 
-    address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", address_type);
+    if (ui->radioToken->isChecked() && tokenIndex >= 0 && tokenIndex < m_tokenRecords.size()) {
+        // Generate a colored receiving address
+        const WalletModel::IssuedTokenRecord& rec = m_tokenRecords[tokenIndex];
+        const std::vector<unsigned char> vColorId(ParseHex(rec.colorId.toStdString()));
+        ColorIdentifier colorId(vColorId.data(), vColorId.data() + vColorId.size());
+
+        CPubKey newKey;
+        if (!model->wallet().getKeyFromPool(false /* internal */, newKey)) {
+            WalletModel::UnlockContext ctx(model->requestUnlock());
+            if (!ctx.isValid()) return;
+            if (!model->wallet().getKeyFromPool(false, newKey)) return;
+        }
+        CColorKeyID colorKeyId(newKey.GetID(), colorId);
+        address = QString::fromStdString(EncodeDestination(colorKeyId));
+        model->wallet().setAddressBook(colorKeyId, label.toStdString(), "receive");
+    } else {
+        // Generate a standard TPC receiving address
+        OutputType address_type = model->wallet().getDefaultAddressType();
+        address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", address_type);
+    }
+
     SendCoinsRecipient info(address, label,
         ui->reqAmount->value(), ui->reqMessage->text());
+    if (ui->radioToken->isChecked() && tokenIndex >= 0 && tokenIndex < m_tokenRecords.size()) {
+        const std::vector<unsigned char> vColorId(ParseHex(m_tokenRecords[tokenIndex].colorId.toStdString()));
+        info.colorid = ColorIdentifier(vColorId.data(), vColorId.data() + vColorId.size());
+    }
     ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setModel(model);

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -6,13 +6,16 @@
 #define BITCOIN_QT_RECEIVECOINSDIALOG_H
 
 #include <qt/guiutil.h>
+#include <qt/walletmodel.h>
 
 #include <QDialog>
 #include <QHeaderView>
 #include <QItemSelection>
 #include <QKeyEvent>
+#include <QList>
 #include <QMenu>
 #include <QPoint>
+#include <QRadioButton>
 #include <QVariant>
 
 class PlatformStyle;
@@ -33,7 +36,8 @@ public:
     enum ColumnWidths {
         DATE_COLUMN_WIDTH = 130,
         LABEL_COLUMN_WIDTH = 120,
-        AMOUNT_MINIMUM_COLUMN_WIDTH = 180,
+        TOKEN_COLUMN_WIDTH = 130,
+        AMOUNT_MINIMUM_COLUMN_WIDTH = 160,
         MINIMUM_COLUMN_WIDTH = 130
     };
 
@@ -56,10 +60,12 @@ private:
     WalletModel *model;
     QMenu *contextMenu;
     const PlatformStyle *platformStyle;
+    QList<WalletModel::IssuedTokenRecord> m_tokenRecords;
 
     QModelIndex selectedRow();
     void copyColumnToClipboard(int column);
     void resizeEvent(QResizeEvent *event) override;
+    void refreshTokenCombo();
 
 private Q_SLOTS:
     void on_receiveButton_clicked();
@@ -68,6 +74,8 @@ private Q_SLOTS:
     void on_recentRequestsView_doubleClicked(const QModelIndex &index);
     void recentRequestsView_selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void updateDisplayUnit();
+    void on_radioToken_toggled(bool checked);
+    void on_reqToken_currentIndexChanged(int index);
     void showMenu(const QPoint &point);
     void copyURI();
     void copyLabel();

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -9,6 +9,7 @@
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
+#include <coloridentifier.h>
 
 #include <QClipboard>
 #include <QDrag>
@@ -135,8 +136,14 @@ void ReceiveRequestDialog::update()
     html += "<b>"+tr("URI")+"</b>: ";
     html += "<a href=\""+uri+"\">" + GUIUtil::HtmlEscape(uri) + "</a><br>";
     html += "<b>"+tr("Address")+"</b>: " + GUIUtil::HtmlEscape(info.address) + "<br>";
-    if(info.amount)
-        html += "<b>"+tr("Amount")+"</b>: " + TapyrusUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), info.amount) + "<br>";
+    if (info.colorid.type != TokenTypes::NONE)
+        html += "<b>"+tr("Token")+"</b>: " + GUIUtil::HtmlEscape(QString::fromStdString(info.colorid.toHexString())) + "<br>";
+    if(info.amount) {
+        if (info.colorid.type != TokenTypes::NONE)
+            html += "<b>"+tr("Amount")+"</b>: " + TapyrusUnits::formatHtmlWithUnit(TapyrusUnits::TOKEN, info.amount) + "<br>";
+        else
+            html += "<b>"+tr("Amount")+"</b>: " + TapyrusUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), info.amount) + "<br>";
+    }
     if(!info.label.isEmpty())
         html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";
     if(!info.message.isEmpty())

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -9,6 +9,7 @@
 #include <qt/optionsmodel.h>
 
 #include <clientversion.h>
+#include <coloridentifier.h>
 #include <streams.h>
 
 
@@ -24,7 +25,7 @@ RecentRequestsTableModel::RecentRequestsTableModel(WalletModel *parent) :
         addNewRequest(request);
 
     /* These columns must match the indices in the ColumnIndex enumeration */
-    columns << tr("Date") << tr("Label") << tr("Message") << getAmountTitle();
+    columns << tr("Date") << tr("Label") << tr("Message") << tr("Token") << tr("Requested");
 
     connect(walletModel->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &RecentRequestsTableModel::updateDisplayUnit);
 }
@@ -78,18 +79,27 @@ QVariant RecentRequestsTableModel::data(const QModelIndex &index, int role) cons
             {
                 return rec->recipient.message;
             }
-        case Amount:
+        case Token: {
+            if (rec->recipient.colorid.type == TokenTypes::NONE)
+                return QVariant();
+            return QString::fromStdString(rec->recipient.colorid.toHexString());
+        }
+        case Amount: {
+            bool isToken = rec->recipient.colorid.type != TokenTypes::NONE;
             if (rec->recipient.amount == 0 && role == Qt::DisplayRole)
                 return tr("(no amount requested)");
-            else if (role == Qt::EditRole)
-                return TapyrusUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), rec->recipient.amount, false, TapyrusUnits::separatorNever);
-            else
-                return TapyrusUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), rec->recipient.amount);
+            if (isToken)
+                return QString::number(rec->recipient.amount);
+            int unit = walletModel->getOptionsModel()->getDisplayUnit();
+            if (role == Qt::EditRole)
+                return TapyrusUnits::format(unit, rec->recipient.amount, false, TapyrusUnits::separatorNever);
+            return TapyrusUnits::format(unit, rec->recipient.amount);
+        }
         }
     }
     else if (role == Qt::TextAlignmentRole)
     {
-        if (index.column() == Amount)
+        if (index.column() == Amount || index.column() == Token)
             return (int)(Qt::AlignRight|Qt::AlignVCenter);
     }
     return QVariant();
@@ -115,14 +125,14 @@ QVariant RecentRequestsTableModel::headerData(int section, Qt::Orientation orien
 /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
 void RecentRequestsTableModel::updateAmountColumnTitle()
 {
-    columns[Amount] = getAmountTitle();
-    Q_EMIT headerDataChanged(Qt::Horizontal,Amount,Amount);
+    // Amount column title stays fixed; signal so the view re-reads header data
+    Q_EMIT headerDataChanged(Qt::Horizontal, Amount, Amount);
 }
 
-/** Gets title for amount column including current display unit if optionsModel reference available. */
+/** Gets title for amount column. */
 QString RecentRequestsTableModel::getAmountTitle()
 {
-    return (this->walletModel->getOptionsModel() != nullptr) ? QString(tr("Requested") + " ("+TapyrusUnits::shortName(this->walletModel->getOptionsModel()->getDisplayUnit()) + ")") : QString("");
+    return tr("Requested");
 }
 
 QModelIndex RecentRequestsTableModel::index(int row, int column, const QModelIndex &parent) const
@@ -228,6 +238,8 @@ bool RecentRequestEntryLessThan::operator()(RecentRequestEntry &left, RecentRequ
         return pLeft->recipient.label < pRight->recipient.label;
     case RecentRequestsTableModel::Message:
         return pLeft->recipient.message < pRight->recipient.message;
+    case RecentRequestsTableModel::Token:
+        return pLeft->recipient.colorid.toHexString() < pRight->recipient.colorid.toHexString();
     case RecentRequestsTableModel::Amount:
         return pLeft->recipient.amount < pRight->recipient.amount;
     default:

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -65,7 +65,8 @@ public:
         Date = 0,
         Label = 1,
         Message = 2,
-        Amount = 3,
+        Token = 3,
+        Amount = 4,
         NUMBER_OF_COLUMNS
     };
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -17,6 +17,7 @@
 #include <qt/platformstyle.h>
 #include <qt/sendcoinsentry.h>
 
+#include <coloridentifier.h>
 #include <chainparams.h>
 #include <interfaces/node.h>
 #include <key_io.h>
@@ -613,17 +614,17 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
         coin_control = *CoinControlDialog::coinControl();
     }
 
-    // get available amount to send from the entry
+    // Calculate available amount to send, respecting the color of the entry's address.
     CAmount amount = entry->getAvailableBalance(coin_control);
+    ColorIdentifier colorId = entry->getValue().colorid;
     for (int i = 0; i < ui->entries->count(); ++i) {
         SendCoinsEntry* e = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
-        if (e && !e->isHidden() && e != entry) {
+        if (e && !e->isHidden() && e != entry && e->getValue().colorid == colorId) {
             amount -= e->getValue().amount;
         }
     }
 
     if (amount > 0) {
-      //entry->checkSubtractFeeFromAmount();
       entry->setAmount(amount);
     } else {
       entry->setAmount(0);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -283,7 +283,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     for (const SendCoinsRecipient &rcp : currentTransaction.getRecipients())
     {
         // generate bold amount string with wallet name in case of multiwallet
-        QString amount = "<b>" + TapyrusUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
+        QString amount = "<b>" + (rcp.colorid.type != TokenTypes::NONE ? TapyrusUnits::formatHtmlWithUnit(TapyrusUnits::TOKEN, rcp.amount) : TapyrusUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount));
         if (model->isMultiwallet()) {
             amount.append(" <u>"+tr("from wallet %1").arg(GUIUtil::HtmlEscape(model->getWalletName()))+"</u> ");
         }
@@ -613,8 +613,8 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
         coin_control = *CoinControlDialog::coinControl();
     }
 
-    // Calculate available amount to send.
-    CAmount amount = model->wallet().getAvailableBalance(coin_control);
+    // get available amount to send from the entry
+    CAmount amount = entry->getAvailableBalance(coin_control);
     for (int i = 0; i < ui->entries->count(); ++i) {
         SendCoinsEntry* e = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
         if (e && !e->isHidden() && e != entry) {
@@ -623,7 +623,7 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
     }
 
     if (amount > 0) {
-      entry->checkSubtractFeeFromAmount();
+      //entry->checkSubtractFeeFromAmount();
       entry->setAmount(amount);
     } else {
       entry->setAmount(0);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -12,6 +12,9 @@
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
+#include <qt/tapyrusunits.h>
+
+#include <coloridentifier.h>
 
 #include <QApplication>
 #include <QClipboard>
@@ -77,6 +80,26 @@ void SendCoinsEntry::on_addressBookButton_clicked()
 void SendCoinsEntry::on_payTo_textChanged(const QString &address)
 {
     updateLabel(address);
+    ColorIdentifier colorId = model ? model->getColorFromAddress(address) : ColorIdentifier();
+    bool isColored = colorId.type != TokenTypes::NONE;
+
+    ui->payAmount->setTokenMode(isColored);
+    ui->payAmount_is->setTokenMode(isColored);
+    ui->payAmount_s->setTokenMode(isColored);
+    ui->labelTokenName->setText(isColored ? QString::fromStdString(colorId.toHexString()) : QString());
+    ui->tokenRowSpacer->setVisible(isColored);
+    ui->labelToken->setVisible(isColored);
+    ui->labelTokenName->setVisible(isColored);
+    ui->checkboxSubtractFeeFromAmount->setEnabled(!isColored);
+    ui->checkboxSubtractFeeFromAmount->setCheckState(Qt::Unchecked);
+    if (isColored && colorId.type == TokenTypes::NFT) {
+        ui->payAmount->setValue(1);
+        ui->payAmount->setEnabled(false);
+    } else {
+        ui->payAmount->setEnabled(true);
+        if (!isColored)
+            updateDisplayUnit();
+    }
 }
 
 void SendCoinsEntry::setModel(WalletModel *_model)
@@ -94,6 +117,12 @@ void SendCoinsEntry::clear()
     // clear UI elements for normal payment
     ui->payTo->clear();
     ui->addAsLabel->clear();
+    ui->labelTokenName->clear();
+    ui->tokenRowSpacer->setVisible(false);
+    ui->labelToken->setVisible(false);
+    ui->labelTokenName->setVisible(false);
+    ui->payAmount->setTokenMode(false);
+    ui->payAmount->setEnabled(true);
     ui->payAmount->clear();
     ui->checkboxSubtractFeeFromAmount->setCheckState(Qt::Unchecked);
     ui->messageTextLabel->clear();
@@ -153,8 +182,9 @@ bool SendCoinsEntry::validate(interfaces::Node& node)
         retval = false;
     }
 
-    // Reject dust outputs:
-    if (retval && GUIUtil::isDust(node, ui->payTo->text(), ui->payAmount->value())) {
+    // Reject dust outputs (not applicable to token sends — token outputs have nValue=0):
+    if (retval && model->getColorFromAddress(ui->payTo->text()).type == TokenTypes::NONE &&
+        GUIUtil::isDust(node, ui->payTo->text(), ui->payAmount->value())) {
         ui->payAmount->setValid(false);
         retval = false;
     }
@@ -170,6 +200,8 @@ SendCoinsRecipient SendCoinsEntry::getValue()
     recipient.amount = ui->payAmount->value();
     recipient.message = ui->messageTextLabel->text();
     recipient.fSubtractFeeFromAmount = (ui->checkboxSubtractFeeFromAmount->checkState() == Qt::Checked);
+    if (model)
+        recipient.colorid = model->getColorFromAddress(recipient.address);
 
     return recipient;
 }
@@ -249,4 +281,13 @@ bool SendCoinsEntry::updateLabel(const QString &address)
     }
 
     return false;
+}
+
+CAmount SendCoinsEntry::getAvailableBalance(CCoinControl& coin_control)
+{
+    if (!model)
+        return 0;
+    const QString address = ui->payTo->text();
+    ColorIdentifier colorId = model->getColorFromAddress(address);
+    return model->wallet().getAvailableBalance(coin_control, colorId);
 }

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -32,6 +32,7 @@ public:
     void setModel(WalletModel *model);
     bool validate(interfaces::Node& node);
     SendCoinsRecipient getValue();
+    CAmount getAvailableBalance(CCoinControl& coin_control);
 
     /** Return whether the entry is still empty and unedited */
     bool isClear();

--- a/src/qt/tapyrusamountfield.cpp
+++ b/src/qt/tapyrusamountfield.cpp
@@ -228,7 +228,29 @@ void BitcoinAmountField::clear()
 void BitcoinAmountField::setEnabled(bool fEnabled)
 {
     amount->setEnabled(fEnabled);
+    unit->setEnabled(fEnabled && !m_tokenMode);
+}
+
+void BitcoinAmountField::setUnitEnabled(bool fEnabled)
+{
     unit->setEnabled(fEnabled);
+}
+
+void BitcoinAmountField::setTokenMode(bool isToken)
+{
+    m_tokenMode = isToken;
+    if (isToken) {
+        // Set spinbox to TOKEN unit (factor=1, no conversion) without touching the combobox
+        amount->setDisplayUnit(TapyrusUnits::TOKEN);
+        amount->setSingleStep(1); // step by 1 token per click
+    } else {
+        // Restore the unit currently shown in the combobox
+        int idx = unit->currentIndex();
+        int currentUnit = unit->itemData(idx, TapyrusUnits::UnitRole).toInt();
+        amount->setDisplayUnit(currentUnit);
+        amount->setSingleStep(100000); // restore default TPC step (0.001 TPC)
+    }
+    unit->setEnabled(!isToken);
 }
 
 bool BitcoinAmountField::validate()

--- a/src/qt/tapyrusamountfield.h
+++ b/src/qt/tapyrusamountfield.h
@@ -49,6 +49,13 @@ public:
     /** Enable/Disable. */
     void setEnabled(bool fEnabled);
 
+    /** Enable/Disable only the unit selector. */
+    void setUnitEnabled(bool fEnabled);
+
+    /** Switch between token mode (raw integer, no conversion) and normal TPC mode.
+     *  In token mode the unit combobox is disabled and the spinbox uses TOKEN factor (1). */
+    void setTokenMode(bool isToken);
+
     /** Qt messes up the tab chain by default in some cases (issue https://bugreports.qt-project.org/browse/QTBUG-10907),
         in these cases we have to set it up manually.
     */
@@ -64,6 +71,7 @@ protected:
 private:
     AmountSpinBox *amount;
     QValueComboBox *unit;
+    bool m_tokenMode = false;
 
 private Q_SLOTS:
     void unitChanged(int idx);

--- a/src/qt/tapyrusunits.cpp
+++ b/src/qt/tapyrusunits.cpp
@@ -21,7 +21,6 @@ QList<TapyrusUnits::Unit> TapyrusUnits::availableUnits()
     unitlist.append(mTPC);
     unitlist.append(uTPC);
     unitlist.append(TAP);
-    unitlist.append(TOKEN);
     return unitlist;
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -114,7 +114,7 @@ void WalletModel::updateAddressBook(const QString &address, const QString &label
 
     if (isMine && purpose == "receive") {
         CTxDestination dest = DecodeDestination(address.toStdString());
-        if (std::get_if<CColorScriptID>(&dest))
+        if (std::get_if<CColorScriptID>(&dest) || std::get_if<CColorKeyID>(&dest) )
             Q_EMIT tokenAddressBookChanged();
     }
 }
@@ -176,7 +176,21 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         return DuplicateAddress;
     }
 
-    CAmount nBalance = m_wallet->getAvailableBalance(coinControl);
+    // Determine if this is a colored coin send and set up coin control accordingly
+    ColorIdentifier colorId;
+    for (const SendCoinsRecipient &rcp : recipients) {
+        if (rcp.colorid.type != TokenTypes::NONE) {
+            colorId = rcp.colorid;
+            break;
+        }
+    }
+    CCoinControl localCoinControl = coinControl;
+    if (colorId.type != TokenTypes::NONE) {
+        localCoinControl.m_colorTxType = ColoredTxType::TRANSFER;
+        localCoinControl.m_colorId = colorId;
+    }
+
+    CAmount nBalance = m_wallet->getAvailableBalance(localCoinControl, colorId);
 
     if(total > nBalance)
     {
@@ -189,7 +203,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         std::string strFailReason;
 
         auto& newTx = transaction.getWtx();
-        newTx = m_wallet->createTransaction(vecSend, coinControl, true /* sign */, nChangePosRet, nFeeRequired, strFailReason);
+        newTx = m_wallet->createTransaction(vecSend, localCoinControl, true /* sign */, nChangePosRet, nFeeRequired, strFailReason);
         transaction.setTransactionFee(nFeeRequired);
         if (fSubtractFeeFromAmount && newTx)
             transaction.reassignAmounts(nChangePosRet);
@@ -381,6 +395,14 @@ OptionsModel *WalletModel::getOptionsModel()
 AddressTableModel *WalletModel::getAddressTableModel()
 {
     return addressTableModel;
+}
+
+ColorIdentifier WalletModel::getColorFromAddress(const QString &address) const
+{
+    CTxDestination dest = DecodeDestination(address.toStdString());
+    if (const CColorScriptID* p = std::get_if<CColorScriptID>(&dest)) return p->color;
+    if (const CColorKeyID*   p = std::get_if<CColorKeyID>(&dest))   return p->color;
+    return ColorIdentifier();
 }
 
 TransactionTableModel *WalletModel::getTransactionTableModel()
@@ -653,3 +675,12 @@ bool WalletModel::isMultiwallet()
 {
     return m_node.getWallets().size() > 1;
 }
+
+//Constructor definition moved here to initialize colorid
+SendCoinsRecipient::SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message):
+    address(addr), label(_label), amount(_amount), message(_message), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION)
+    {
+        CTxDestination dest = DecodeDestination(address.toStdString());
+        if (const CColorScriptID* p = std::get_if<CColorScriptID>(&dest)) colorid = p->color;
+        else if (const CColorKeyID* p = std::get_if<CColorKeyID>(&dest)) colorid = p->color;
+    }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -48,9 +48,9 @@ class QTimer;
 class SendCoinsRecipient
 {
 public:
-    explicit SendCoinsRecipient() : amount(0), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) { }
-    explicit SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message):
-        address(addr), label(_label), amount(_amount), message(_message), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) {}
+    explicit SendCoinsRecipient() : colorid(), amount(0), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) { }
+    //only decleration is here
+    explicit SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message);
 
     // If from an unauthenticated payment request, this is used for storing
     // the addresses, e.g. address-A<br />address-B<br />address-C.
@@ -59,6 +59,7 @@ public:
     // Todo: This is a hack, should be replaced with a cleaner solution!
     QString address;
     QString label;
+    ColorIdentifier colorid;
     CAmount amount;
     // If from a payment request, this is used for storing the memo
     QString message;
@@ -69,7 +70,7 @@ public:
 
     bool fSubtractFeeFromAmount; // memory only
 
-    static const int CURRENT_VERSION = 1;
+    static const int CURRENT_VERSION = 2;
     int nVersion;
 
     ADD_SERIALIZE_METHODS;
@@ -86,6 +87,8 @@ public:
         READWRITE(amount);
         READWRITE(sMessage);
         READWRITE(sPaymentRequest);
+        if (this->nVersion >= 2)
+            READWRITE(colorid);
 
         if (ser_action.ForRead())
         {
@@ -135,6 +138,9 @@ public:
 
     // Check address for validity
     bool validateAddress(const QString &address);
+
+    // Return the ColorIdentifier encoded in a colored address, or ColorIdentifier() (NONE) for TPC.
+    ColorIdentifier getColorFromAddress(const QString &address) const;
 
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1418,9 +1418,9 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int n
             if (fLong)
                 WalletTxToJSON(wtx, entry);
             ret.push_back(entry);
-
         }
     }
+
 }
 
 


### PR DESCRIPTION
Enable sending and receiving colored coins from tapyrus-qt
In send coins tab
- address can now be colored address. Then the token type is populated automatically.
- amount spin control is changed to increment in counts of 1 when the token is selected.
- SendCoinRecepient class needs to store color id

In receive coins tab
- amount spin controls shared with send tab
- color id is added to received payments table
