### PR TITLE
fix macos native build 

### DIFF
--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -17,7 +17,7 @@
 
 #include <deque>
 #include <boost/algorithm/string/replace.hpp>
-#include <ranges>
+
 
 // Defined in validation.cpp; declared here to avoid pulling in validation.h
 // (which includes chainstate.h, creating an indirect self-inclusion).
@@ -941,7 +941,8 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, CBlockIndex* pi
         nHeight = nTargetHeight;
 
         // Connect new blocks.
-        for (CBlockIndex *pindexConnect : std::views::reverse(vpindexToConnect)) {
+        for (auto it = vpindexToConnect.rbegin(); it != vpindexToConnect.rend(); ++it) {
+            CBlockIndex *pindexConnect = *it;
             if (!ConnectTip(state, pindexConnect, pindexConnect == pindexMostWork ? pblock : std::shared_ptr<const CBlock>(), connectTrace, disconnectpool)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -9,7 +9,6 @@
 #include <validation.h>
 
 #include <stdint.h>
-#include <ranges>
 
 namespace Checkpoints {
 
@@ -18,8 +17,8 @@ namespace Checkpoints {
         AssertLockHeld(cs_main);
         const MapCheckpoints& checkpoints = data.mapCheckpoints;
 
-        for (const MapCheckpoints::value_type& i : std::views::reverse(checkpoints))
-        {
+        for (auto it = checkpoints.rbegin(); it != checkpoints.rend(); ++it) {
+            const MapCheckpoints::value_type& i = *it;
             const uint256& hash = i.second;
             CBlockIndex* pindex = LookupBlockIndex(hash);
             if (pindex) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -36,7 +36,6 @@
 #include <deque>
 #include <memory>
 #include <array>
-#include <ranges>
 
 #if defined(NDEBUG)
 # error "Tapyrus cannot be compiled without assertions."
@@ -1035,7 +1034,8 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
         // Relay inventory, but don't relay old inventory during initial block download.
         connman->ForEachNode([nNewHeight, &vHashes](CNode* pnode) {
             if (nNewHeight > (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : 0)) {
-                for (const uint256& hash : std::views::reverse(vHashes)) {
+                for (auto it = vHashes.rbegin(); it != vHashes.rend(); ++it) {
+                    const uint256& hash = *it;
                     pnode->PushBlockHash(hash);
                 }
             }
@@ -1601,7 +1601,8 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
             } else {
                 std::vector<CInv> vGetData;
                 // Download as much as possible, from earliest to latest.
-                for (const CBlockIndex *pindex : std::views::reverse(vToFetch)) {
+                for (auto it = vToFetch.rbegin(); it != vToFetch.rend(); ++it) {
+                    const CBlockIndex *pindex = *it;
                     if (nodestate->vBlocksInFlight.size() >= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
                         // Can't download any more from this peer
                         break;

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -12,7 +12,6 @@
 #include <test/test_tapyrus.h>
 
 #include <boost/test/unit_test.hpp>
-#include <ranges>
 
 BOOST_FIXTURE_TEST_SUITE(prevector_tests, TestingSetup)
 
@@ -58,13 +57,15 @@ class prevector_tester {
         for (const T& v : pre_vector) {
              local_check(v == real_vector[pos++]);
         }
-        for (const T& v : std::views::reverse(pre_vector)) {
+        for (auto it = std::make_reverse_iterator(pre_vector.end()); it != std::make_reverse_iterator(pre_vector.begin()); ++it) {
+             const T& v = *it;
              local_check(v == real_vector[--pos]);
         }
         for (const T& v : const_pre_vector) {
              local_check(v == real_vector[pos++]);
         }
-        for (const T& v : std::views::reverse(const_pre_vector)) {
+        for (auto it = std::make_reverse_iterator(const_pre_vector.end()); it != std::make_reverse_iterator(const_pre_vector.begin()); ++it) {
+             const T& v = *it;
              local_check(v == real_vector[--pos]);
         }
         CDataStream ss1(SER_DISK, 0);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -18,7 +18,6 @@
 #include <utilmoneystr.h>
 #include <utiltime.h>
 
-#include <ranges>
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
                                  int64_t _nTime, unsigned int _entryHeight,
@@ -125,7 +124,8 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     // This maximizes the benefit of the descendant cache and guarantees that
     // setMemPoolChildren will be updated, an assumption made in
     // UpdateForDescendants.
-    for (const uint256 &hash : std::views::reverse(vHashesToUpdate)) {
+    for (auto rit = vHashesToUpdate.rbegin(); rit != vHashesToUpdate.rend(); ++rit) {
+        const uint256 &hash = *rit;
         // we cache the in-mempool children to avoid duplicate updates
         setEntries setChildren;
         // calculate children from mapNextTx


### PR DESCRIPTION
Mac OS native build fails because std::view::reverse is missing. It is replaced with `begin()` and `rend()` vector iterators.