### PR TITLE
Fix CVE-2024-52911 in v0.7

### DIFF
--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -574,15 +574,19 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     CBlockUndo blockundo;
 
-    CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? scriptcheckqueue.get() : nullptr);
-
     std::vector<int> prevheights;
     CAmount nFees = 0;
     int nInputs = 0;
     int64_t nSigOpsCost = 0;
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
+    // txdata must be declared before control: on early return, C++ destroys locals in
+    // reverse declaration order, so control's destructor (which calls Wait()) must run
+    // before txdata is freed — otherwise background script-check threads access freed memory
+    // (CVE-2024-52911).
     std::vector<PrecomputedTransactionData> txdata;
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
+
+    CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? scriptcheckqueue.get() : nullptr);
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = *(block.vtx[i]);


### PR DESCRIPTION
Declare txdata before CCheckQueueControl in ConnectBlock

CScriptCheck holds a raw pointer into the txdata vector. When ConnectBlock returns early (e.g. CheckTxInputs, SequenceLocks, or colored coin validation failures) after script checks have already been queued, C++ destroys locals in reverse declaration order. With control declared before txdata, txdata was freed before control's destructor called Wait(), leaving background script-check threads accessing freed memory.

Fix by declaring txdata before control so that control (and thus Wait()) is destroyed first, ensuring all worker threads have finished before txdata is freed.