### PR TITLE
Port Bitcoin Core PR#25325: Pool-based memory resource for CCoinsMap

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -221,10 +221,12 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 
 bool CCoinsViewCache::Flush() {
     bool fOk = base->BatchWrite(cacheCoins, hashBlock);
-    if (fOk) {
-        cacheCoins.clear();
-        ReallocateCache();
-    }
+    // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
+    // cacheCoins unconditionally during iteration, so the map is always empty
+    // clear() here is defensive; ReallocateCache() returns the pool backing memory.
+    // All three are safe to call on failure and success.
+    cacheCoins.clear();
+    ReallocateCache();
     cachedCoinsUsage = 0;
     return fOk;
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -33,7 +33,9 @@ size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
 SaltedOutpointHasher::SaltedOutpointHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), cachedCoinsUsage(0) {}
+CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn),
+    cacheCoins(0, SaltedOutpointHasher{}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource),
+    cachedCoinsUsage(0) {}
 
 size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
@@ -219,9 +221,22 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 
 bool CCoinsViewCache::Flush() {
     bool fOk = base->BatchWrite(cacheCoins, hashBlock);
-    cacheCoins.clear();
+    if (fOk) {
+        cacheCoins.clear();
+        ReallocateCache();
+    }
     cachedCoinsUsage = 0;
     return fOk;
+}
+
+void CCoinsViewCache::ReallocateCache()
+{
+    // Cache should be empty when we're calling this.
+    assert(cacheCoins.size() == 0);
+    cacheCoins.~CCoinsMap();
+    m_cache_coins_memory_resource.~CCoinsMapMemoryResource();
+    ::new (&m_cache_coins_memory_resource) CCoinsMapMemoryResource{};
+    ::new (&cacheCoins) CCoinsMap{0, SaltedOutpointHasher{}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource};
 }
 
 void CCoinsViewCache::Uncache(const COutPoint& hash)

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -221,19 +221,31 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 
 bool CCoinsViewCache::Flush() {
     bool fOk = base->BatchWrite(cacheCoins, hashBlock);
-    // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
-    // cacheCoins unconditionally during iteration, so the map is always empty
-    // clear() here is defensive; ReallocateCache() returns the pool backing memory.
-    // All three are safe to call on failure and success.
-    cacheCoins.clear();
-    ReallocateCache();
+    if (fOk) {
+        // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
+        // cacheCoins inside the iteration loop, so the map must be empty here.
+        // The assertion catches any future refactor that breaks that invariant.
+        if (!cacheCoins.empty()) {
+            throw std::logic_error("Not all cached coins were erased");
+        }
+        ReallocateCache();
+    }
     cachedCoinsUsage = 0;
     return fOk;
 }
 
 void CCoinsViewCache::ReallocateCache()
 {
-    // Cache should be empty when we're calling this.
+    // After Flush(), the pool resource still holds all chunks that were used
+    // during this flush cycle. We want to return that memory to the OS so the
+    // next flush cycle starts clean. We can't simply reset the resource because
+    // cacheCoins's allocator holds a pointer to it — so we tear down both objects
+    // and reconstruct them in place. The member addresses are preserved, so any
+    // references held elsewhere (there should be none, but defensively) remain
+    // valid.
+    //
+    // Order matters: cacheCoins must be destroyed before the resource it
+    // allocates from, and reconstructed after the new resource is in place.
     assert(cacheCoins.size() == 0);
     cacheCoins.~CCoinsMap();
     m_cache_coins_memory_resource.~CCoinsMapMemoryResource();

--- a/src/coins.h
+++ b/src/coins.h
@@ -226,7 +226,14 @@ protected:
      * declared as "const".
      */
     mutable uint256 hashBlock;
+    // Note: declaration order is load-bearing. m_cache_coins_memory_resource
+    // must precede cacheCoins because cacheCoins's allocator stores a pointer
+    // to it, which is dereferenced from cacheCoins's destructor (and from
+    // every allocate/deallocate). Reordering these is undefined behavior.
     mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
+    // cacheCoins (and the underlying memory resource) must only be accessed
+    // while cs_main is held. PoolResource is not thread-safe — concurrent
+    // access from multiple threads is undefined behavior.
     mutable CCoinsMap cacheCoins;
 
     /* Cached dynamic memory usage for the inner Coin objects. */

--- a/src/coins.h
+++ b/src/coins.h
@@ -19,6 +19,8 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include <support/allocators/pool.h>
+
 #include <unordered_map>
 
 /**
@@ -121,7 +123,23 @@ struct CCoinsCacheEntry
     explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
 };
 
-typedef std::unordered_map<COutPoint, CCoinsCacheEntry, SaltedOutpointHasher> CCoinsMap;
+/**
+ * PoolAllocator's MAX_BLOCK_SIZE_BYTES parameter here uses sizeof the data, and adds the size
+ * of 4 pointers. We do not know the exact node size used in the std::unordered_map implementation
+ * because it is implementation defined. Most implementations have an overhead of 1 or 2 pointers,
+ * so nodes can be connected in a linked list, and in some cases the hash value is stored as well.
+ * Using an additional sizeof(void*)*4 for MAX_BLOCK_SIZE_BYTES should thus be sufficient so that
+ * all implementations can allocate the nodes from the PoolAllocator.
+ */
+using CCoinsMap = std::unordered_map<COutPoint,
+                                     CCoinsCacheEntry,
+                                     SaltedOutpointHasher,
+                                     std::equal_to<COutPoint>,
+                                     PoolAllocator<std::pair<const COutPoint, CCoinsCacheEntry>,
+                                                   sizeof(std::pair<const COutPoint, CCoinsCacheEntry>) + sizeof(void*) * 4,
+                                                   alignof(void*)>>;
+
+using CCoinsMapMemoryResource = CCoinsMap::allocator_type::ResourceType;
 
 /** Cursor for iterating over CoinsView state */
 class CCoinsViewCursor
@@ -208,6 +226,7 @@ protected:
      * declared as "const".
      */
     mutable uint256 hashBlock;
+    mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
     mutable CCoinsMap cacheCoins;
 
     /* Cached dynamic memory usage for the inner Coin objects. */
@@ -269,6 +288,13 @@ public:
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
     bool Flush();
+
+    /**
+     * Destructively reset the contents of this cache to a fresh, empty state.
+     * Used after Flush() to return pre-allocated memory to the OS and start
+     * the next IBD flush cycle with a clean pool.
+     */
+    void ReallocateCache();
 
     /**
      * Removes the UTXO with the given outpoint from the cache, if it is

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_MEMUSAGE_H
 #define BITCOIN_MEMUSAGE_H
 
+#include <support/allocators/pool.h>
+
 #include <indirectmap.h>
 
 #include <stdlib.h>
@@ -163,6 +165,23 @@ template<typename X, typename Y, typename Z>
 static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
+}
+
+template <typename Key, typename T, typename Hash, typename Pred,
+          std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+static inline size_t DynamicUsage(const std::unordered_map<Key, T, Hash, Pred,
+                                                           PoolAllocator<std::pair<const Key, T>,
+                                                                         MAX_BLOCK_SIZE_BYTES,
+                                                                         ALIGN_BYTES>>& m)
+{
+    auto* pool_resource = m.get_allocator().resource();
+
+    // The allocated chunks are stored in a std::list. Size per node should
+    // therefore be 3 pointers: next, previous, and a pointer to the chunk.
+    size_t estimated_list_node_size = MallocUsage(sizeof(void*) * 3);
+    size_t usage_resource = estimated_list_node_size * pool_resource->NumAllocatedChunks();
+    size_t usage_chunks = MallocUsage(pool_resource->ChunkSizeBytes()) * pool_resource->NumAllocatedChunks();
+    return usage_resource + usage_chunks + MallocUsage(sizeof(void*) * m.bucket_count());
 }
 
 }

--- a/src/support/allocators/pool.h
+++ b/src/support/allocators/pool.h
@@ -1,0 +1,350 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_POOL_H
+#define BITCOIN_SUPPORT_ALLOCATORS_POOL_H
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <list>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+/**
+ * A memory resource similar to std::pmr::unsynchronized_pool_resource, but
+ * optimized for node-based containers. It has the following properties:
+ *
+ * * Owns the allocated memory and frees it on destruction, even when deallocate
+ *   has not been called on the allocated blocks.
+ *
+ * * Consists of a number of pools, each one for a different block size.
+ *   Each pool holds blocks of uniform size in a freelist.
+ *
+ * * Exhausting memory in a freelist causes a new allocation of a fixed size chunk.
+ *   This chunk is used to carve out blocks.
+ *
+ * * Block sizes or alignments that can not be served by the pools are allocated
+ *   and deallocated by operator new().
+ *
+ * PoolResource is not thread-safe. It is intended to be used by PoolAllocator.
+ *
+ * @tparam MAX_BLOCK_SIZE_BYTES Maximum size to allocate with the pool. If larger
+ *         sizes are requested, allocation falls back to new().
+ *
+ * @tparam ALIGN_BYTES Required alignment for the allocations.
+ *
+ * An example: If you create a PoolResource<128, 8>(262144) and perform a bunch of
+ * allocations and deallocate 2 blocks with size 8 bytes, and 3 blocks with size 16,
+ * the members will look like this:
+ *
+ *     m_free_lists                         m_allocated_chunks
+ *        ┌───┐                                ┌───┐  ┌────────────-------──────┐
+ *        │   │  blocks                        │   ├─►│    262144 B             │
+ *        │   │  ┌─────┐  ┌─────┐              └─┬─┘  └────────────-------──────┘
+ *        │ 1 ├─►│ 8 B ├─►│ 8 B │                │
+ *        │   │  └─────┘  └─────┘                :
+ *        │   │                                  │
+ *        │   │  ┌─────┐  ┌─────┐  ┌─────┐       ▼
+ *        │ 2 ├─►│16 B ├─►│16 B ├─►│16 B │     ┌───┐  ┌─────────────────────────┐
+ *        │   │  └─────┘  └─────┘  └─────┘     │   ├─►│          ▲              │ ▲
+ *        │   │                                └───┘  └──────────┬──────────────┘ │
+ *        │ . │                                                  │    m_available_memory_end
+ *        │ . │                                         m_available_memory_it
+ *        │ . │
+ *        │   │
+ *        │   │
+ *        │16 │
+ *        └───┘
+ *
+ * Here m_free_lists[1] holds the 2 blocks of size 8 bytes, and m_free_lists[2]
+ * holds the 3 blocks of size 16. The blocks came from the data stored in the
+ * m_allocated_chunks list. Each chunk has bytes 262144. The last chunk has still
+ * some memory available for the blocks, and when m_available_memory_it is at the
+ * end, a new chunk will be allocated and added to the list.
+ */
+template <std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+class PoolResource final
+{
+    static_assert(ALIGN_BYTES > 0, "ALIGN_BYTES must be nonzero");
+    static_assert((ALIGN_BYTES & (ALIGN_BYTES - 1)) == 0, "ALIGN_BYTES must be a power of two");
+
+    /**
+     * In-place linked list of the allocations, used for the freelist.
+     */
+    struct ListNode {
+        ListNode* m_next;
+
+        explicit ListNode(ListNode* next) : m_next(next) {}
+    };
+    static_assert(std::is_trivially_destructible_v<ListNode>, "Make sure we don't need to manually call a destructor");
+
+    /**
+     * Internal alignment value. The larger of the requested ALIGN_BYTES and alignof(FreeList).
+     */
+    static constexpr std::size_t ELEM_ALIGN_BYTES = std::max(alignof(ListNode), ALIGN_BYTES);
+    static_assert((ELEM_ALIGN_BYTES & (ELEM_ALIGN_BYTES - 1)) == 0, "ELEM_ALIGN_BYTES must be a power of two");
+    static_assert(sizeof(ListNode) <= ELEM_ALIGN_BYTES, "Units of size ELEM_SIZE_ALIGN need to be able to store a ListNode");
+    static_assert((MAX_BLOCK_SIZE_BYTES & (ELEM_ALIGN_BYTES - 1)) == 0, "MAX_BLOCK_SIZE_BYTES needs to be a multiple of the alignment.");
+
+    /**
+     * Size in bytes to allocate per chunk
+     */
+    const size_t m_chunk_size_bytes;
+
+    /**
+     * Contains all allocated pools of memory, used to free the data in the destructor.
+     */
+    std::list<std::byte*> m_allocated_chunks{};
+
+    /**
+     * Single linked lists of all data that came from deallocating.
+     * m_free_lists[n] will serve blocks of size n*ELEM_ALIGN_BYTES.
+     */
+    std::array<ListNode*, MAX_BLOCK_SIZE_BYTES / ELEM_ALIGN_BYTES + 1> m_free_lists{};
+
+    /**
+     * Points to the beginning of available memory for carving out allocations.
+     */
+    std::byte* m_available_memory_it = nullptr;
+
+    /**
+     * Points to the end of available memory for carving out allocations.
+     *
+     * That member variable is redundant, and is always equal to `m_allocated_chunks.back() + m_chunk_size_bytes`
+     * whenever it is accessed, but `m_available_memory_end` caches this for clarity and efficiency.
+     */
+    std::byte* m_available_memory_end = nullptr;
+
+    /**
+     * How many multiple of ELEM_ALIGN_BYTES are necessary to fit bytes. We use that result directly as an index
+     * into m_free_lists. Round up for the special case when bytes==0.
+     */
+    [[nodiscard]] static constexpr std::size_t NumElemAlignBytes(std::size_t bytes)
+    {
+        return (bytes + ELEM_ALIGN_BYTES - 1) / ELEM_ALIGN_BYTES + (bytes == 0);
+    }
+
+    /**
+     * True when it is possible to make use of the freelist
+     */
+    [[nodiscard]] static constexpr bool IsFreeListUsable(std::size_t bytes, std::size_t alignment)
+    {
+        return alignment <= ELEM_ALIGN_BYTES && bytes <= MAX_BLOCK_SIZE_BYTES;
+    }
+
+    /**
+     * Replaces node with placement constructed ListNode that points to the previous node
+     */
+    void PlacementAddToList(void* p, ListNode*& node)
+    {
+        node = new (p) ListNode{node};
+    }
+
+    /**
+     * Allocate one full memory chunk which will be used to carve out allocations.
+     * Also puts any leftover bytes into the freelist.
+     *
+     * Precondition: leftover bytes are either 0 or few enough to fit into a place in the freelist
+     */
+    void AllocateChunk()
+    {
+        // if there is still any available memory left, put it into the freelist.
+        size_t remaining_available_bytes = std::distance(m_available_memory_it, m_available_memory_end);
+        if (0 != remaining_available_bytes) {
+            PlacementAddToList(m_available_memory_it, m_free_lists[remaining_available_bytes / ELEM_ALIGN_BYTES]);
+        }
+
+        void* storage = ::operator new (m_chunk_size_bytes, std::align_val_t{ELEM_ALIGN_BYTES});
+        m_available_memory_it = new (storage) std::byte[m_chunk_size_bytes];
+        m_available_memory_end = m_available_memory_it + m_chunk_size_bytes;
+        m_allocated_chunks.emplace_back(m_available_memory_it);
+    }
+
+    /**
+     * Access to internals for testing purpose only
+     */
+    friend class PoolResourceTester;
+
+public:
+    /**
+     * Construct a new PoolResource object which allocates the first chunk.
+     * chunk_size_bytes will be rounded up to next multiple of ELEM_ALIGN_BYTES.
+     */
+    explicit PoolResource(std::size_t chunk_size_bytes)
+        : m_chunk_size_bytes(NumElemAlignBytes(chunk_size_bytes) * ELEM_ALIGN_BYTES)
+    {
+        assert(m_chunk_size_bytes >= MAX_BLOCK_SIZE_BYTES);
+        AllocateChunk();
+    }
+
+    /**
+     * Construct a new Pool Resource object, defaults to 2^18=262144 chunk size.
+     */
+    PoolResource() : PoolResource(262144) {}
+
+    /**
+     * Disable copy & move semantics, these are not supported for the resource.
+     */
+    PoolResource(const PoolResource&) = delete;
+    PoolResource& operator=(const PoolResource&) = delete;
+    PoolResource(PoolResource&&) = delete;
+    PoolResource& operator=(PoolResource&&) = delete;
+
+    /**
+     * Deallocates all memory allocated associated with the memory resource.
+     */
+    ~PoolResource()
+    {
+        for (std::byte* chunk : m_allocated_chunks) {
+            std::destroy(chunk, chunk + m_chunk_size_bytes);
+            ::operator delete ((void*)chunk, std::align_val_t{ELEM_ALIGN_BYTES});
+        }
+    }
+
+    /**
+     * Allocates a block of bytes. If possible the freelist is used, otherwise allocation
+     * is forwarded to ::operator new().
+     */
+    void* Allocate(std::size_t bytes, std::size_t alignment)
+    {
+        if (IsFreeListUsable(bytes, alignment)) {
+            const std::size_t num_alignments = NumElemAlignBytes(bytes);
+            if (nullptr != m_free_lists[num_alignments]) {
+                // we've already got data in the pool's freelist, unlink one element and return the pointer
+                // to the unlinked memory. Since FreeList is trivially destructible we can just treat it as
+                // uninitialized memory.
+                return std::exchange(m_free_lists[num_alignments], m_free_lists[num_alignments]->m_next);
+            }
+
+            // freelist is empty: get one allocation from allocated chunk memory.
+            const std::ptrdiff_t round_bytes = static_cast<std::ptrdiff_t>(num_alignments * ELEM_ALIGN_BYTES);
+            if (round_bytes > m_available_memory_end - m_available_memory_it) {
+                // slow path, only happens when a new chunk needs to be allocated
+                AllocateChunk();
+            }
+
+            // Make sure we use the right amount of bytes for that freelist (might be rounded up),
+            return std::exchange(m_available_memory_it, m_available_memory_it + round_bytes);
+        }
+
+        // Can't use the pool => use operator new()
+        return ::operator new (bytes, std::align_val_t{alignment});
+    }
+
+    /**
+     * Returns a block to the freelists, or deletes the block when it did not come from the chunks.
+     */
+    void Deallocate(void* p, std::size_t bytes, std::size_t alignment) noexcept
+    {
+        if (IsFreeListUsable(bytes, alignment)) {
+            const std::size_t num_alignments = NumElemAlignBytes(bytes);
+            // put the memory block into the linked list. We can placement construct the FreeList
+            // into the memory since we can be sure the alignment is correct.
+            PlacementAddToList(p, m_free_lists[num_alignments]);
+        } else {
+            // Can't use the pool => forward deallocation to ::operator delete().
+            ::operator delete (p, std::align_val_t{alignment});
+        }
+    }
+
+    /**
+     * Number of allocated chunks
+     */
+    [[nodiscard]] std::size_t NumAllocatedChunks() const
+    {
+        return m_allocated_chunks.size();
+    }
+
+    /**
+     * Size in bytes to allocate per chunk, currently hardcoded to a fixed size.
+     */
+    [[nodiscard]] size_t ChunkSizeBytes() const
+    {
+        return m_chunk_size_bytes;
+    }
+};
+
+
+/**
+ * Forwards all allocations/deallocations to the PoolResource.
+ */
+template <class T, std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+class PoolAllocator
+{
+    PoolResource<MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>* m_resource;
+
+    template <typename U, std::size_t M, std::size_t A>
+    friend class PoolAllocator;
+
+public:
+    using value_type = T;
+    using ResourceType = PoolResource<MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>;
+
+    /**
+     * Not explicit so we can easily construct it with the correct resource
+     */
+    PoolAllocator(ResourceType* resource) noexcept
+        : m_resource(resource)
+    {
+    }
+
+    PoolAllocator(const PoolAllocator& other) noexcept = default;
+    PoolAllocator& operator=(const PoolAllocator& other) noexcept = default;
+
+    template <class U>
+    PoolAllocator(const PoolAllocator<U, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& other) noexcept
+        : m_resource(other.resource())
+    {
+    }
+
+    /**
+     * The rebind struct here is mandatory because we use non type template arguments for
+     * PoolAllocator. See https://en.cppreference.com/w/cpp/named_req/Allocator#cite_note-2
+     */
+    template <typename U>
+    struct rebind {
+        using other = PoolAllocator<U, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>;
+    };
+
+    /**
+     * Forwards each call to the resource.
+     */
+    T* allocate(size_t n)
+    {
+        return static_cast<T*>(m_resource->Allocate(n * sizeof(T), alignof(T)));
+    }
+
+    /**
+     * Forwards each call to the resource.
+     */
+    void deallocate(T* p, size_t n) noexcept
+    {
+        m_resource->Deallocate(p, n * sizeof(T), alignof(T));
+    }
+
+    ResourceType* resource() const noexcept
+    {
+        return m_resource;
+    }
+};
+
+template <class T1, class T2, std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+bool operator==(const PoolAllocator<T1, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& a,
+                const PoolAllocator<T2, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& b) noexcept
+{
+    return a.resource() == b.resource();
+}
+
+template <class T1, class T2, std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+bool operator!=(const PoolAllocator<T1, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& a,
+                const PoolAllocator<T2, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& b) noexcept
+{
+    return !(a == b);
+}
+
+#endif // BITCOIN_SUPPORT_ALLOCATORS_POOL_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(test_tapyrus
         main_tests.cpp
         mempool_tests.cpp
         merkle_tests.cpp
+        pool_tests.cpp
         merkleblock_tests.cpp
         miner_tests.cpp
         multisig_tests.cpp
@@ -116,6 +117,7 @@ add_executable(test_tapyrus
         uint256_tests.cpp
         util_tests.cpp
         validation_block_tests.cpp
+        validation_flush_tests.cpp
         xfieldhistory_tests.cpp
         xfield_tests.cpp
         # Tests generated from JSON

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(test_tapyrus
         main_tests.cpp
         mempool_tests.cpp
         merkle_tests.cpp
+        pool_tests.cpp
         merkleblock_tests.cpp
         miner_tests.cpp
         multisig_tests.cpp
@@ -116,6 +117,7 @@ add_executable(test_tapyrus
         uint256_tests.cpp
         util_tests.cpp
         validation_block_tests.cpp
+        validation_flush_tests.cpp
         xfieldhistory_tests.cpp
         xfield_tests.cpp
         zmq_tests.cpp

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -605,7 +605,8 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags)
 
 void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
 {
-    CCoinsMap map;
+    CCoinsMapMemoryResource resource;
+    CCoinsMap map(0, SaltedOutpointHasher{}, CCoinsMap::key_equal{}, &resource);
     InsertCoinsMapEntry(map, value, flags);
     view.BatchWrite(map, {});
 }

--- a/src/test/pool_tests.cpp
+++ b/src/test/pool_tests.cpp
@@ -1,0 +1,195 @@
+// Copyright (c) 2022-present The Bitcoin Core developers
+// Copyright (c) 2019-2024 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// Ported from Bitcoin Core src/test/pool_tests.cpp (PR #25325).
+// Adaptations for Tapyrus:
+//   - BasicTestingSetup and random helpers from test/test_tapyrus.h
+//   - InsecureRandRange() / InsecureRandBool() replace m_rng.randrange()
+//   - ASAN poison/unpoison calls removed (not used in Tapyrus CI)
+//   - std::span available (C++20 is required by CMakeLists.txt)
+
+// These must precede memusage.h: Tapyrus's memusage.h includes indirectmap.h
+// (which needs std::map) and references prevector<> without including either.
+#include <map>
+#include <prevector.h>
+#include <memusage.h>
+#include <support/allocators/pool.h>
+#include <test/poolresourcetester.h>
+#include <test/test_tapyrus.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(pool_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(basic_allocating)
+{
+    auto resource = PoolResource<8, 8>();
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+
+    // First chunk is already allocated.
+    size_t expected_bytes_available = resource.ChunkSizeBytes();
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    // Consume one block from the chunk.
+    void* block = resource.Allocate(8, 8);
+    expected_bytes_available -= 8;
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    BOOST_TEST(0 == PoolResourceTester::FreeListSizes(resource)[1]);
+    resource.Deallocate(block, 8, 8);
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+    BOOST_TEST(1 == PoolResourceTester::FreeListSizes(resource)[1]);
+
+    // Alignment smaller than block size: the best-fitting freelist is used; nothing new allocated.
+    void* b = resource.Allocate(8, 1);
+    BOOST_TEST(b == block); // same block reused
+    BOOST_TEST(0 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    resource.Deallocate(block, 8, 1);
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+    BOOST_TEST(1 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    // Alignment too large for pool: falls back to system allocator.
+    b = resource.Allocate(8, 16);
+    BOOST_TEST(b != block);
+    block = b;
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+    BOOST_TEST(1 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    resource.Deallocate(block, 8, 16);
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+    BOOST_TEST(1 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    // Size too large for pool: falls back to system allocator.
+    block = resource.Allocate(16, 8);
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+    BOOST_TEST(1 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    resource.Deallocate(block, 16, 8);
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+    BOOST_TEST(1 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    // Zero-byte allocation: forwarded to operator new; consumes one freelist entry.
+    void* p = resource.Allocate(0, 1);
+    BOOST_TEST(0 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+
+    resource.Deallocate(p, 0, 1);
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+    BOOST_TEST(1 == PoolResourceTester::FreeListSizes(resource)[1]);
+    BOOST_TEST(expected_bytes_available == PoolResourceTester::AvailableMemoryFromChunk(resource));
+}
+
+// Allocate 0..n bytes where n exceeds the pool's chunk size — every size must succeed.
+BOOST_AUTO_TEST_CASE(allocate_any_byte)
+{
+    auto resource = PoolResource<128, 8>(1024);
+
+    uint8_t num_allocs = 200;
+    auto data = std::vector<std::span<uint8_t>>();
+
+    for (uint8_t num_bytes = 0; num_bytes < num_allocs; ++num_bytes) {
+        uint8_t* bytes = new (resource.Allocate(num_bytes, 1)) uint8_t[num_bytes];
+        BOOST_TEST(bytes != nullptr);
+        data.emplace_back(bytes, num_bytes);
+        std::fill(bytes, bytes + num_bytes, num_bytes);
+    }
+
+    uint8_t val = 0;
+    for (auto const& span : data) {
+        for (auto x : span) {
+            BOOST_TEST(val == x);
+        }
+        std::destroy(span.data(), span.data() + span.size());
+        resource.Deallocate(span.data(), span.size(), 1);
+        ++val;
+    }
+
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+}
+
+BOOST_AUTO_TEST_CASE(random_allocations)
+{
+    struct PtrSizeAlignment {
+        void* ptr;
+        size_t bytes;
+        size_t alignment;
+    };
+
+    auto resource = PoolResource<128, 8>(65536);
+    std::vector<PtrSizeAlignment> ptr_size_alignment{};
+
+    for (size_t i = 0; i < 1000; ++i) {
+        if (ptr_size_alignment.empty() || 0 != InsecureRandRange(4)) {
+            std::size_t alignment = std::size_t{1} << InsecureRandRange(8);          // 1, 2, ..., 128
+            std::size_t size = (InsecureRandRange(200) / alignment + 1) * alignment; // multiple of alignment
+            void* ptr = resource.Allocate(size, alignment);
+            BOOST_TEST(ptr != nullptr);
+            BOOST_TEST((reinterpret_cast<uintptr_t>(ptr) & (alignment - 1)) == 0);
+            ptr_size_alignment.push_back({ptr, size, alignment});
+        } else {
+            auto& x = ptr_size_alignment[InsecureRandRange(ptr_size_alignment.size())];
+            resource.Deallocate(x.ptr, x.bytes, x.alignment);
+            x = ptr_size_alignment.back();
+            ptr_size_alignment.pop_back();
+        }
+    }
+
+    for (auto const& x : ptr_size_alignment) {
+        resource.Deallocate(x.ptr, x.bytes, x.alignment);
+    }
+
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+}
+
+BOOST_AUTO_TEST_CASE(memusage_test)
+{
+    auto std_map = std::unordered_map<int64_t, int64_t>{};
+
+    using Map = std::unordered_map<int64_t,
+                                   int64_t,
+                                   std::hash<int64_t>,
+                                   std::equal_to<int64_t>,
+                                   PoolAllocator<std::pair<const int64_t, int64_t>,
+                                                 sizeof(std::pair<const int64_t, int64_t>) + sizeof(void*) * 4,
+                                                 alignof(void*)>>;
+    auto resource = Map::allocator_type::ResourceType(1024);
+
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+
+    {
+        auto resource_map = Map{0, std::hash<int64_t>{}, std::equal_to<int64_t>{}, &resource};
+
+        BOOST_TEST(memusage::DynamicUsage(std_map) != memusage::DynamicUsage(resource_map));
+
+        for (size_t i = 0; i < 10000; ++i) {
+            std_map[i];
+            resource_map[i];
+        }
+
+        // Pool allocator has significantly lower overhead than the system allocator.
+        BOOST_TEST(memusage::DynamicUsage(resource_map) <= memusage::DynamicUsage(std_map) * 90 / 100);
+
+        auto max_nodes_per_chunk = resource.ChunkSizeBytes() / sizeof(Map::value_type);
+        auto min_num_allocated_chunks = resource_map.size() / max_nodes_per_chunk + 1;
+        BOOST_TEST(resource.NumAllocatedChunks() >= min_num_allocated_chunks);
+    }
+
+    PoolResourceTester::CheckAllDataAccountedFor(resource);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/poolresourcetester.h
+++ b/src/test/poolresourcetester.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2022-present The Bitcoin Core developers
+// Copyright (c) 2019-2024 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef TAPYRUS_TEST_POOLRESOURCETESTER_H
+#define TAPYRUS_TEST_POOLRESOURCETESTER_H
+
+#include <support/allocators/pool.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+/**
+ * Helper to access private members of PoolResource for unit tests.
+ * Ported from Bitcoin Core src/test/util/poolresourcetester.h (PR #25325).
+ * ASAN poison/unpoison calls are omitted — Tapyrus does not enable ASAN in CI.
+ */
+class PoolResourceTester
+{
+    struct PtrAndBytes {
+        uintptr_t ptr;
+        std::size_t size;
+
+        PtrAndBytes(const void* p, std::size_t s)
+            : ptr(reinterpret_cast<uintptr_t>(p)), size(s)
+        {
+        }
+
+        friend bool operator<(PtrAndBytes const& a, PtrAndBytes const& b)
+        {
+            return a.ptr < b.ptr;
+        }
+    };
+
+public:
+    /** Returns the number of elements in each freelist bucket. */
+    template <std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+    static std::vector<std::size_t> FreeListSizes(const PoolResource<MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& resource)
+    {
+        auto sizes = std::vector<std::size_t>();
+        for (const auto* ptr : resource.m_free_lists) {
+            size_t size = 0;
+            while (ptr != nullptr) {
+                ++size;
+                ptr = ptr->m_next;
+            }
+            sizes.push_back(size);
+        }
+        return sizes;
+    }
+
+    /** How many bytes remain unused in the last allocated chunk. */
+    template <std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+    static std::size_t AvailableMemoryFromChunk(const PoolResource<MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& resource)
+    {
+        return resource.m_available_memory_end - resource.m_available_memory_it;
+    }
+
+    /**
+     * After all blocks have been returned to the resource, verifies that:
+     * - every free-list entry comes from a known chunk
+     * - no two entries overlap
+     * - every byte in every chunk is accounted for (freelist or available)
+     */
+    template <std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+    static void CheckAllDataAccountedFor(const PoolResource<MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& resource)
+    {
+        std::vector<PtrAndBytes> free_blocks;
+        for (std::size_t freelist_idx = 0; freelist_idx < resource.m_free_lists.size(); ++freelist_idx) {
+            std::size_t bytes = freelist_idx * resource.ELEM_ALIGN_BYTES;
+            auto* ptr = resource.m_free_lists[freelist_idx];
+            while (ptr != nullptr) {
+                free_blocks.emplace_back(ptr, bytes);
+                ptr = ptr->m_next;
+            }
+        }
+        auto num_available_bytes = resource.m_available_memory_end - resource.m_available_memory_it;
+        if (num_available_bytes > 0) {
+            free_blocks.emplace_back(resource.m_available_memory_it, num_available_bytes);
+        }
+
+        std::vector<PtrAndBytes> chunks;
+        for (const std::byte* ptr : resource.m_allocated_chunks) {
+            chunks.emplace_back(ptr, resource.ChunkSizeBytes());
+        }
+
+        std::sort(free_blocks.begin(), free_blocks.end());
+        std::sort(chunks.begin(), chunks.end());
+
+        auto chunk_it = chunks.begin();
+        auto chunk_ptr_remaining = chunk_it->ptr;
+        auto chunk_size_remaining = chunk_it->size;
+        for (const auto& free_block : free_blocks) {
+            if (chunk_size_remaining == 0) {
+                assert(chunk_it != chunks.end());
+                ++chunk_it;
+                assert(chunk_it != chunks.end());
+                chunk_ptr_remaining = chunk_it->ptr;
+                chunk_size_remaining = chunk_it->size;
+            }
+            assert(free_block.ptr == chunk_ptr_remaining);
+            assert(free_block.size <= chunk_size_remaining);
+            assert((free_block.ptr & (resource.ELEM_ALIGN_BYTES - 1)) == 0);
+            chunk_ptr_remaining += free_block.size;
+            chunk_size_remaining -= free_block.size;
+        }
+        assert(chunk_ptr_remaining == chunk_it->ptr + chunk_it->size);
+        ++chunk_it;
+        assert(chunk_it == chunks.end());
+        assert(chunk_size_remaining == 0);
+    }
+};
+
+#endif // TAPYRUS_TEST_POOLRESOURCETESTER_H

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2019-present The Bitcoin Core developers
+// Copyright (c) 2019-2024 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// Ported from Bitcoin Core src/test/validation_flush_tests.cpp.
+// Adaptations for Tapyrus:
+//   - No Chainstate class / GetCoinsCacheSizeState(): threshold logic inlined
+//     from FlushStateToDisk() in file_io.cpp (fCacheLarge / fCacheCritical).
+//   - Uses global pcoinsTip and nCoinCacheUsage from validation.h.
+//   - AddTestCoin() reimplemented using COutPoint(uint256, n) directly.
+//   - InsecureRand256() / InsecureRand32() replace FastRandomContext helpers.
+
+#include <coins.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/test_tapyrus.h>
+#include <txdb.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <algorithm>
+
+//! Mirrors LargeCoinsCacheThreshold() from Bitcoin Core validation.h.
+//! In Tapyrus this threshold is inlined in FlushStateToDisk() (file_io.cpp:436):
+//!   max((9 * nTotalSpace) / 10, nTotalSpace - MAX_BLOCK_COINSDB_USAGE * 1024 * 1024)
+static int64_t LargeCacheSizeThreshold(int64_t total_space)
+{
+    return std::max((9 * total_space) / 10,
+                    total_space - static_cast<int64_t>(MAX_BLOCK_COINSDB_USAGE) * 1024 * 1024);
+}
+
+//! Add one test coin to the view.
+//! Mirrors Bitcoin Core's test/util/coins.cpp:AddTestCoin().
+//! The coin has a 56-byte scriptPubKey, giving roughly 80 bytes DynamicMemoryUsage.
+static void AddTestCoin(CCoinsViewCache& view)
+{
+    Coin coin;
+    COutPoint outpoint{InsecureRand256(), /*n=*/0};
+    coin.nHeight = 1;
+    coin.out.nValue = static_cast<CAmount>(InsecureRandRange(21000000LL * COIN) + 1);
+    coin.out.scriptPubKey.assign(56, static_cast<unsigned char>(1));
+    view.AddCoin(outpoint, std::move(coin), /*possible_overwrite=*/false);
+}
+
+BOOST_FIXTURE_TEST_SUITE(validation_flush_tests, TestingSetup)
+
+//! Verify that the cache-size thresholds used in FlushStateToDisk() switch
+//! from "OK" → "LARGE" → "CRITICAL" at the expected utilisation levels.
+//!
+//! Bitcoin Core tests Chainstate::GetCoinsCacheSizeState().  Tapyrus does not
+//! have that method; instead FlushStateToDisk() (file_io.cpp) computes
+//!   nTotalSpace = nCoinCacheUsage + max(nMempoolSizeMax - nMempoolUsage, 0)
+//!   fCacheLarge   = cacheSize > LargeCacheSizeThreshold(nTotalSpace)
+//!   fCacheCritical= cacheSize > nTotalSpace
+//! This test exercises the same state-machine by controlling nCoinCacheUsage
+//! and filling pcoinsTip until each threshold is crossed.
+BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
+{
+    LOCK(cs_main);
+    CCoinsViewCache& view = *pcoinsTip;
+
+    // An empty cache should occupy well under one pool chunk (~256 KiB).
+    BOOST_CHECK_LT(view.DynamicMemoryUsage() / (256.0 * 1024), 1.1);
+
+    // Use a small cache cap so the test runs fast.
+    constexpr int64_t MAX_COINS_BYTES = 8 * 1024 * 1024;   //  8 MiB
+    constexpr int64_t MAX_MEMPOOL_BYTES = 4 * 1024 * 1024; //  4 MiB
+    // 200k attempts gives comfortable headroom: the larger total_space in the
+    // second pass (12 MiB) needs ~55k coins to cross its LARGE threshold.
+    constexpr size_t  MAX_ATTEMPTS = 200'000;
+
+    // Save and restore nCoinCacheUsage so other tests are not affected.
+    const size_t saved_nCoinCacheUsage = nCoinCacheUsage;
+    nCoinCacheUsage = static_cast<size_t>(MAX_COINS_BYTES);
+
+    // Run twice: once with no mempool head-room, once with head-room.
+    for (int64_t max_mempool_size_bytes : {int64_t{0}, MAX_MEMPOOL_BYTES}) {
+        const int64_t total_space = MAX_COINS_BYTES + max_mempool_size_bytes;
+        const int64_t large_threshold = LargeCacheSizeThreshold(total_space);
+
+        // --- OK → LARGE ---
+        for (size_t i = 0; i < MAX_ATTEMPTS; ++i) {
+            int64_t cacheSize = static_cast<int64_t>(view.DynamicMemoryUsage());
+            if (cacheSize > large_threshold) break;
+            // While below the LARGE threshold the cache is still "OK".
+            BOOST_CHECK_LE(cacheSize, large_threshold);
+            AddTestCoin(view);
+        }
+        // Ensure we actually crossed the LARGE threshold before proceeding.
+        BOOST_REQUIRE_GT(static_cast<int64_t>(view.DynamicMemoryUsage()), large_threshold);
+
+        // --- LARGE → CRITICAL ---
+        for (size_t i = 0; i < MAX_ATTEMPTS; ++i) {
+            int64_t cacheSize = static_cast<int64_t>(view.DynamicMemoryUsage());
+            if (cacheSize > total_space) break;
+            // While above LARGE but not yet above total_space the cache is "LARGE".
+            BOOST_CHECK_GT(cacheSize, large_threshold);
+            BOOST_CHECK_LE(cacheSize, total_space);
+            AddTestCoin(view);
+        }
+
+        // Cache must now be CRITICAL (above total_space).
+        BOOST_CHECK_GT(static_cast<int64_t>(view.DynamicMemoryUsage()), total_space);
+
+        // --- CRITICAL → OK via Flush ---
+        view.SetBestBlock(InsecureRand256());
+        BOOST_CHECK(view.Flush());
+        BOOST_CHECK_LE(static_cast<int64_t>(view.DynamicMemoryUsage()), large_threshold);
+    }
+
+    nCoinCacheUsage = saved_nCoinCacheUsage;
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds a PoolAllocator backed by PoolResource for the UTXO cache map (CCoinsMap). Pre-allocates memory in 256KB chunks and serves node allocations from freelists, eliminating per-entry malloc/free overhead during IBD.

Changes:
- src/support/allocators/pool.h: new PoolResource + PoolAllocator
- src/coins.h: replace CCoinsMap typedef with PoolAllocator variant; add CCoinsMapMemoryResource member; declare ReallocateCache()
- src/coins.cpp: wire resource into CCoinsMap constructor; add ReallocateCache() to return chunk memory after each Flush()
- src/memusage.h: add DynamicUsage overload for PoolAllocator maps

Tapyrus adaptation notes:
- No m_deterministic flag; SaltedOutpointHasher{} used directly
- COutPoint uses hashMalFix (same sizeof as Bitcoin's hash field)
- No validation.cpp change needed (Tapyrus has no ResizeCoinsCaches)

Bitcoin Core reference: https://github.com/bitcoin/bitcoin/commit/5aa0c82ccd6ceb4a141686fc8658f679de75a787