### PR TITLE
Fix security vulnerabilities ij

### DIFF
--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -863,7 +863,7 @@ bool CChainState::ConnectTip(CValidationState& state, CBlockIndex* pindexNew, co
         CXFieldHistory xfieldHistory;
         if(blockConnecting.xfield.IsValid()
             && pindexNew->nHeight > 0
-            && IsXFieldNew(blockConnecting.xfield, &xfieldHistory))
+            && IsXFieldNew(blockConnecting.xfield, &xfieldHistory, static_cast<uint32_t>(pindexNew->nHeight - 1)))
         {
             XFieldChange newChange(blockConnecting.xfield.xfieldValue, pindexNew->nHeight + 1, blockConnecting.GetHash());
             xfieldHistory.Add(blockConnecting.xfield.xfieldType, newChange);
@@ -1407,7 +1407,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     if(pxfieldHistory
         && block.xfield.IsValid()
         && pindex->nHeight > 0
-        && IsXFieldNew(block.xfield, pxfieldHistory))
+        && IsXFieldNew(block.xfield, pxfieldHistory, static_cast<uint32_t>(pindex->nHeight - 1)))
     {
         XFieldChange newChange(block.xfield.xfieldValue, pindex->nHeight + 1, block.GetHash());
         pxfieldHistory->Add(block.xfield.xfieldType, newChange);

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -303,13 +303,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                         continue;
                     COutPoint prevout = tx.vin[j].prevout;
                     if (ColorIdentifier(prevout, outColorId.type) == outColorId) {
-                        // Skip global state writes when called from VerifyDB's dry-run
-                        // sandbox (level 3): chainActive is not actually disconnected, so
-                        // mutating g_colorid_state here would leave it permanently
-                        // inconsistent with the real chain tip.
-                        if (!fDryRun) {
-                            g_colorid_state->Erase(outColorId);
-                        }
+                        g_colorid_state->Erase(outColorId);
                         break;
                     }
                 }

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -247,7 +247,7 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  When FAILED is returned, view is left in an indeterminate state. */
-DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
+DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, bool fDryRun)
 {
     bool fClean = true;
 
@@ -303,7 +303,13 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                         continue;
                     COutPoint prevout = tx.vin[j].prevout;
                     if (ColorIdentifier(prevout, outColorId.type) == outColorId) {
-                        g_colorid_state->Erase(outColorId);
+                        // Skip global state writes when called from VerifyDB's dry-run
+                        // sandbox (level 3): chainActive is not actually disconnected, so
+                        // mutating g_colorid_state here would leave it permanently
+                        // inconsistent with the real chain tip.
+                        if (!fDryRun) {
+                            g_colorid_state->Erase(outColorId);
+                        }
                         break;
                     }
                 }

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -718,6 +718,11 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     }
 
     // Stage new issuances only after all other disk writes have succeeded.
+    // Placing this before WriteUndoDataForBlock would leave colorIds permanently
+    // in the chainstate DB if the undo write failed: ConnectBlock would return
+    // false without state.IsInvalid(), the block would not be marked
+    // BLOCK_FAILED_VALID, and the next ActivateBestChain retry would be rejected
+    // with bad-txns-colorid-already-issued, permanently poisoning that block.
     // CommitToBatch will write them to LevelDB atomically with DB_BEST_BLOCK
     // inside the next view.Flush() → BatchWrite call, preventing a crash
     // between the colorId write and the UTXO flush from permanently poisoning

--- a/src/chainstate.h
+++ b/src/chainstate.h
@@ -136,7 +136,7 @@ public:
     bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock, CXFieldHistoryMap* pxfieldHistory = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Block (dis)connection on a given view:
-    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, bool fDryRun = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex,
                     CCoinsViewCache& view, bool fJustCheck = false);
 

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -585,12 +585,12 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
         return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
     }
 
+    // Use nHeight from the trusted block index (pindex->nHeight) when available.
+    // When nHeight == -1 (caller has no index context), fall back to UINT32_MAX so
+    // Get() returns the latest aggregate key — the safe conservative choice.
+    // Never use block.GetHeight() (coinbase prevout.n): that field is attacker-controlled.
     CValidationState state;
-    // Use -1 (→ UINT32_MAX) as the height sentinel so CheckBlockHeader selects
-    // the latest aggregate public key.  block.GetHeight() reads coinbase prevout.n
-    // which is attacker-controllable; passing it here would allow block data on
-    // disk to influence which signing key is used for verification (PR #411 footgun).
-    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, -1, true))
+    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, nHeight, true))
         return error("%s: ReadBlockFromDisk: %s", __func__, FormatStateMessage(state));
 
     return true;

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -585,12 +585,12 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
         return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
     }
 
-    // Use nHeight from the trusted block index (pindex->nHeight) when available.
-    // When nHeight == -1 (caller has no index context), fall back to UINT32_MAX so
-    // Get() returns the latest aggregate key — the safe conservative choice.
-    // Never use block.GetHeight() (coinbase prevout.n): that field is attacker-controlled.
     CValidationState state;
-    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, nHeight, true))
+    // Use -1 (→ UINT32_MAX) as the height sentinel so CheckBlockHeader selects
+    // the latest aggregate public key.  block.GetHeight() reads coinbase prevout.n
+    // which is attacker-controllable; passing it here would allow block data on
+    // disk to influence which signing key is used for verification (PR #411 footgun).
+    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, -1, true))
         return error("%s: ReadBlockFromDisk: %s", __func__, FormatStateMessage(state));
 
     return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -47,6 +47,8 @@ static constexpr int64_t ORPHAN_TX_EXPIRE_TIME = 20 * 60;
 static constexpr int64_t ORPHAN_TX_EXPIRE_INTERVAL = 5 * 60;
 /** How long a transaction has to be in the mempool before it can unconditionally be relayed (even when not in mapRelay). */
 static constexpr std::chrono::seconds UNCONDITIONAL_RELAY_DELAY = std::chrono::minutes{2};
+/** Maximum number of entries in mapRelay. Oldest entries are evicted when this is reached. */
+static constexpr size_t MAX_RELAY_MAP_SIZE = 50000;
 /** Headers download timeout expressed in microseconds
  *  Timeout = base + per_header * (expected number of headers) */
 static constexpr int64_t HEADERS_DOWNLOAD_TIMEOUT_BASE = 15 * 60 * 1000000; // 15 minutes
@@ -3766,6 +3768,12 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                         // Expire old relay messages
                         while (!vRelayExpiration.empty() && vRelayExpiration.front().first < nNow)
                         {
+                            mapRelay.erase(vRelayExpiration.front().second);
+                            vRelayExpiration.pop_front();
+                        }
+
+                        // Enforce size cap: evict oldest entries if at limit
+                        while (mapRelay.size() >= MAX_RELAY_MAP_SIZE && !vRelayExpiration.empty()) {
                             mapRelay.erase(vRelayExpiration.front().second);
                             vRelayExpiration.pop_front();
                         }

