### PR TITLE
Change all fixed fee to dynamic relay fee based calculation in functional tests

### DIFF
--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -186,7 +186,13 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
             assert_equal(nodei_utxo_hash, node3_utxo_hash)
 
     def generate_small_transactions(self, node, count, utxo_list):
-        FEE = 1000  # TODO: replace this with node relay fee based calculation
+        # Derive fee and dust threshold from the node's current relay fee rate.
+        relay_fee_tpc_per_kb = node.getnetworkinfo()['relayfee']
+        relay_fee_sat_per_byte = max(1, int(relay_fee_tpc_per_kb * COIN / 1000))
+        FEE = relay_fee_sat_per_byte * 1000  # flat fee: 1 kB equivalent
+        # Dust limit for a P2PKH output: 3 * fee_rate * (34-byte output + 148-byte spend cost)
+        dust_threshold = 3 * relay_fee_sat_per_byte * (34 + 148)
+
         num_transactions = 0
         random.shuffle(utxo_list)
         while len(utxo_list) >= 2 and num_transactions < count:
@@ -198,8 +204,8 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 input_amount += int(utxo['amount'] * COIN)
             output_amount = (input_amount - FEE) // 3
 
-            if output_amount <= 0:
-                # Sanity check -- if we chose inputs that are too small, skip
+            if output_amount < dust_threshold:
+                # Skip if outputs would be below dust threshold or non-positive
                 continue
 
             for i in range(3):

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -42,7 +42,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         vout = utxo[0]['vout']
         value = utxo[0]['amount']
 
-        fee = Decimal("0.0001")
+        fee = self.nodes[0].getnetworkinfo()['relayfee']
         # MAX_ANCESTORS transactions off a confirmed tx should be fine
         chain = []
         for i in range(MAX_ANCESTORS):

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -72,7 +72,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         # generate a random transaction and submit it
         min_relay_fee = self.nodes[0].getnetworkinfo()["relayfee"]
         # min_relay_fee is fee per 1000 bytes, which should be more than enough.
-        (txid, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), min_relay_fee, Decimal("0.001"), 20)
+        (txid, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), min_relay_fee, min_relay_fee * 100, 20)
         # after one minute, every 10 seconds the mempool is probed, so in 80 seconds it should have returned
         wait_until(lambda: not thr.is_alive(), timeout=60 + 20)  # wait up to 80 seconds for thread to exit
         assert(not thr.is_alive())

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -6,7 +6,6 @@
 """Test transaction signing using the signrawtransaction* RPCs."""
 
 from test_framework.test_framework import BitcoinTestFramework
-import decimal
 
 class RpcCreateMultiSigTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -83,7 +82,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
         node0.generate(1, self.signblockprivkey_wif)
 
-        outval = value - decimal.Decimal("0.00001000")
+        outval = value - node0.getnetworkinfo()['relayfee']
         rawtx = node2.createrawtransaction([{"txid": txid, "vout": vout}], [{self.final: outval}])
 
         rawtx2 = node2.signrawtransactionwithkey(rawtx, self.priv[0:self.nsigs-1], prevtxs, "ALL", self.options.scheme)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -198,8 +198,9 @@ class WalletTest(BitcoinTestFramework):
 
         # Send 10 TPC normal
         address = self.nodes[0].getnewaddress("test")
-        fee_per_byte = Decimal('0.001') / 1000
-        self.nodes[2].settxfee(fee_per_byte * 1000)
+        relay_fee = self.nodes[2].getnetworkinfo()['relayfee']
+        fee_per_byte = relay_fee / 1000
+        self.nodes[2].settxfee(relay_fee)
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", False)
         # generate block on another node so that balance is not distorted by block reward
         self.sync_all([self.nodes[0:3]])

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -54,7 +54,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # First: use raw transaction API to send 1240 TPC to node1_address,
         # but don't broadcast:
-        doublespend_fee = Decimal('-.02')
+        doublespend_fee = -self.nodes[0].getnetworkinfo()['relayfee']
         rawtx_input_0 = {}
         rawtx_input_0["txid"] = fund_foo_txid
         rawtx_input_0["vout"] = find_output(self.nodes[0], fund_foo_txid, 1219)


### PR DESCRIPTION
this is the log from CI failure :
```
 test  2026-03-24T18:55:27.247000Z TestFramework (DEBUG): Node3 utxo count: 7064 
 test  2026-03-24T18:55:27.247000Z TestFramework (INFO): Iteration 38, generating 2500 transactions [9, 2, 0] 
 node3 2026-03-24T18:55:27.249660Z Received a POST request for / from 127.0.0.1:49594 
 node3 2026-03-24T18:55:27.249735Z ThreadRPCServer method=signrawtransactionwithwallet user=__cookie__ 
 test  2026-03-24T18:55:27.251000Z TestFramework (ERROR): JSONRPC error

Traceback (most recent call last):

  File "/Users/runner/work/tapyrus-core/tapyrus-core/test/functional/test_framework/test_framework.py", line 179, in main
    self.run_test()
  File "/Users/runner/work/tapyrus-core/tapyrus-core/test/functional/feature_dbcrash.py", line 240, in run_test
    self.generate_small_transactions(self.nodes[3], 2500, utxo_list)
  File "/Users/runner/work/tapyrus-core/tapyrus-core/test/functional/feature_dbcrash.py", line 210, in generate_small_transactions
    node.sendrawtransaction(tx_signed_hex)
  File "/Users/runner/work/tapyrus-core/tapyrus-core/test/functional/test_framework/coverage.py", line 52, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
  File "/Users/runner/work/tapyrus-core/tapyrus-core/test/functional/test_framework/authproxy.py", line 138, in __call__
    raise JSONRPCException(response['error'])
test_framework.authproxy.JSONRPCException: dust (code 64) (-26) 
```
The test failed because one of the transactions created by the test case has an output below dust threshold. TO avoid this, the test case is updated to set the minimum output based on the nodes relay fee rate.
Other tests which have fixed fee are changed to use the same approach.