--- a/src/test/chainstate_tests.cpp
+++ b/src/test/chainstate_tests.cpp
@@ -25,6 +25,8 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <file_io.h>
+#include <xfieldhistory.h>
+#include <key.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -657,6 +659,59 @@ BOOST_AUTO_TEST_CASE(block_sequence_id_edge_cases)
     if (pindexHeader) {
         BOOST_CHECK(pindexHeader->nSequenceId == 0);
         BOOST_CHECK(pindexHeader->nSequenceId < pindex1->nSequenceId);
+    }
+}
+
+/**
+ * Regression test: 
+ * CheckBlockHeader(nHeight=-1) must look up the
+ * *latest* aggpubkey (UINT32_MAX semantics), not the genesis key (height-0).
+ * After a key rotation any header signed by the
+ * post-rotation key would fail with bad-proof instead of the expected
+ * prev-blk-not-found.
+ */
+BOOST_AUTO_TEST_CASE(check_block_header_orphan_uses_latest_aggpubkey)
+{
+    // Generate a fresh key to represent the post-rotation aggpubkey.
+    CKey rotatedKey;
+    rotatedKey.MakeNewKey(true);
+    CPubKey rotatedPubKey = rotatedKey.GetPubKey();
+
+    // CTempXFieldHistory copies the global history (genesis key only) then
+    // lets us append a rotation entry without touching the real history.
+    CTempXFieldHistory tempHistory;
+    tempHistory.Add(TAPYRUS_XFIELDTYPES::AGGPUBKEY,
+                    XFieldChange(XFieldAggPubKey(rotatedPubKey), 5, uint256()));
+
+    // Build a block header with an unknown prev (simulates the orphan path in
+    // AcceptBlockHeader) and sign it with the post-rotation key.
+    CBlockHeader header;
+    header.nFeatures     = CBlock::TAPYRUS_BLOCK_FEATURES;
+    header.hashPrevBlock =
+        uint256S("deadbeef00000000000000000000000000000000000000000000000000000001");
+    header.nTime = GetTime();
+    header.xfield.clear();  // TAPYRUS_XFIELDTYPES::NONE — no xfield change in this header
+
+    std::vector<unsigned char> sig;
+    BOOST_REQUIRE(rotatedKey.Sign_Schnorr(header.GetHashForSign(), sig));
+    BOOST_REQUIRE(header.AbsorbBlockProof(sig, rotatedPubKey));
+
+    // CheckBlockHeader with nHeight=-1 must succeed: UINT32_MAX → latest entry
+    // → rotated key → valid Schnorr signature.
+    {
+        CValidationState state;
+        BOOST_CHECK(CheckBlockHeader(header, state, &tempHistory, -1));
+    }
+
+    // AcceptBlockHeader must reject for "prev-blk-not-found", not "bad-proof".
+    // This confirms the fix: the signature is accepted, then rejected for the
+    // unrelated missing-parent reason.
+    {
+        LOCK(cs_main);
+        CValidationState state;
+        CBlockIndex* pindex = nullptr;
+        g_chainstate.AcceptBlockHeader(header, state, &pindex, &tempHistory);
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "prev-blk-not-found");
     }
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -111,6 +111,7 @@ public:
     /** Connect the issued-colorId state object.  Call before ReplayBlocks. */
     void SetColorIdState(CIssuedColorIds* state) { m_colorid_state = state; }
 
+
     bool LoadIssuedColorIds(std::set<ColorIdentifier>& colorIds);
 };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1329,13 +1329,16 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, CXFiel
     if(!proofSize)
         return state.Invalid(false, REJECT_INVALID, "bad-proof", "No Proof in block");
 
-    //Aggpubkey to verify blocks is read from temp xfieldhistory if it is given in the argument list. otherwise it is read from the global list according to the block height.
+    // Aggpubkey to verify blocks is read from the xfield history at the block's
+    // height, not at the chain tip. Both temp and non-temp paths now call Get(height) uniformly.
+    // nHeight < 0 means AcceptBlockHeader has no pindexPrev yet (block will be
+    // rejected for missing parent); treat as 0 so Get() returns the genesis key.
+    const uint32_t uHeight = (nHeight > 0) ? static_cast<uint32_t>(nHeight) : 0;
     XFieldAggPubKey aggregatePubkeyObj;
-    if(pxfieldHistory) {
-        pxfieldHistory->GetLatest(TAPYRUS_XFIELDTYPES::AGGPUBKEY, aggregatePubkeyObj);
-    }
+    if(pxfieldHistory)
+        aggregatePubkeyObj = std::get<XFieldAggPubKey>(pxfieldHistory->Get(TAPYRUS_XFIELDTYPES::AGGPUBKEY, uHeight).xfieldValue);
     else
-        aggregatePubkeyObj = std::get<XFieldAggPubKey>(CXFieldHistory().Get(TAPYRUS_XFIELDTYPES::AGGPUBKEY, nHeight).xfieldValue);
+        aggregatePubkeyObj = std::get<XFieldAggPubKey>(CXFieldHistory().Get(TAPYRUS_XFIELDTYPES::AGGPUBKEY, uHeight).xfieldValue);
     CPubKey aggregatePubkey(aggregatePubkeyObj.getPubKey());
 
     const uint256 blockHash = block.GetHashForSign();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1331,9 +1331,12 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, CXFiel
 
     // Aggpubkey to verify blocks is read from the xfield history at the block's
     // height, not at the chain tip. Both temp and non-temp paths now call Get(height) uniformly.
-    // nHeight < 0 means AcceptBlockHeader has no pindexPrev yet (block will be
-    // rejected for missing parent); treat as 0 so Get() returns the genesis key.
-    const uint32_t uHeight = (nHeight > 0) ? static_cast<uint32_t>(nHeight) : 0;
+    // nHeight < 0 means the caller has no known block height (e.g. AcceptBlockHeader
+    // with no pindexPrev, or ReadBlockFromDisk on an orphan child during reindex).
+    // Use UINT32_MAX so Get() returns the latest rotation entry for those callers,
+    // avoiding spurious bad-proof failures against post-rotation headers.
+    // nHeight == 0 is the genesis block and must use height 0 (returns genesis key).
+    const uint32_t uHeight = (nHeight >= 0) ? static_cast<uint32_t>(nHeight) : UINT32_MAX;
     XFieldAggPubKey aggregatePubkeyObj;
     if(pxfieldHistory)
         aggregatePubkeyObj = std::get<XFieldAggPubKey>(pxfieldHistory->Get(TAPYRUS_XFIELDTYPES::AGGPUBKEY, uHeight).xfieldValue);

--- a/src/verifydb.cpp
+++ b/src/verifydb.cpp
@@ -89,7 +89,10 @@ bool CVerifyDB::VerifyDB(CCoinsView *coinsview, int nCheckLevel, int nCheckDepth
         // check level 3: check for inconsistencies during memory-only disconnect of tip blocks
         if (nCheckLevel >= 3 && (coins.DynamicMemoryUsage() + pcoinsTip->DynamicMemoryUsage()) <= nCoinCacheUsage) {
             assert(coins.GetBestBlock() == pindex->GetBlockHash());
-            DisconnectResult res = g_chainstate.DisconnectBlock(block, pindex, coins);
+            // fDryRun=true: this is a view-only sandbox — do not mutate g_issued_colorids
+            // or the chainstate DB.  chainActive stays at tip; level 4 reconnects via
+            // ConnectBlock which will restore state, but only when -checklevel=4 is set.
+            DisconnectResult res = g_chainstate.DisconnectBlock(block, pindex, coins, /*fDryRun=*/true);
             if (res == DISCONNECT_FAILED) {
                 return error("VerifyDB(): *** irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -109,9 +109,35 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
             nOutput = i;
         }
     }
+    // For colored transfers the original tx may have no TPC change output (e.g. when
+    // BnB covered the fee exactly).  When fAllowOtherInputs is set the caller has
+    // pre-arranged a destChange address; find a fresh TPC UTXO to add as a new input.
+    COutPoint newInputOp;
+    CAmount   newInputValue = 0;
     if (nOutput == -1) {
-        errors.push_back("Cannot bump fee: transaction has no TPC change output to absorb the fee delta");
-        return Result::WALLET_ERROR;
+        if (!coin_control.fAllowOtherInputs || !IsValidDestination(coin_control.destChange)) {
+            errors.push_back("Cannot bump fee: transaction has no TPC change output to absorb the fee delta");
+            return Result::WALLET_ERROR;
+        }
+        std::vector<COutput> vAvailableCoins;
+        wallet->AvailableCoins(vAvailableCoins, true, nullptr);
+        for (const auto& out : vAvailableCoins) {
+            if (!out.fSpendable) continue;
+            const CTxOut& txout = out.tx->tx->vout[out.i];
+            if (GetColorIdFromScript(txout.scriptPubKey).type != TokenTypes::NONE) continue;
+            COutPoint op(out.tx->tx->GetHashMalFix(), out.i);
+            bool alreadyIn = false;
+            for (const auto& vin : wtx.tx->vin)
+                if (vin.prevout == op) { alreadyIn = true; break; }
+            if (alreadyIn) continue;
+            newInputOp   = op;
+            newInputValue = txout.nValue;
+            break;
+        }
+        if (newInputOp.IsNull()) {
+            errors.push_back("Cannot bump fee: no available TPC UTXO to add as new input");
+            return Result::WALLET_ERROR;
+        }
     }
 
     // Calculate the expected size of the new transaction.
@@ -189,23 +215,40 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
         return Result::WALLET_ERROR;
     }
 
-    // Now modify the output to increase the fee.
-    // If the output is not large enough to pay the fee, fail.
     CAmount nDelta = new_fee - old_fee;
     assert(nDelta > 0);
     mtx = CMutableTransaction{*wtx.tx};
-    CTxOut* poutput = &(mtx.vout[nOutput]);
-    if (poutput->nValue < nDelta) {
-        errors.push_back("Change output is too small to bump the fee");
-        return Result::WALLET_ERROR;
-    }
 
-    // If the output would become dust, discard it (converting the dust to fee)
-    poutput->nValue -= nDelta;
-    if (poutput->nValue <= GetDustThreshold(*poutput, GetDiscardRate(*wallet, ::feeEstimator))) {
-        wallet->WalletLogPrintf("Bumping fee and discarding dust output\n");
-        new_fee += poutput->nValue;
-        mtx.vout.erase(mtx.vout.begin() + nOutput);
+    if (nOutput != -1) {
+        // Reduce the existing TPC change output to cover the fee delta.
+        CTxOut* poutput = &(mtx.vout[nOutput]);
+        if (poutput->nValue < nDelta) {
+            errors.push_back("Change output is too small to bump the fee");
+            return Result::WALLET_ERROR;
+        }
+        poutput->nValue -= nDelta;
+        if (poutput->nValue <= GetDustThreshold(*poutput, GetDiscardRate(*wallet, ::feeEstimator))) {
+            wallet->WalletLogPrintf("Bumping fee and discarding dust output\n");
+            new_fee += poutput->nValue;
+            mtx.vout.erase(mtx.vout.begin() + nOutput);
+        }
+    } else {
+        // Add the new TPC input and create a change output for the surplus.
+        bool rbf = coin_control.m_signal_bip125_rbf.get_value_or(wallet->m_signal_rbf);
+        mtx.vin.push_back(CTxIn(newInputOp, CScript(), rbf ? MAX_BIP125_RBF_SEQUENCE : 0xfffffffe));
+        if (newInputValue < nDelta) {
+            errors.push_back("Cannot bump fee: new TPC input insufficient to cover fee delta");
+            return Result::WALLET_ERROR;
+        }
+        CAmount changeValue = newInputValue - nDelta;
+        CScript changeScript = GetScriptForDestination(coin_control.destChange);
+        CTxOut  changeOut(changeValue, changeScript);
+        if (changeValue > GetDustThreshold(changeOut, GetDiscardRate(*wallet, ::feeEstimator))) {
+            mtx.vout.push_back(changeOut);
+        } else {
+            wallet->WalletLogPrintf("Bumping fee: discarding dust change from new TPC input\n");
+            new_fee += changeValue;
+        }
     }
 
     // Mark new tx not replaceable, if requested.
@@ -214,7 +257,6 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
             if (input.nSequence < 0xfffffffe) input.nSequence = 0xfffffffe;
         }
     }
-
 
     return Result::OK;
 }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -120,7 +120,7 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
             return Result::WALLET_ERROR;
         }
         std::vector<COutput> vAvailableCoins;
-        wallet->AvailableCoins(vAvailableCoins, true, nullptr);
+        wallet->AvailableCoins(vAvailableCoins, true, &coin_control);
         for (const auto& out : vAvailableCoins) {
             if (!out.fSpendable) continue;
             const CTxOut& txout = out.tx->tx->vout[out.i];
@@ -130,9 +130,11 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
             for (const auto& vin : wtx.tx->vin)
                 if (vin.prevout == op) { alreadyIn = true; break; }
             if (alreadyIn) continue;
-            newInputOp   = op;
-            newInputValue = txout.nValue;
-            break;
+            // Keep the largest TPC UTXO to maximise the chance of covering the fee delta.
+            if (txout.nValue > newInputValue) {
+                newInputOp    = op;
+                newInputValue = txout.nValue;
+            }
         }
         if (newInputOp.IsNull()) {
             errors.push_back("Cannot bump fee: no available TPC UTXO to add as new input");
@@ -140,9 +142,19 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
         }
     }
 
+    // Build the candidate transaction first so that CalculateMaximumSignedTxSize accounts for
+    // any new input and placeholder change output when there is no TPC change output.
+    bool rbf = coin_control.m_signal_bip125_rbf.get_value_or(wallet->m_signal_rbf);
+    mtx = CMutableTransaction{*wtx.tx};
+    if (nOutput == -1) {
+        mtx.vin.push_back(CTxIn(newInputOp, CScript(), rbf ? MAX_BIP125_RBF_SEQUENCE : 0xfffffffe));
+        // Placeholder change output with full input value; corrected after fee delta is computed.
+        mtx.vout.push_back(CTxOut(newInputValue, GetScriptForDestination(coin_control.destChange)));
+    }
+
     // Calculate the expected size of the new transaction.
     int64_t txSize = GetTransactionSize(*(wtx.tx));
-    const int64_t maxNewTxSize = CalculateMaximumSignedTxSize(*wtx.tx, wallet);
+    const int64_t maxNewTxSize = CalculateMaximumSignedTxSize(CTransaction(mtx), wallet);
     if (maxNewTxSize < 0) {
         errors.push_back("Transaction contains inputs that cannot be signed");
         return Result::INVALID_ADDRESS_OR_KEY;
@@ -217,7 +229,6 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
 
     CAmount nDelta = new_fee - old_fee;
     assert(nDelta > 0);
-    mtx = CMutableTransaction{*wtx.tx};
 
     if (nOutput != -1) {
         // Reduce the existing TPC change output to cover the fee delta.
@@ -233,26 +244,23 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
             mtx.vout.erase(mtx.vout.begin() + nOutput);
         }
     } else {
-        // Add the new TPC input and create a change output for the surplus.
-        bool rbf = coin_control.m_signal_bip125_rbf.get_value_or(wallet->m_signal_rbf);
-        mtx.vin.push_back(CTxIn(newInputOp, CScript(), rbf ? MAX_BIP125_RBF_SEQUENCE : 0xfffffffe));
+        // Correct the placeholder change output (last output) with the actual surplus.
         if (newInputValue < nDelta) {
             errors.push_back("Cannot bump fee: new TPC input insufficient to cover fee delta");
             return Result::WALLET_ERROR;
         }
         CAmount changeValue = newInputValue - nDelta;
-        CScript changeScript = GetScriptForDestination(coin_control.destChange);
-        CTxOut  changeOut(changeValue, changeScript);
-        if (changeValue > GetDustThreshold(changeOut, GetDiscardRate(*wallet, ::feeEstimator))) {
-            mtx.vout.push_back(changeOut);
-        } else {
+        CTxOut& changeOut = mtx.vout.back();
+        changeOut.nValue = changeValue;
+        if (changeValue <= GetDustThreshold(changeOut, GetDiscardRate(*wallet, ::feeEstimator))) {
             wallet->WalletLogPrintf("Bumping fee: discarding dust change from new TPC input\n");
             new_fee += changeValue;
+            mtx.vout.pop_back();
         }
     }
 
     // Mark new tx not replaceable, if requested.
-    if (!coin_control.m_signal_bip125_rbf.get_value_or(wallet->m_signal_rbf)) {
+    if (!rbf) {
         for (auto& input : mtx.vin) {
             if (input.nSequence < 0xfffffffe) input.nSequence = 0xfffffffe;
         }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <coloridentifier.h>
 #include <consensus/validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>
@@ -93,8 +94,13 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
 
     // figure out which output was change
     // if there was no change output or multiple change outputs, fail
+    // Colored outputs are skipped: their nValue is a token amount, not satoshis,
+    // so subtracting a TPC fee delta from them silently destroys tokens.
     int nOutput = -1;
     for (size_t i = 0; i < wtx.tx->vout.size(); ++i) {
+        if (GetColorIdFromScript(wtx.tx->vout[i].scriptPubKey).type != TokenTypes::NONE) {
+            continue;  // never adjust a colored output to cover a fee delta
+        }
         if (wallet->IsChange(wtx.tx->vout[i])) {
             if (nOutput != -1) {
                 errors.push_back("Transaction has multiple change outputs");
@@ -104,7 +110,7 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
         }
     }
     if (nOutput == -1) {
-        errors.push_back("Transaction does not have a change output");
+        errors.push_back("Cannot bump fee: transaction has no TPC change output to absorb the fee delta");
         return Result::WALLET_ERROR;
     }
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -652,6 +652,18 @@ UniValue importwallet(const JSONRPCRequest& request)
                    pwallet->m_script_metadata[id].nCreateTime = birth_time;
                    nTimeBegin = std::min(nTimeBegin, birth_time);
                }
+            } else {
+               CTxDestination dest = DecodeDestination(vstr[0]);
+               if (std::holds_alternative<CColorKeyID>(dest) || std::holds_alternative<CColorScriptID>(dest)) {
+                   std::string strLabel;
+                   for (unsigned int nStr = 1; nStr < vstr.size(); nStr++) {
+                       if (vstr[nStr].front() == '#')
+                           break;
+                       if (vstr[nStr].substr(0, 6) == "label=")
+                           strLabel = DecodeDumpString(vstr[nStr].substr(6));
+                   }
+                   pwallet->SetAddressBook(dest, strLabel, "receive");
+               }
             }
         }
         file.close();
@@ -830,6 +842,13 @@ UniValue dumpwallet(const JSONRPCRequest& request)
         if(pwallet->GetCScript(scriptid, script)) {
             file << strprintf("%s %s script=1", HexStr(script.begin(), script.end()), create_time);
             file << strprintf(" # addr=%s\n", address);
+        }
+    }
+    for (const auto& entry : pwallet->mapAddressBook) {
+        if (std::holds_alternative<CColorKeyID>(entry.first) || std::holds_alternative<CColorScriptID>(entry.first)) {
+            file << strprintf("%s label=%s\n",
+                EncodeDestination(entry.first),
+                EncodeDumpString(entry.second.name));
         }
     }
     file << "\n";

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3295,6 +3295,9 @@ static UniValue bumpfee(const JSONRPCRequest& request)
     // covered the fee exactly), feebumper needs to add a fresh TPC input.
     // Signal this with fAllowOtherInputs and supply a change destination so
     // feebumper can route the surplus back to the wallet.
+    // reservekey lives here so its RAII destructor returns the key to the pool
+    // on any feebumper failure path (KeepKey is deferred until success).
+    CReserveKey bumpfeeReserveKey(pwallet);
     {
         const CWalletTx* wtx = pwallet->GetWalletTx(hash);
         if (wtx) {
@@ -3308,11 +3311,10 @@ static UniValue bumpfee(const JSONRPCRequest& request)
             }
             if (hasColoredOutput && !hasTpcChange) {
                 coin_control.fAllowOtherInputs = true;
-                CReserveKey reservekey(pwallet);
                 CPubKey pubkey;
-                if (reservekey.GetReservedKey(pubkey, true)) {
+                if (bumpfeeReserveKey.GetReservedKey(pubkey, true)) {
                     coin_control.destChange = pubkey.GetID();
-                    reservekey.KeepKey();
+                    // KeepKey() is called only after feebumper succeeds below.
                 }
             }
         }
@@ -3342,6 +3344,9 @@ static UniValue bumpfee(const JSONRPCRequest& request)
                 break;
         }
     }
+
+    // Feebumper succeeded — commit the reserved change key to the keypool.
+    bumpfeeReserveKey.KeepKey();
 
     // sign bumped transaction
     if (!feebumper::SignTransaction(pwallet, mtx)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2881,7 +2881,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
                 entry.pushKV("label", i->second.name);
             }
 
-            if (scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsColoredPayToScriptHash()) {
+            if (scriptPubKey.IsPayToScriptHash()) {
                 const CScriptID& hash = std::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwallet->GetCScript(hash, redeemScript)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -382,7 +382,7 @@ static CTransactionRef SendMoney(CWallet * const pwallet, const CTxDestination &
     vecSend.push_back(recipient);
     CTransactionRef tx;
     if (!pwallet->CreateTransaction(vecSend, tx, reservekey, nFeeRequired, mapChangePosRet, strError, coin_control)) {
-        if (!fSubtractFeeFromAmount && nValue + nFeeRequired > curBalance)
+        if (!fSubtractFeeFromAmount && colorId.type == TokenTypes::NONE && nValue + nFeeRequired > curBalance)
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s", FormatMoney(nFeeRequired));
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
@@ -489,7 +489,7 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
 
     if (colorId.type != TokenTypes::NONE)
     {
-        coin_control.m_colorTxType = ColoredTxType::TRANSFER; 
+        coin_control.m_colorTxType = ColoredTxType::TRANSFER;
         coin_control.m_colorId = colorId;
     }
 
@@ -3284,7 +3284,6 @@ static UniValue bumpfee(const JSONRPCRequest& request)
             }
         }
     }
-
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
     pwallet->BlockUntilSyncedToCurrentChain();
@@ -3292,6 +3291,32 @@ static UniValue bumpfee(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
     EnsureWalletIsUnlocked(pwallet);
 
+    // For colored token transfers that have no TPC change output (e.g. when BnB
+    // covered the fee exactly), feebumper needs to add a fresh TPC input.
+    // Signal this with fAllowOtherInputs and supply a change destination so
+    // feebumper can route the surplus back to the wallet.
+    {
+        const CWalletTx* wtx = pwallet->GetWalletTx(hash);
+        if (wtx) {
+            bool hasColoredOutput = false;
+            bool hasTpcChange = false;
+            for (const auto& out : wtx->tx->vout) {
+                if (GetColorIdFromScript(out.scriptPubKey).type != TokenTypes::NONE)
+                    hasColoredOutput = true;
+                else if (pwallet->IsChange(out))
+                    hasTpcChange = true;
+            }
+            if (hasColoredOutput && !hasTpcChange) {
+                coin_control.fAllowOtherInputs = true;
+                CReserveKey reservekey(pwallet);
+                CPubKey pubkey;
+                if (reservekey.GetReservedKey(pubkey, true)) {
+                    coin_control.destChange = pubkey.GetID();
+                    reservekey.KeepKey();
+                }
+            }
+        }
+    }
 
     std::vector<std::string> errors;
     CAmount old_fee;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3181,7 +3181,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
     }
 
     SignatureScheme sigScheme(SignatureScheme::ECDSA);
-    if(!request.params[4].isNull() && request.params[3].get_str() == "SCHNORR")
+    if(!request.params[3].isNull() && request.params[3].get_str() == "SCHNORR")
         sigScheme = SignatureScheme::SCHNORR;
 
     // Sign the transaction

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2881,7 +2881,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
                 entry.pushKV("label", i->second.name);
             }
 
-            if (scriptPubKey.IsPayToScriptHash()) {
+            if (scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsColoredPayToScriptHash()) {
                 const CScriptID& hash = std::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwallet->GetCScript(hash, redeemScript)) {

--- a/src/wallet/test/create_transaction_tests.cpp
+++ b/src/wallet/test/create_transaction_tests.cpp
@@ -235,5 +235,44 @@ BOOST_FIXTURE_TEST_CASE(test_creating_colored_transaction, TestWalletSetup)
     BOOST_CHECK_EQUAL(wallet->GetBalance()[cid], 1);
 }
 
+// Regression test:
+// IsColoredOutPointWith must guard against an out-of-range vout index without crashing.
+BOOST_FIXTURE_TEST_CASE(IsColoredOutPointWith_bounds_check, TestWalletSetup)
+{
+    ImportCoin(10 * COIN);
+    ColorIdentifier cid;
+    BOOST_REQUIRE(IssueNonReissunableColoredCoin(100 * CENT, cid));
+
+    // Locate the issuance tx in the wallet so we have a real hash and size.
+    uint256 issueTxHash;
+    uint32_t issueTxVoutSize = 0;
+    {
+        LOCK(wallet->cs_wallet);
+        for (const auto& entry : wallet->mapWallet) {
+            for (const auto& out : entry.second.tx->vout) {
+                if (GetColorIdFromScript(out.scriptPubKey) == cid) {
+                    issueTxHash     = entry.second.tx->GetHashMalFix();
+                    issueTxVoutSize = (uint32_t)entry.second.tx->vout.size();
+                    break;
+                }
+            }
+            if (!issueTxHash.IsNull()) break;
+        }
+    }
+    BOOST_REQUIRE(!issueTxHash.IsNull());
+
+    // Unknown txid: wallet lookup returns null → must return false, not crash.
+    COutPoint unknownTx(
+        uint256S("deadbeef00000000000000000000000000000000000000000000000000000000"), 0);
+    BOOST_CHECK(!wallet->IsColoredOutPointWith(unknownTx, cid));
+
+    // Valid txid, n == vout.size(): exactly at the boundary → must return false.
+    COutPoint atBoundary(issueTxHash, issueTxVoutSize);
+    BOOST_CHECK(!wallet->IsColoredOutPointWith(atBoundary, cid));
+
+    // Valid txid, n well beyond vout.size(): same guard covers larger offsets.
+    COutPoint pastBoundary(issueTxHash, issueTxVoutSize + 100);
+    BOOST_CHECK(!wallet->IsColoredOutPointWith(pastBoundary, cid));
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2485,14 +2485,13 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
         std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(outpoint.hashMalFix);
         if (it != mapWallet.end())
         {
-            if (!IsColoredOutPointWith(outpoint, colorId)) {
-                continue;
-            }
-
             const CWalletTx* pcoin = &it->second;
             // Clearly invalid input, fail
             if (pcoin->tx->vout.size() <= outpoint.n)
                 return false;
+            if (!IsColoredOutPointWith(outpoint, colorId)) {
+                continue;
+            }
             // Just to calculate the marginal byte size
             nValueFromPresetInputs += pcoin->tx->vout[outpoint.n].nValue;
             setPresetCoins.insert(CInputCoin(pcoin->tx, outpoint.n));
@@ -2603,10 +2602,16 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, ChangeP
         tx.vout.push_back(tx_new->vout[idx]);
     }
 
-    if (mapChangePosInOut[ColorIdentifier()] != -1) {
-        // We don't have the normal Create/Commit cycle, and don't want to risk
-        // reusing change, so just remove the key from the keypool here.
-        reservekey.KeepKey();
+    // scriptChange (derived from the reservekey address) is used for both TPC
+    // and colored change outputs.  Keep the key whenever any change was added,
+    // not just when TPC change was added; otherwise the key returns to the pool
+    // and a subsequent getnewaddress reuses the address that colored change
+    // UTXOs are already sitting on.
+    for (const auto& p : mapChangePosInOut) {
+        if (p.second != -1) {
+            reservekey.KeepKey();
+            break;
+        }
     }
 
     // Add new txins while keeping original txin scriptSig/order.
@@ -3735,6 +3740,7 @@ void CWallet::DeleteLabel(const std::string& label)
 bool CWallet::IsColoredOutPointWith(const COutPoint& outpoint, const ColorIdentifier& colorId) const
 {
     const CWalletTx* wtx = GetWalletTx(outpoint.hashMalFix);
+    if (!wtx || outpoint.n >= wtx->tx->vout.size()) return false;
     return GetColorIdFromScript(wtx->tx->vout[outpoint.n].scriptPubKey) == colorId;
 }
 

--- a/src/xfieldhistory.cpp
+++ b/src/xfieldhistory.cpp
@@ -91,9 +91,9 @@ int32_t CXFieldHistoryMap::GetReorgHeight()
     return *std::max_element(changeHeights.begin(), changeHeights.end());
 }
 
-bool IsXFieldNew(const CXField& xfield, CXFieldHistoryMap* pxfieldHistory)
+bool IsXFieldNew(const CXField& xfield, CXFieldHistoryMap* pxfieldHistory, uint32_t parentHeight)
 {
-    IsXFieldLastInHistoryVisitor checkVisitor(pxfieldHistory);
+    IsXFieldLastInHistoryVisitor checkVisitor(pxfieldHistory, parentHeight);
     return xfield.IsValid()
           && std::find(XFIELDTYPES_INIT_LIST.begin(), XFIELDTYPES_INIT_LIST.end(), xfield.xfieldType) != XFIELDTYPES_INIT_LIST.end()
           && !std::visit(checkVisitor, xfield.xfieldValue);

--- a/src/xfieldhistory.h
+++ b/src/xfieldhistory.h
@@ -224,20 +224,22 @@ public:
 class IsXFieldLastInHistoryVisitor
 {
     CXFieldHistoryMap* history;
+    uint32_t parentHeight;
 public:
-    IsXFieldLastInHistoryVisitor(CXFieldHistoryMap* historyIn):history(historyIn) {}
+    IsXFieldLastInHistoryVisitor(CXFieldHistoryMap* historyIn, uint32_t height)
+        : history(historyIn), parentHeight(height) {}
 
     template <typename T>
     bool operator()(const T &xField) const {
         assert(history);
         TAPYRUS_XFIELDTYPES X = GetXFieldTypeFrom(xField);
-        XFieldChangeList list = history->GetListCopy(X);
-        return std::get<T>(list.back().xfieldValue).operator==(T(xField));
+        XFieldChange entry = history->Get(X, parentHeight);
+        return std::get<T>(entry.xfieldValue) == T(xField);
     }
 
 };
 
-bool IsXFieldNew(const CXField& xfield, CXFieldHistoryMap* pxfieldHistory);
+bool IsXFieldNew(const CXField& xfield, CXFieldHistoryMap* pxfieldHistory, uint32_t parentHeight);
 
 /** 
  * The maximum block size according the current xfield history */

--- a/test/functional/feature_federation_management.py
+++ b/test/functional/feature_federation_management.py
@@ -703,9 +703,6 @@ class FederationManagementTest(BitcoinTestFramework):
         tip56 = self.tip  # B56, height=56, active key=aggpubkeys[5]
 
         # B57_rot: rotation to aggpubkeys[6], signed by the current active key aggprivkey[5].
-        # XFieldChange stores (aggpubkeys[6], height_applicable=58) — the new key is first
-        # required for the block AT height 58.  B57_rot itself (at height 57) is still
-        # verified with Get(AGGPUBKEY, 57) = aggpubkeys[5].
         block_time += 10
         b57_rot = create_block(int(tip56, 16), create_coinbase(57), block_time, self.aggpubkeys[6])
         b57_rot.solve(self.aggprivkey[5])

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -503,16 +503,18 @@ class MempoolLimitTest(BitcoinTestFramework):
         txid = node.sendrawtransaction(txFS['hex'] ,True)
         assert(txid in node.getrawmempool())
 
-        # fill the mempool with large transactions
-        self.fill_mempool(node, utxos, relayfee)
+        # fill the mempool with large transactions at 2x relayfee so txid (at 1x)
+        # is the cheapest transaction and is evicted first when the pool overflows.
+        fill_feerate = relayfee * 2
+        self.fill_mempool(node, utxos, fill_feerate)
         assert(txid in node.getrawmempool())
 
         mempoolinfo = node.getmempoolinfo()
         size_needed = mempoolinfo['maxmempool'] - mempoolinfo['usage'] - tx_size(tx_o)
 
         # send one last transaction that will fill the rest of the mempool
-        utxo = [utxo for utxo in node.listunspent()if utxo['amount'] >  relayfee * 10000][0]
-        tx = self.create_tx_with_large_script(utxo, relayfee, size_needed)
+        utxo = [utxo for utxo in node.listunspent()if utxo['amount'] >  fill_feerate * 10000][0]
+        tx = self.create_tx_with_large_script(utxo, fill_feerate, size_needed)
         signresult = node.signrawtransactionwithwallet(ToHex(tx))
         node.sendrawtransaction(signresult["hex"], True)
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -74,6 +74,7 @@ class BumpFeeTest(BitcoinTestFramework):
         test_unconfirmed_not_spendable(rbf_node, rbf_node_address, self.signblockprivkey, self.signblockprivkey_wif)
         test_bumpfee_metadata(rbf_node, dest_address)
         test_bumpfee_preserves_colored_token_balance(rbf_node, peer_node, self.signblockprivkey_wif)
+        test_bumpfee_no_tpc_change(rbf_node, peer_node, self.signblockprivkey_wif)
         test_locked_wallet_fails(rbf_node, dest_address)
         self.log.info("Success")
 
@@ -280,6 +281,74 @@ def test_bumpfee_preserves_colored_token_balance(rbf_node, peer_node, signblockp
     sync_mempools((rbf_node, peer_node))
 
     # Token balance must still be 100 (60 sent-to-self + 40 change).
+    assert_equal(rbf_node.getwalletinfo()['balance'][color], 100)
+
+
+def test_bumpfee_no_tpc_change(rbf_node, peer_node, signblockprivkey_wif):
+    """Regression for H3: bumpfee on a colored transfer that has no TPC change output
+    must add a new TPC input via the fAllowOtherInputs fallback path."""
+    rbf_node.generate(1, signblockprivkey_wif)
+    sync_mempools((rbf_node, peer_node))
+
+    # Issue 100 tokens.
+    seed_utxo = next(u for u in rbf_node.listunspent() if u.get('token') == 'TPC')
+    issue_result = rbf_node.issuetoken(2, 100, seed_utxo['txid'], seed_utxo['vout'])
+    color = issue_result['color']
+    sync_mempools((rbf_node, peer_node))
+    peer_node.generate(1, signblockprivkey_wif)
+    sync_mempools((rbf_node, peer_node))
+
+    # Create a small TPC UTXO that will be consumed entirely as fee in the colored transfer.
+    small_tpc_addr = rbf_node.getnewaddress()
+    small_tpc_txid = rbf_node.sendtoaddress(small_tpc_addr, Decimal("0.00005"))
+    sync_mempools((rbf_node, peer_node))  # ensure peer_node sees the tx before mining
+    peer_node.generate(1, signblockprivkey_wif)
+    sync_mempools((rbf_node, peer_node))
+
+    # Locate the two UTXOs to spend.
+    token_utxo = next(u for u in rbf_node.listunspent() if u.get('token') == color)
+    # Use getrawtransaction to find the vout index for the small TPC output by address.
+    raw_small = rbf_node.getrawtransaction(small_tpc_txid, True)
+    small_tpc_vout_idx = next(
+        v['n'] for v in raw_small['vout']
+        if small_tpc_addr in v.get('scriptPubKey', {}).get('addresses', [])
+    )
+    small_tpc_utxo = {'txid': small_tpc_txid, 'vout': small_tpc_vout_idx}
+
+    # Build a colored transfer with no TPC change output: fee = entire small TPC input.
+    colored_addr = rbf_node.getnewaddress("", color)
+    rawtx = rbf_node.createrawtransaction(
+        inputs=[
+            {'txid': token_utxo['txid'], 'vout': token_utxo['vout'],
+             'sequence': BIP125_SEQUENCE_NUMBER},
+            {'txid': small_tpc_utxo['txid'], 'vout': small_tpc_utxo['vout'],
+             'sequence': BIP125_SEQUENCE_NUMBER},
+        ],
+        outputs=[{colored_addr: 100}],
+    )
+    signed = rbf_node.signrawtransactionwithwallet(rawtx, [], "ALL", SCHEME)
+    assert signed['complete'], "Failed to sign colored transfer with no TPC change"
+    orig_txid = rbf_node.sendrawtransaction(signed['hex'])
+    assert orig_txid in rbf_node.getrawmempool()
+
+    sync_mempools((rbf_node, peer_node))
+
+    # Capture original vin count before bumpfee replaces the tx in the mempool.
+    orig_decoded = rbf_node.getrawtransaction(orig_txid, True)
+    orig_vin_count = len(orig_decoded['vin'])
+
+    # bumpfee must succeed by adding a new TPC input (fAllowOtherInputs fallback).
+    bumped = rbf_node.bumpfee(orig_txid)
+    assert_equal(bumped['errors'], [])
+
+    bumped_decoded = rbf_node.getrawtransaction(bumped['txid'], True)
+    assert_greater_than(len(bumped_decoded['vin']), orig_vin_count)
+
+    # Mine and verify token balance is fully preserved.
+    sync_mempools((rbf_node, peer_node))
+    peer_node.generate(1, signblockprivkey_wif)
+    sync_mempools((rbf_node, peer_node))
+
     assert_equal(rbf_node.getwalletinfo()['balance'][color], 100)
 
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -73,6 +73,7 @@ class BumpFeeTest(BitcoinTestFramework):
         test_rebumping_not_replaceable(rbf_node, dest_address)
         test_unconfirmed_not_spendable(rbf_node, rbf_node_address, self.signblockprivkey, self.signblockprivkey_wif)
         test_bumpfee_metadata(rbf_node, dest_address)
+        test_bumpfee_preserves_colored_token_balance(rbf_node, peer_node, self.signblockprivkey_wif)
         test_locked_wallet_fails(rbf_node, dest_address)
         self.log.info("Success")
 
@@ -241,6 +242,45 @@ def test_locked_wallet_fails(rbf_node, dest_address):
     rbf_node.walletlock()
     assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first.",
                           rbf_node.bumpfee, rbfid)
+
+
+def test_bumpfee_preserves_colored_token_balance(rbf_node, peer_node, signblockprivkey_wif):
+    """Regression for J2: bumpfee on a colored-token transfer must not silently
+    subtract the fee delta from a colored output."""
+    # Mine any leftover mempool txns from preceding tests.
+    rbf_node.generate(1, signblockprivkey_wif)
+    sync_mempools((rbf_node, peer_node))
+
+    # Issue 100 NON_REISSUABLE tokens using a wallet TPC UTXO as the colorId seed.
+    seed_utxo = next(u for u in rbf_node.listunspent() if u.get('token') == 'TPC')
+    issue_result = rbf_node.issuetoken(2, 100, seed_utxo['txid'], seed_utxo['vout'])
+    color = issue_result['color']
+
+    # Propagate issuance to peer_node first, then mine it.
+    sync_mempools((rbf_node, peer_node))
+    peer_node.generate(1, signblockprivkey_wif)
+    sync_mempools((rbf_node, peer_node))
+
+    balance_before = rbf_node.getwalletinfo()['balance'][color]
+    assert_equal(balance_before, 100)
+
+    # Transfer 60 tokens to self (walletrbf=1 -> BIP125 replaceable).
+    dest_addr = rbf_node.getnewaddress("", color)
+    transfer_txid = rbf_node.transfertoken(dest_addr, 60)
+    assert_equal(rbf_node.gettransaction(transfer_txid)['bip125-replaceable'], 'yes')
+
+    # Propagate transfer to peer_node before bumping fee.
+    sync_mempools((rbf_node, peer_node))
+
+    # Bump the fee — only the TPC change output may shrink; colored outputs must be untouched.
+    rbf_node.bumpfee(transfer_txid)
+
+    sync_mempools((rbf_node, peer_node))
+    peer_node.generate(1, signblockprivkey_wif)
+    sync_mempools((rbf_node, peer_node))
+
+    # Token balance must still be 100 (60 sent-to-self + 40 change).
+    assert_equal(rbf_node.getwalletinfo()['balance'][color], 100)
 
 
 def spend_one_input(node, dest_address):

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -253,7 +253,7 @@ def test_bumpfee_preserves_colored_token_balance(rbf_node, peer_node, signblockp
     sync_mempools((rbf_node, peer_node))
 
     # Issue 100 NON_REISSUABLE tokens using a wallet TPC UTXO as the colorId seed.
-    seed_utxo = next(u for u in rbf_node.listunspent() if u.get('token') == 'TPC')
+    seed_utxo = max((u for u in rbf_node.listunspent() if u.get('token') == 'TPC'), key=lambda u: u['amount'])
     issue_result = rbf_node.issuetoken(2, 100, seed_utxo['txid'], seed_utxo['vout'])
     color = issue_result['color']
 
@@ -291,7 +291,7 @@ def test_bumpfee_no_tpc_change(rbf_node, peer_node, signblockprivkey_wif):
     sync_mempools((rbf_node, peer_node))
 
     # Issue 100 tokens.
-    seed_utxo = next(u for u in rbf_node.listunspent() if u.get('token') == 'TPC')
+    seed_utxo = max((u for u in rbf_node.listunspent() if u.get('token') == 'TPC'), key=lambda u: u['amount'])
     issue_result = rbf_node.issuetoken(2, 100, seed_utxo['txid'], seed_utxo['vout'])
     color = issue_result['color']
     sync_mempools((rbf_node, peer_node))

--- a/test/functional/wallet_coloredcoin.py
+++ b/test/functional/wallet_coloredcoin.py
@@ -22,6 +22,7 @@
 
     """
 from codecs import encode
+import json
 import math
 import time
 
@@ -656,6 +657,16 @@ class WalletColoredCoinTest(BitcoinTestFramework):
             assert_raises_rpc_error(-8, "Invalid vout 10 in tx: "+ node2_utxos[1]['txid'], self.nodes[2].issuetoken, 2, 100, node2_utxos[1]['txid'], 10)
             assert_raises_rpc_error(-8, str("Invalid vout 0 in tx: %s" % res1['txids'][1]), self.nodes[2].issuetoken, 2, 100, res1['txids'][1], 0)
 
+    def test_sendmany_rejects_colored_address(self):
+        """sendmany must reject colored-coin destinations (use transfertoken instead)."""
+        self.log.info("Testing sendmany rejects colored addresses")
+        colored_addr = self.nodes[0].getnewaddress("", self.colorids[1])
+        # CLI mode uses str() on positional args, producing Python dict repr (single-quoted)
+        # which tapyrus-cli cannot parse as JSON.  Pass a JSON string in CLI mode instead.
+        amounts = json.dumps({colored_addr: 1}) if self.options.usecli else {colored_addr: 1}
+        assert_raises_rpc_error(-5, "sendmany does not support colored addresses; use transfertoken instead",
+                                self.nodes[0].sendmany, amounts)
+
     def test_only_token_filter(self):
 
         self.log.info("Testing only_token filter in listunspent")
@@ -829,6 +840,7 @@ class WalletColoredCoinTest(BitcoinTestFramework):
         utxos = self.nodes[0].listunspent()
 
         self.test_getcolorRPC(utxos)
+        self.test_sendmany_rejects_colored_address()
         self.test_createrawtransaction(utxos)
         self.test_sendRPC('sendtoaddress')
         self.test_sendRPC('transfertoken')


### PR DESCRIPTION
Fix
J1: Out-of-bounds read in IsColoredOutPointWith triggered via fundrawtransaction / walletcreatefundedpsbt 

  IsColoredOutPointWith dereferences wtx->tx->vout[outpoint.n].scriptPubKey without checking either that GetWalletTx returned non-null or that outpoint.n < vout.size(). The bounds check inside SelectCoins (if (pcoin->tx->vout.size() <= outpoint.n) return false;) sits after the IsColoredOutPointWith call.

J2: bumpfee silently destroys colored tokens when bumping a token transfer 

  The change-detection loop in feebumper was inherited from upstream Bitcoin Core and assumes a single asset class. After colored-coin integration, IsChange correctly classifies a colored change output as "change", but the subsequent line 
  poutput->nValue -= nDelta;   // nDelta is a fee delta, in TPC satoshis
  is then executed against an output whose nValue field holds a token amount, not satoshis. The result is silent destruction of nDelta tokens.

I2 — CheckBlockHeader uses GetLatest() instead of Get(height) when pxfieldHistory is supplied

  When the temp-history branch is taken (pxfieldHistory != nullptr, the ProcessNewBlockHeaders path), the function fetches the aggregate pubkey via pxfieldHistory->GetLatest(...) rather than Get(AGGPUBKEY, nHeight). The non-temp branch on line 1339 uses Get(nHeight) — so the same header has different validity depending on which path validates it. 
  Concrete consequence: after a confirmed AGGPUBKEY rotation at active-chain height M+1 (history contains {K0, K1@M+1}), a legitimate fork header at height N ≤ M (which must be signed under K0) is checked against GetLatest() = K1, fails verification, and is rejected as bad-proof. Legitimate alternate chains (e.g., emergency rotation, federation split recovery) cannot be learned by this node over the wire, even though they would validate correctly during reindex (which uses the non-temp path). 

additional warnings fixed:
  -IsXFieldNew predicate (xfieldhistory.cpp:91-97) only compares against the last entry
  - mapRelay growth bound is chain-progression dependent (net_processing.cpp:3765, 15-minute prune).                                  
  - signrawtransactionwithwallet SCHNORR selection bug (rpcwallet.cpp:3122)
  - FundTransaction colored-only-change leaks the change address back to the keypool (wallet.cpp:2603-2613)  
  - importwallet does not reconstruct colored address-book entries (rpcdump.cpp:538-665)


I1 is not applicable to tapyrus as we cannot mallet the transaction id(hashmalfix) by creating a new signature. So the follow up warning related to vExtraTxnForCompact is also not possible.

other warnings related to colored coin can be included in the PR for soft fork activation:

- walletcreatefundedpsbt returns only TPC change position (rpcwallet.cpp:4117)
 - CP2SH issuance keying (rpcwallet.cpp:4238-4243, 4296-4299)