### PR TITLE
Add CP2SH colored coin softfork manager and activation gating

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -549,6 +549,9 @@ jobs:
           else
             # Native builds: enable tests and benchmarks
             CMAKE_OPTS+=("-DENABLE_TESTS=ON" "-DENABLE_BENCH=ON")
+            # Inject the CP2SH softfork activation height for functional tests.
+            # Not included in cross-compiled (release) builds above.
+            CMAKE_OPTS+=("-DCP2SH_ACTIVATION_TEST_HEIGHT=120")
           fi
 
           # Use depends-generated CMake toolchain file

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -548,7 +548,7 @@ jobs:
             CMAKE_OPTS+=("-DENABLE_TESTS=OFF" "-DENABLE_BENCH=OFF" "-DBUILD_UTILS=ON")
           else
             # Native builds: enable tests and benchmarks
-            CMAKE_OPTS+=("-DENABLE_TESTS=ON" "-DENABLE_BENCH=ON")
+            CMAKE_OPTS+=("-DENABLE_TESTS=ON" "-DENABLE_BENCH=ON" "-DCP2SH_ACTIVATION_TEST_HEIGHT=120")
           fi
 
           # Use depends-generated CMake toolchain file

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -549,9 +549,6 @@ jobs:
           else
             # Native builds: enable tests and benchmarks
             CMAKE_OPTS+=("-DENABLE_TESTS=ON" "-DENABLE_BENCH=ON")
-            # Inject the CP2SH softfork activation height for functional tests.
-            # Not included in cross-compiled (release) builds above.
-            CMAKE_OPTS+=("-DCP2SH_ACTIVATION_TEST_HEIGHT=120")
           fi
 
           # Use depends-generated CMake toolchain file

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -200,7 +200,7 @@ jobs:
             CMAKE_OPTS+=("-DENABLE_TESTS=OFF")  # Skip tests for cross-compilation
           else
             # Native builds (Linux/macOS)
-            CMAKE_OPTS+=("-DENABLE_TESTS=ON")
+            CMAKE_OPTS+=("-DENABLE_TESTS=ON" "-DCP2SH_ACTIVATION_TEST_HEIGHT=120")
 
             # Disable BDB version warning for macOS if using newer version
             if [ "${{ matrix.config.platform }}" == "macos" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,15 +551,12 @@ target_compile_definitions(core_interface INTERFACE ${DEPENDS_COMPILE_DEFINITION
 target_compile_definitions(core_interface_relwithdebinfo INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_RELWITHDEBINFO})
 target_compile_definitions(core_interface_debug INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_DEBUG})
 
-# Set the CP2SH colored softfork activation height for test builds so that
-# functional tests can exercise the pre/post-activation transition without
-# mining hundreds of thousands of blocks.  Defaults to 120 whenever tests are
-# enabled (native builds on all platforms).  Can be overridden via
-# -DCP2SH_ACTIVATION_TEST_HEIGHT=<n>.  Not set when ENABLE_TESTS is OFF (e.g.
-# cross-compiled release builds).
-if(ENABLE_TESTS AND NOT DEFINED CP2SH_ACTIVATION_TEST_HEIGHT)
-  set(CP2SH_ACTIVATION_TEST_HEIGHT 120)
-endif()
+# CI-only: override the CP2SH colored softfork activation height so functional
+# tests can exercise the pre/post-activation transition without mining hundreds
+# of thousands of blocks.  Must be passed explicitly (e.g. by CI via
+# -DCP2SH_ACTIVATION_TEST_HEIGHT=120).  Never set automatically — doing so
+# would activate the softfork at block 120 on all networks including testnet,
+# breaking IBD of any historical chain that has CP2SH colored outputs.
 if(DEFINED CP2SH_ACTIVATION_TEST_HEIGHT)
   target_compile_definitions(core_interface INTERFACE
     CP2SH_ACTIVATION_TEST_HEIGHT=${CP2SH_ACTIVATION_TEST_HEIGHT}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,15 @@ target_compile_definitions(core_interface INTERFACE ${DEPENDS_COMPILE_DEFINITION
 target_compile_definitions(core_interface_relwithdebinfo INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_RELWITHDEBINFO})
 target_compile_definitions(core_interface_debug INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_DEBUG})
 
+# CI-only: override the CP2SH colored softfork activation height so functional
+# tests can exercise the pre/post-activation transition without mining hundreds
+# of thousands of blocks.  Not set in GUIX/release builds.
+if(DEFINED CP2SH_ACTIVATION_TEST_HEIGHT)
+  target_compile_definitions(core_interface INTERFACE
+    CP2SH_ACTIVATION_TEST_HEIGHT=${CP2SH_ACTIVATION_TEST_HEIGHT}
+  )
+endif()
+
 # If the {CXX,LD}FLAGS environment variables are defined during building depends
 # and configuring this build system, their content might be duplicated.
 if(DEFINED ENV{CXXFLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,9 +551,15 @@ target_compile_definitions(core_interface INTERFACE ${DEPENDS_COMPILE_DEFINITION
 target_compile_definitions(core_interface_relwithdebinfo INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_RELWITHDEBINFO})
 target_compile_definitions(core_interface_debug INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_DEBUG})
 
-# CI-only: override the CP2SH colored softfork activation height so functional
-# tests can exercise the pre/post-activation transition without mining hundreds
-# of thousands of blocks.  Not set in GUIX/release builds.
+# Set the CP2SH colored softfork activation height for test builds so that
+# functional tests can exercise the pre/post-activation transition without
+# mining hundreds of thousands of blocks.  Defaults to 120 whenever tests are
+# enabled (native builds on all platforms).  Can be overridden via
+# -DCP2SH_ACTIVATION_TEST_HEIGHT=<n>.  Not set when ENABLE_TESTS is OFF (e.g.
+# cross-compiled release builds).
+if(ENABLE_TESTS AND NOT DEFINED CP2SH_ACTIVATION_TEST_HEIGHT)
+  set(CP2SH_ACTIVATION_TEST_HEIGHT 120)
+endif()
 if(DEFINED CP2SH_ACTIVATION_TEST_HEIGHT)
   target_compile_definitions(core_interface INTERFACE
     CP2SH_ACTIVATION_TEST_HEIGHT=${CP2SH_ACTIVATION_TEST_HEIGHT}

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -303,7 +303,13 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                         continue;
                     COutPoint prevout = tx.vin[j].prevout;
                     if (ColorIdentifier(prevout, outColorId.type) == outColorId) {
-                        g_colorid_state->Erase(outColorId);
+                        // Skip global state writes when called from VerifyDB's dry-run
+                        // sandbox (level 3): chainActive is not actually disconnected, so
+                        // mutating g_colorid_state here would leave it permanently
+                        // inconsistent with the real chain tip.
+                        if (!fDryRun) {
+                            g_colorid_state->Erase(outColorId);
+                        }
                         break;
                     }
                 }

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -303,13 +303,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                         continue;
                     COutPoint prevout = tx.vin[j].prevout;
                     if (ColorIdentifier(prevout, outColorId.type) == outColorId) {
-                        // Skip global state writes when called from VerifyDB's dry-run
-                        // sandbox (level 3): chainActive is not actually disconnected, so
-                        // mutating g_colorid_state here would leave it permanently
-                        // inconsistent with the real chain tip.
-                        if (!fDryRun) {
-                            g_colorid_state->Erase(outColorId);
-                        }
+                        g_colorid_state->Erase(outColorId);
                         break;
                     }
                 }

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -661,20 +661,20 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         {
             std::vector<CScriptCheck> vChecks;
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
-            if (!CheckInputs(tx, state, view, fScriptChecks, SCRIPT_VERIFY_NONE, fCacheResults, fCacheResults, txdata[i], nScriptCheckThreads ? &vChecks : nullptr))
+            if (!CheckInputs(tx, state, view, fScriptChecks, GetBlockScriptFlags(pindex), fCacheResults, fCacheResults, txdata[i], nScriptCheckThreads ? &vChecks : nullptr))
                 return error("ConnectBlock(): CheckInputs on %s failed with %s",
                     tx.GetHashMalFix().ToString(), FormatStateMessage(state));
             control.Add(std::move(vChecks));
         }
 
         //if there are colored coins in the output verify their colorids
-        if(!CheckColorIdentifierValidity(tx, state, view))
+        if(!CheckColorIdentifierValidity(tx, state, view, pindex->nHeight))
             return false;
 
         //verify token balances (coinbase has no real inputs so balance check does not apply)
         if (!tx.IsCoinBase()) {
             std::set<ColorIdentifier> newIssuances;
-            if (!VerifyTokenBalances(tx, state, view, txfee, !fJustCheck ? &newIssuances : nullptr))
+            if (!VerifyTokenBalances(tx, state, view, txfee, !fJustCheck ? &newIssuances : nullptr, pindex->nHeight))
                 return false;
             allNewIssuances.insert(newIssuances.begin(), newIssuances.end());
         }

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -124,8 +124,7 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
     // blocks.  The override applies to whichever network the test node is running.
     //
     // Production builds register only the Chaintope testnet (1939510133) entry,
-    // deferring activation to block 693367 (last legacy CP2SH colored spend on
-    // testnet was at block 693366; all earlier CP2SH outputs predate this rule).
+    // deferring activation to TESTNET_CP2SH_ACTIVATION_HEIGHT
     // All other networks have no entry and therefore activate CP2SH at genesis
     // (CSoftForkManager::IsActive returns true when no entry is found).
 #ifdef CP2SH_ACTIVATION_TEST_HEIGHT
@@ -137,7 +136,7 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
     if (networkId == 1939510133u) {
         params->RegisterSoftFork(CSoftFork(
             networkId, SCRIPT_VERIFY_CP2SH_COLORED,
-            HeightActivation(693367)
+            HeightActivation(TESTNET_CP2SH_ACTIVATION_HEIGHT)
         ));
     }
 #endif

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -154,6 +154,11 @@ const CSoftForkManager& GetSoftForkManager()
     return FederationParams().SoftForkManager();
 }
 
+bool CSoftForkManager::IsActive(unsigned int flag, int32_t blockHeight) const
+{
+    return IsActive(FederationParams().NetworkId(), flag, blockHeight);
+}
+
 CFederationParams::CFederationParams(const uint32_t networkId, const std::string dataDirName, const std::string genesisHex) : nNetworkId(networkId), strNetworkID(std::to_string(networkId)), dataDir(dataDirName) {
 
     /**

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -15,6 +15,7 @@
 #include <tapyrusmodes.h>
 #include <validation.h>
 #include <xfieldhistory.h>
+#include <script/interpreter.h>
 
 #include <assert.h>
 #include <fstream>
@@ -114,12 +115,43 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
     const std::string dataDirName(GetDataDirNameFromNetworkId(networkId));
     const std::string genesisHex(withGenesis ? ReadGenesisBlock() : "");
 
-    return MakeUnique<CFederationParams>(networkId, dataDirName, genesisHex);
+    auto params = MakeUnique<CFederationParams>(networkId, dataDirName, genesisHex);
+
+    // CP2SH colored softfork registration:
+    //
+    // CI test builds define CP2SH_ACTIVATION_TEST_HEIGHT so the functional test
+    // can cross the activation boundary without mining hundreds of thousands of
+    // blocks.  The override applies to whichever network the test node is running.
+    //
+    // Production builds register only the Chaintope testnet (1939510133) entry,
+    // deferring activation to block 261594 (legacy colored outputs predate CP2SH).
+    // All other networks have no entry and therefore activate CP2SH at genesis
+    // (CSoftForkManager::IsActive returns true when no entry is found).
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    params->RegisterSoftFork(CSoftFork(
+        networkId, SCRIPT_VERIFY_CP2SH_COLORED,
+        HeightActivation(CP2SH_ACTIVATION_TEST_HEIGHT)
+    ));
+#else
+    if (networkId == 1939510133u) {
+        params->RegisterSoftFork(CSoftFork(
+            networkId, SCRIPT_VERIFY_CP2SH_COLORED,
+            HeightActivation(261594)
+        ));
+    }
+#endif
+
+    return params;
 }
 
 void SelectFederationParams(const TAPYRUS_OP_MODE mode, const bool withGenesis)
 {
     globalChainFederationParams = CreateFederationParams(mode, withGenesis);
+}
+
+const CSoftForkManager& GetSoftForkManager()
+{
+    return FederationParams().SoftForkManager();
 }
 
 CFederationParams::CFederationParams(const uint32_t networkId, const std::string dataDirName, const std::string genesisHex) : nNetworkId(networkId), strNetworkID(std::to_string(networkId)), dataDir(dataDirName) {

--- a/src/federationparams.cpp
+++ b/src/federationparams.cpp
@@ -124,7 +124,8 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
     // blocks.  The override applies to whichever network the test node is running.
     //
     // Production builds register only the Chaintope testnet (1939510133) entry,
-    // deferring activation to block 261594 (legacy colored outputs predate CP2SH).
+    // deferring activation to block 693367 (last legacy CP2SH colored spend on
+    // testnet was at block 693366; all earlier CP2SH outputs predate this rule).
     // All other networks have no entry and therefore activate CP2SH at genesis
     // (CSoftForkManager::IsActive returns true when no entry is found).
 #ifdef CP2SH_ACTIVATION_TEST_HEIGHT
@@ -136,7 +137,7 @@ std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE 
     if (networkId == 1939510133u) {
         params->RegisterSoftFork(CSoftFork(
             networkId, SCRIPT_VERIFY_CP2SH_COLORED,
-            HeightActivation(261594)
+            HeightActivation(693367)
         ));
     }
 #endif

--- a/src/federationparams.h
+++ b/src/federationparams.h
@@ -19,6 +19,11 @@
 
 const std::string TAPYRUS_GENESIS_FILENAME = "genesis.dat";
 
+// Activation height for SCRIPT_VERIFY_CP2SH_COLORED on Chaintope testnet
+// (networkId 1939510133). The last legacy CP2SH colored spend on testnet was
+// at block 693366
+static constexpr int TESTNET_CP2SH_ACTIVATION_HEIGHT = 693367;
+
 struct SeedSpec6 {
     uint8_t addr[16];
     uint16_t port;

--- a/src/federationparams.h
+++ b/src/federationparams.h
@@ -14,6 +14,7 @@
 #include <streams.h>
 #include <pubkey.h>
 #include <primitives/block.h>
+#include <softforkmanager.h>
 #include <util.h>
 
 const std::string TAPYRUS_GENESIS_FILENAME = "genesis.dat";
@@ -32,6 +33,7 @@ class CFederationParams
 {
 public:
     std::string NetworkIDString() const { return strNetworkID; }
+    uint32_t NetworkId() const { return nNetworkId; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
     bool ReadGenesisBlock(std::string genesisHex);
     const CBlock& GenesisBlock() const { return genesis; }
@@ -39,11 +41,20 @@ public:
     /** Return the list of hostnames to look up for DNS seeds */
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
 
+    /** Returns the softfork manager holding all registered softforks for this node's network. */
+    const CSoftForkManager& SoftForkManager() const { return m_softForkManager; }
+
     CFederationParams();
     CFederationParams(const uint32_t networkId, const std::string dataDirName, const std::string genesisHex);
 
+    /** Register a softfork; called once at startup from CreateFederationParams (PROD mode only). */
+    void RegisterSoftFork(CSoftFork sf) { m_softForkManager.Register(std::move(sf)); }
+
+    friend std::unique_ptr<CFederationParams> CreateFederationParams(const TAPYRUS_OP_MODE mode, const bool withGenesis);
+
 private:
     uint32_t nNetworkId;
+    CSoftForkManager m_softForkManager;
     CMessageHeader::MessageStartChars pchMessageStart;
     std::string strNetworkID;
     std::string dataDir;

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -585,12 +585,12 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
         return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
     }
 
+    // Use nHeight from the trusted block index (pindex->nHeight) when available.
+    // When nHeight == -1 (caller has no index context), fall back to UINT32_MAX so
+    // Get() returns the latest aggregate key — the safe conservative choice.
+    // Never use block.GetHeight() (coinbase prevout.n): that field is attacker-controlled.
     CValidationState state;
-    // Use -1 (→ UINT32_MAX) as the height sentinel so CheckBlockHeader selects
-    // the latest aggregate public key.  block.GetHeight() reads coinbase prevout.n
-    // which is attacker-controllable; passing it here would allow block data on
-    // disk to influence which signing key is used for verification (PR #411 footgun).
-    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, -1, true))
+    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, nHeight, true))
         return error("%s: ReadBlockFromDisk: %s", __func__, FormatStateMessage(state));
 
     return true;

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -585,12 +585,12 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
         return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
     }
 
-    // Use nHeight from the trusted block index (pindex->nHeight) when available.
-    // When nHeight == -1 (caller has no index context), fall back to UINT32_MAX so
-    // Get() returns the latest aggregate key — the safe conservative choice.
-    // Never use block.GetHeight() (coinbase prevout.n): that field is attacker-controlled.
     CValidationState state;
-    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, nHeight, true))
+    // Use -1 (→ UINT32_MAX) as the height sentinel so CheckBlockHeader selects
+    // the latest aggregate public key.  block.GetHeight() reads coinbase prevout.n
+    // which is attacker-controllable; passing it here would allow block data on
+    // disk to influence which signing key is used for verification (PR #411 footgun).
+    if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, -1, true))
         return error("%s: ReadBlockFromDisk: %s", __func__, FormatStateMessage(state));
 
     return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1389,8 +1389,15 @@ void static ProcessGetData(CNode* pfrom, CConnman* connman, const std::atomic<bo
                 auto txinfo = mempool.info(txin.prevout.hashMalFix);
                 if (txinfo.tx && txinfo.nTime > (now - UNCONDITIONAL_RELAY_DELAY).count()) {
                     // Relaying a transaction with a recent but unconfirmed parent.
-                    LOCK(pfrom->cs_inventory);
-                    if (!pfrom->filterInventoryKnown.contains(txin.prevout.hashMalFix)) {
+                    // Check filterInventoryKnown under cs_inventory, then release it before
+                    // acquiring cs_main to avoid cs_inventory→cs_main / cs_main→cs_inventory
+                    // lock-order inversion with SendMessages (which takes cs_main then cs_inventory).
+                    bool needsAnnounce;
+                    {
+                        LOCK(pfrom->cs_inventory);
+                        needsAnnounce = !pfrom->filterInventoryKnown.contains(txin.prevout.hashMalFix);
+                    }
+                    if (needsAnnounce) {
                         LOCK(cs_main);
                         State(pfrom->GetId())->m_recently_announced_invs.insert(txin.prevout.hashMalFix);
                     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -26,6 +26,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/standard.h>
+#include <softforkmanager.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <utilstrencodings.h>
@@ -717,6 +718,13 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
         view.SetBackend(viewDummy); // switch back to avoid locking mempool for too long
     }
 
+    unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+    {
+        LOCK(cs_main);
+        if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1))
+            signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
+    }
+
     // Use CTransaction for the constant parts of the
     // transaction to avoid rehashing.
     const CTransaction txConst(mergedTx);
@@ -735,7 +743,7 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
                 sigdata.MergeSignatureData(DataFromTransaction(txv, i, coin.out));
             }
         }
-        ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(&mergedTx, i, coin.out.nValue, 1), coin.out.scriptPubKey, sigdata);
+        ProduceSignature(DUMMY_SIGNING_PROVIDER, MutableTransactionSignatureCreator(&mergedTx, i, coin.out.nValue, 1), coin.out.scriptPubKey, sigdata, signVerifyFlags);
 
         UpdateInput(txin, sigdata);
     }
@@ -829,6 +837,13 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
 
+    unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+    {
+        LOCK(cs_main);
+        if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1))
+            signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
+    }
+
     // Script verification errors
     UniValue vErrors(UniValue::VARR);
 
@@ -851,14 +866,14 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
         SignatureData sigdata = DataFromTransaction(mtx, i, coin.out);
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
         if (!fHashSingle || (i < mtx.vout.size())) {
-            ProduceSignature(*keystore, MutableTransactionSignatureCreator(&mtx, i, amount, nHashType, sigScheme), prevPubKey, sigdata);
+            ProduceSignature(*keystore, MutableTransactionSignatureCreator(&mtx, i, amount, nHashType, sigScheme), prevPubKey, sigdata, signVerifyFlags);
         }
 
         UpdateInput(txin, sigdata);
 
         ColorIdentifier tempColorId;
         ScriptError serror = SCRIPT_ERR_OK;
-        if (!VerifyScript(txin.scriptSig, prevPubKey, nullptr, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&txConst, i, amount), tempColorId, &serror)) {
+        if (!VerifyScript(txin.scriptSig, prevPubKey, nullptr, signVerifyFlags, TransactionSignatureChecker(&txConst, i, amount), tempColorId, &serror)) {
             if (serror == SCRIPT_ERR_INVALID_STACK_OPERATION) {
                 // Unable to sign input and verification failed (possible attempt to partially sign).
                 TxInErrorToJSON(txin, vErrors, "Unable to sign input, invalid stack size (possibly missing key)");

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1646,8 +1646,13 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         stack.resize(1);
     }
 
-    // Additional validation for spend-to-script-hash transactions:
-    if (scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsColoredPayToScriptHash())
+    // Additional validation for spend-to-script-hash transactions.
+    // For CP2SH colored outputs, redeem-script evaluation is gated on the
+    // SCRIPT_VERIFY_CP2SH_COLORED softfork flag.  Before the flag is set (pre-
+    // activation) only the OP_HASH160 equality check is enforced; after activation
+    // the redeemScript must also evaluate to true, just like plain P2SH.
+    if (scriptPubKey.IsPayToScriptHash() ||
+        (scriptPubKey.IsColoredPayToScriptHash() && GetSoftForkManager().IsEnabled(SCRIPT_VERIFY_CP2SH_COLORED, flags)))
     {
         // scriptSig must be literals-only or validation fails
         if (!scriptSig.IsPushOnly())

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -6,6 +6,7 @@
 
 #include <script/interpreter.h>
 
+#include <softforkmanager.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -89,6 +89,11 @@ enum
     // Making OP_CODESEPARATOR and FindAndDelete fail any non-segwit scripts
     //
     SCRIPT_VERIFY_CONST_SCRIPTCODE = (1U << 16),
+
+    // Require colored coin outputs to use CP2SH (OP_COLOR <colorid> OP_HASH160 <hash> OP_EQUAL)
+    // rather than bare CP2PKH.  Activated per-network via CSoftForkManager.
+    //
+    SCRIPT_VERIFY_CP2SH_COLORED = (1U << 17),
 };
 /**
  * Mandatory script verification flags that all blocks must comply with for

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -176,7 +176,7 @@ static CScript PushAll(const std::vector<valtype>& values)
     return result;
 }
 
-bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& fromPubKey, SignatureData& sigdata)
+bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& fromPubKey, SignatureData& sigdata, unsigned int scriptVerifyFlags)
 {
     if (sigdata.complete) return true;
 
@@ -186,24 +186,33 @@ bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreato
     bool P2SH = false;
     CScript subscript;
 
-    if (solved && (whichType == TX_SCRIPTHASH || whichType == TX_COLOR_SCRIPTHASH))
+    if (solved && whichType == TX_SCRIPTHASH)
     {
-        // Solver returns the subscript that needs to be evaluated;
-        // the final scriptSig is the signatures from that
-        // and then the serialized subscript:
+        // Plain P2SH: always evaluate the redeemScript.
         subscript = CScript(result[0].begin(), result[0].end());
         sigdata.redeem_script = subscript;
-        solved = solved && SignStep(provider, creator, subscript, result, whichType, SigVersion::BASE, sigdata) && whichType != TX_SCRIPTHASH && whichType != TX_COLOR_SCRIPTHASH;
+        solved = solved && SignStep(provider, creator, subscript, result, whichType, SigVersion::BASE, sigdata) && whichType != TX_SCRIPTHASH;
         P2SH = true;
+    }
+    else if (solved && whichType == TX_COLOR_SCRIPTHASH)
+    {
+        subscript = CScript(result[0].begin(), result[0].end());
+        sigdata.redeem_script = subscript;
+        if (scriptVerifyFlags & SCRIPT_VERIFY_CP2SH_COLORED) {
+            // Post-activation: redeemScript must evaluate to true
+            solved = solved && SignStep(provider, creator, subscript, result, whichType, SigVersion::BASE, sigdata) && whichType != TX_COLOR_SCRIPTHASH;
+            P2SH = true;  // will append serialized redeemScript after sig+pubkey
+        }
     }
     if (P2SH) {
         result.push_back(std::vector<unsigned char>(subscript.begin(), subscript.end()));
     }
     sigdata.scriptSig = PushAll(result);
 
-    // Test solution
+    // Test solution using the caller-supplied flags so that post-activation
+    // signings are verified with SCRIPT_VERIFY_CP2SH_COLORED included.
     ColorIdentifier colorId;
-    sigdata.complete = solved && VerifyScript(sigdata.scriptSig, fromPubKey, nullptr, STANDARD_SCRIPT_VERIFY_FLAGS, creator.Checker(), colorId, nullptr);
+    sigdata.complete = solved && VerifyScript(sigdata.scriptSig, fromPubKey, nullptr, scriptVerifyFlags, creator.Checker(), colorId, nullptr);
     return sigdata.complete;
 }
 

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -612,8 +612,10 @@ struct PartiallySignedTransaction
     }
 };
 
-/** Produce a script signature using a generic signature creator. */
-bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& scriptPubKey, SignatureData& sigdata);
+/** Produce a script signature using a generic signature creator.
+ *  scriptVerifyFlags controls the self-verification at the end; callers that
+ *  sign real transactions should pass flags appropriate for the next block. */
+bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& scriptPubKey, SignatureData& sigdata, unsigned int scriptVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS);
 
 /** Produce a script signature for a transaction. */
 bool SignSignature(const SigningProvider &provider, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, const CAmount& amount, int nHashType);

--- a/src/softforkmanager.h
+++ b/src/softforkmanager.h
@@ -38,9 +38,6 @@ struct CSoftFork {
     CSoftFork(uint32_t netId, unsigned int flag, HeightActivation activation)
         : networkId(netId), scriptVerifyFlag(flag),
           activationHeight(activation.activationHeight), isActive(std::move(activation)) {}
-
-    /** True when the compiled script flags indicate this fork is enforced. */
-    bool IsEnforced(unsigned int scriptFlags) const { return (scriptFlags & scriptVerifyFlag) != 0; }
 };
 
 /**
@@ -96,22 +93,21 @@ public:
     }
 
     /**
-     * For use by the script interpreter: returns whether the softfork for
-     * the given flag is enforced given the compiled script flags passed to
-     * VerifyScript.
-     *
-     * When no entry is registered the flag is considered active from genesis
-     * and the check degenerates to (scriptFlags & flag).  For registered
-     * networks the result comes from the stored HeightActivation predicate
-     * via CSoftFork::IsEnforced, which checks the same bit — the bit having
-     * been set (or not) by GetBlockScriptFlags() earlier in the call chain.
+     * Convenience overload: queries the current network via FederationParams().
+     * Implemented in federationparams.cpp to avoid a circular include dependency.
      */
-    bool IsEnforced(unsigned int flag, unsigned int scriptFlags) const {
-        for (const auto& sf : m_softforks)
-            if (sf.scriptVerifyFlag & flag)
-                return sf.IsEnforced(scriptFlags);
-        return (scriptFlags & flag) != 0;  // no entry → defer to flag bit
+    bool IsActive(unsigned int flag, int32_t blockHeight) const;
+
+    /**
+     * Returns whether the softfork flag is reflected in the given pre-computed
+     * script-verify flags.  Used in the script interpreter, which sees only the
+     * flags bitmask (already produced by GetBlockScriptFlags / IsActive) and
+     * cannot query by block height.
+     */
+    bool IsEnabled(unsigned int flag, unsigned int scriptFlags) const {
+        return (scriptFlags & flag) != 0;
     }
+
 };
 
 /**

--- a/src/softforkmanager.h
+++ b/src/softforkmanager.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2024 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef TAPYRUS_SOFTFORKMANAGER_H
+#define TAPYRUS_SOFTFORKMANAGER_H
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+/**
+ * Activation predicate for height-based softforks.
+ * Returns true once blockHeight reaches activationHeight.
+ */
+struct HeightActivation {
+    int32_t activationHeight;
+    explicit HeightActivation(int32_t h) : activationHeight(h) {}
+    bool operator()(int32_t blockHeight) const { return blockHeight >= activationHeight; }
+};
+
+/**
+ * Represents a single softfork rule tied to a specific Tapyrus network.
+ *
+ * networkId        — the Tapyrus networkId this fork applies to
+ * scriptVerifyFlag — SCRIPT_VERIFY_* bit(s) added to GetBlockScriptFlags()
+ *                    when the fork is active
+ * activationHeight — block height at which the fork becomes active (for introspection)
+ * isActive         — callable(blockHeight) → bool; the canonical activation check;
+ *                    typically a HeightActivation but may encode any predicate
+ */
+struct CSoftFork {
+    uint32_t networkId;
+    unsigned int scriptVerifyFlag;
+    int32_t activationHeight;
+    std::function<bool(int32_t blockHeight)> isActive;
+
+    CSoftFork(uint32_t netId, unsigned int flag, HeightActivation activation)
+        : networkId(netId), scriptVerifyFlag(flag),
+          activationHeight(activation.activationHeight), isActive(std::move(activation)) {}
+
+    /** True when the compiled script flags indicate this fork is enforced. */
+    bool IsEnforced(unsigned int scriptFlags) const { return (scriptFlags & scriptVerifyFlag) != 0; }
+};
+
+/**
+ * Manages all registered softforks across networks.
+ *
+ * Populated once at startup in PROD mode via CFederationParams.
+ * Empty in DEV mode — no forks are enforced.
+ * Thread-safe for reads after startup (no concurrent writes expected).
+ */
+class CSoftForkManager {
+    std::vector<CSoftFork> m_softforks;
+
+public:
+    void Register(CSoftFork sf) { m_softforks.push_back(std::move(sf)); }
+
+    /**
+     * Returns the registered CSoftFork for the given scriptVerifyFlag on networkId,
+     * or nullptr if no entry exists (i.e. the fork is active from genesis on that network).
+     */
+    const CSoftFork* GetFork(uint32_t networkId, unsigned int flag) const {
+        for (const auto& sf : m_softforks)
+            if (sf.networkId == networkId && (sf.scriptVerifyFlag & flag))
+                return &sf;
+        return nullptr;
+    }
+
+    /**
+     * Returns the union of SCRIPT_VERIFY_* flags for all softforks that are
+     * active on networkId at blockHeight.
+     */
+    unsigned int GetScriptFlags(uint32_t networkId, int32_t blockHeight) const {
+        unsigned int flags = 0;
+        for (const auto& sf : m_softforks) {
+            if (sf.networkId == networkId && sf.isActive(blockHeight))
+                flags |= sf.scriptVerifyFlag;
+        }
+        return flags;
+    }
+
+    /**
+     * Returns whether the given flag is active for networkId at blockHeight.
+     *
+     * When no entry exists for (networkId, flag) the softfork is considered
+     * active from genesis — the manager stores only networks that need a
+     * non-zero activation height.  Callers that want the genesis-default
+     * behaviour for unregistered networks rely on this returning true.
+     */
+    bool IsActive(uint32_t networkId, unsigned int flag, int32_t blockHeight) const {
+        for (const auto& sf : m_softforks)
+            if (sf.networkId == networkId && (sf.scriptVerifyFlag & flag))
+                return sf.isActive(blockHeight);
+        return true;  // no entry → active from genesis by default
+    }
+
+    /**
+     * For use by the script interpreter: returns whether the softfork for
+     * the given flag is enforced given the compiled script flags passed to
+     * VerifyScript.
+     *
+     * When no entry is registered the flag is considered active from genesis
+     * and the check degenerates to (scriptFlags & flag).  For registered
+     * networks the result comes from the stored HeightActivation predicate
+     * via CSoftFork::IsEnforced, which checks the same bit — the bit having
+     * been set (or not) by GetBlockScriptFlags() earlier in the call chain.
+     */
+    bool IsEnforced(unsigned int flag, unsigned int scriptFlags) const {
+        for (const auto& sf : m_softforks)
+            if (sf.scriptVerifyFlag & flag)
+                return sf.IsEnforced(scriptFlags);
+        return (scriptFlags & flag) != 0;  // no entry → defer to flag bit
+    }
+};
+
+/**
+ * Returns the softfork manager for the currently active network.
+ * Declared here so that script/interpreter.cpp can call it without
+ * including federationparams.h (which would create a circular dependency).
+ * Implemented in federationparams.cpp.
+ */
+const CSoftForkManager& GetSoftForkManager();
+
+#endif // TAPYRUS_SOFTFORKMANAGER_H

--- a/src/tapyrus-tx.cpp
+++ b/src/tapyrus-tx.cpp
@@ -627,6 +627,11 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
 
+    // Always include CP2SH_COLORED: this tool produces canonical signatures that
+    // are valid on any post-activation network. Stage-2 CP2SH scriptSigs are also
+    // accepted pre-activation (the redeem-script bytes satisfy the P2SH check).
+    const unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_CP2SH_COLORED;
+
     // Sign what we can:
     for (unsigned int i = 0; i < mergedTx.vin.size(); i++) {
         CTxIn& txin = mergedTx.vin[i];
@@ -640,7 +645,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
         SignatureData sigdata = DataFromTransaction(mergedTx, i, coin.out);
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
         if (!fHashSingle || (i < mergedTx.vout.size()))
-            ProduceSignature(keystore, MutableTransactionSignatureCreator(&mergedTx, i, amount, nHashType, scheme), prevPubKey, sigdata);
+            ProduceSignature(keystore, MutableTransactionSignatureCreator(&mergedTx, i, amount, nHashType, scheme), prevPubKey, sigdata, signVerifyFlags);
 
         UpdateInput(txin, sigdata);
     }

--- a/src/test/federationparams_tests.cpp
+++ b/src/test/federationparams_tests.cpp
@@ -169,15 +169,15 @@ BOOST_AUTO_TEST_CASE(softfork_manager_testnet_activation_heights)
     // Mirror the production registration for Chaintope testnet (networkId 1939510133).
     CSoftForkManager sfm;
     sfm.Register(CSoftFork(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED,
-                           HeightActivation(261594)));
+                           HeightActivation(TESTNET_CP2SH_ACTIVATION_HEIGHT)));
 
     // One block before activation: not yet active.
-    BOOST_CHECK(!sfm.IsActive(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED, 261593));
-    BOOST_CHECK_EQUAL(sfm.GetScriptFlags(1939510133u, 261593), 0u);
+    BOOST_CHECK(!sfm.IsActive(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED, TESTNET_CP2SH_ACTIVATION_HEIGHT - 1));
+    BOOST_CHECK_EQUAL(sfm.GetScriptFlags(1939510133u, TESTNET_CP2SH_ACTIVATION_HEIGHT - 1), 0u);
 
     // At activation height: active.
-    BOOST_CHECK(sfm.IsActive(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED, 261594));
-    BOOST_CHECK_EQUAL(sfm.GetScriptFlags(1939510133u, 261594),
+    BOOST_CHECK(sfm.IsActive(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED, TESTNET_CP2SH_ACTIVATION_HEIGHT));
+    BOOST_CHECK_EQUAL(sfm.GetScriptFlags(1939510133u, TESTNET_CP2SH_ACTIVATION_HEIGHT),
                       static_cast<unsigned>(SCRIPT_VERIFY_CP2SH_COLORED));
 
     // Unregistered network: IsActive returns true (active from genesis by default).

--- a/src/test/federationparams_tests.cpp
+++ b/src/test/federationparams_tests.cpp
@@ -3,6 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <federationparams.h>
+#include <softforkmanager.h>
+#include <script/interpreter.h>
 #include <script/sigcache.h>
 #include <test/test_tapyrus.h>
 #include <test/test_keys_helper.h>
@@ -159,6 +161,27 @@ BOOST_AUTO_TEST_CASE(create_genesis_block_one_publickey)
     const uint256 blockHash = baseChainParams->GenesisBlock().GetHashForSign();
 
     BOOST_CHECK(aggPubkey.Verify_Schnorr(blockHash, baseChainParams->GenesisBlock().proof));
+}
+
+// Standalone test — uses CSoftForkManager directly, no FederationParams setup required.
+BOOST_AUTO_TEST_CASE(softfork_manager_testnet_activation_heights)
+{
+    // Mirror the production registration for Chaintope testnet (networkId 1939510133).
+    CSoftForkManager sfm;
+    sfm.Register(CSoftFork(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED,
+                           HeightActivation(261594)));
+
+    // One block before activation: not yet active.
+    BOOST_CHECK(!sfm.IsActive(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED, 261593));
+    BOOST_CHECK_EQUAL(sfm.GetScriptFlags(1939510133u, 261593), 0u);
+
+    // At activation height: active.
+    BOOST_CHECK(sfm.IsActive(1939510133u, SCRIPT_VERIFY_CP2SH_COLORED, 261594));
+    BOOST_CHECK_EQUAL(sfm.GetScriptFlags(1939510133u, 261594),
+                      static_cast<unsigned>(SCRIPT_VERIFY_CP2SH_COLORED));
+
+    // Unregistered network: IsActive returns true (active from genesis by default).
+    BOOST_CHECK(sfm.IsActive(1u, SCRIPT_VERIFY_CP2SH_COLORED, 0));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -330,7 +330,7 @@ private:
 
 
 public:
-    TestBuilder(const CScript& script_, const std::string& comment_, int flags_, bool P2SH = false, WitnessMode wm = WitnessMode::NONE, int witnessversion = 0, CAmount nValue_ = 0, bool ignoreColor = false, CScript innerScript_ = CScript()) : script(script_), havePush(false), comment(comment_), flags(flags_), scriptError(SCRIPT_ERR_OK), nValue(nValue_)
+    TestBuilder(const CScript& script_, const std::string& comment_, int flags_, bool P2SH = false, WitnessMode wm = WitnessMode::NONE, int witnessversion = 0, CAmount nValue_ = 0, bool ignoreColor = false, const CScript& customRedeem = CScript()) : script(script_), havePush(false), comment(comment_), flags(flags_), scriptError(SCRIPT_ERR_OK), nValue(nValue_)
     {
         CScript scriptPubKey = script;
         if (wm == WitnessMode::PKH) {
@@ -347,8 +347,8 @@ public:
         if (P2SH) {
             if(!ignoreColor && scriptPubKey.IsColoredScript())
             {
-                if (!innerScript_.empty()) {
-                    redeemscript = innerScript_;
+                if (!customRedeem.empty()) {
+                    redeemscript = customRedeem;
                 } else {
                     const KeyData keys;
                     redeemscript = CScript() << OP_DUP << OP_HASH160 << ToByteVector(keys.pubkey1C.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
@@ -2669,13 +2669,13 @@ BOOST_AUTO_TEST_CASE(colored_coin_cp2sh_redeem_scripts)
 
         // Valid: tx.nLockTime == 500, input nSequence non-final
         tests.push_back(TestBuilder(cp2sh, "CP2SH(CLTV) valid spend at height 500",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .LockTime(500).Sequence(0xfffffffe).PushRedeem());
 
         // Invalid: input is finalized — CLTV always fails when nSequence == SEQUENCE_FINAL
         tests.push_back(TestBuilder(cp2sh, "CP2SH(CLTV) fails when input is finalised",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .LockTime(500)   // nSequence stays at default SEQUENCE_FINAL
                 .PushRedeem()
@@ -2683,7 +2683,7 @@ BOOST_AUTO_TEST_CASE(colored_coin_cp2sh_redeem_scripts)
 
         // Invalid: tx.nLockTime is below the required threshold
         tests.push_back(TestBuilder(cp2sh, "CP2SH(CLTV) fails when locktime too low",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .LockTime(499).Sequence(0xfffffffe)
                 .PushRedeem()
@@ -2699,13 +2699,13 @@ BOOST_AUTO_TEST_CASE(colored_coin_cp2sh_redeem_scripts)
 
         // Valid: nSequence = 3 (block-relative, bit 31 clear, >= 3)
         tests.push_back(TestBuilder(cp2sh, "CP2SH(CSV) valid spend with sequence 3",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .Sequence(3).PushRedeem());
 
         // Invalid: nSequence = 2 — below the required minimum
         tests.push_back(TestBuilder(cp2sh, "CP2SH(CSV) fails when sequence too low",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .Sequence(2)
                 .PushRedeem()
@@ -2713,7 +2713,7 @@ BOOST_AUTO_TEST_CASE(colored_coin_cp2sh_redeem_scripts)
 
         // Invalid: SEQUENCE_DISABLE_FLAG set in tx nSequence — CheckSequence returns false
         tests.push_back(TestBuilder(cp2sh, "CP2SH(CSV) fails when disable flag set in nSequence",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .Sequence(CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG | 3)
                 .PushRedeem()
@@ -2730,7 +2730,7 @@ BOOST_AUTO_TEST_CASE(colored_coin_cp2sh_redeem_scripts)
         CScript cp2sh = makeCP2SH(inner);
 
         tests.push_back(TestBuilder(cp2sh, "CP2SH(OP_COLOR in redeem script) rejected",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .PushRedeem()
                 .ScriptError(SCRIPT_ERR_OP_COLOR_UNEXPECTED));
@@ -2745,13 +2745,13 @@ BOOST_AUTO_TEST_CASE(colored_coin_cp2sh_redeem_scripts)
 
         // Valid: push 1 to take the true branch — leaves OP_1 on the stack
         tests.push_back(TestBuilder(cp2sh, "CP2SH(OP_IF true branch) valid",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .Num(1).PushRedeem());
 
         // Invalid: push 0 to take the false branch — leaves OP_0, script returns false
         tests.push_back(TestBuilder(cp2sh, "CP2SH(OP_IF false branch) EVAL_FALSE",
-            SCRIPT_VERIFY_NONE, /*P2SH=*/true,
+            SCRIPT_VERIFY_CP2SH_COLORED, /*P2SH=*/true,
             WitnessMode::NONE, 0, 0, false, inner)
                 .Num(0).PushRedeem()
                 .ScriptError(SCRIPT_ERR_EVAL_FALSE));

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -112,6 +112,37 @@ void testTx(TestChainSetup* setup, const CTransactionRef tx, bool success, std::
     }
 }
 
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+// Verifies that a transaction is admitted to the mempool without mining it into
+// a block.  Used for pre-activation checks: the softfork is not yet active so
+// attack scripts pass CheckColorIdentifierValidity; the UTXO remains unspent so
+// the companion post-activation test can reuse it.
+static void checkMempoolAdmitted(const CTransactionRef& tx)
+{
+    CTxMempoolAcceptanceOptions opt;
+    opt.flags = MempoolAcceptanceFlags::BYPASSS_LIMITS;
+    { LOCK(cs_main); BOOST_CHECK(AcceptToMemoryPool(tx, opt)); }
+    BOOST_CHECK(opt.state.IsValid());
+}
+
+// Fixture that extends TestChainSetup by mining empty blocks until the chain
+// reaches CP2SH_ACTIVATION_TEST_HEIGHT, making SCRIPT_VERIFY_CP2SH_COLORED
+// active for all subsequent mempool and block validation calls.
+// The initial five coinbase UTXOs from TestChainSetup are unspent and mature
+// at activation height (100-block maturity rule is satisfied by height 120).
+struct TestChainSetupPostActivation : public TestChainSetup {
+    TestChainSetupPostActivation() : TestChainSetup() {
+        CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+        int current;
+        { LOCK(cs_main); current = chainActive.Height(); }
+        for (int i = current; i < CP2SH_ACTIVATION_TEST_HEIGHT; i++) {
+            std::vector<CMutableTransaction> noTxns;
+            CreateAndProcessBlock(noTxns, scriptPubKey);
+        }
+    }
+};
+#endif
+
 void Sign(std::vector<unsigned char>& vchSig, CKey& signKey, const CScript& scriptPubKey, CMutableTransaction& inTx, int inIndex, CMutableTransaction& outTx, int outIndex)
 {
     uint256 hash = SignatureHash(scriptPubKey, outTx, inIndex, SIGHASH_ALL, outTx.vout[outIndex].nValue, SigVersion::BASE);
@@ -159,15 +190,63 @@ BOOST_FIXTURE_TEST_CASE(tx_invalid_token_issue, TestChainSetup)
     tokenIssueTx.vout[0].scriptPubKey = scriptPubKey;
 
     Sign(vchSig, key, coinbaseSpendTx.vout[0].scriptPubKey, coinbaseSpendTx, 0, tokenIssueTx, 0);
-    std::vector<unsigned char> vchPubKey0(pubkey0.begin(), pubkey0.end());
     tokenIssueTx.vin[0].scriptSig = CScript() << vchSig << vchPubKey;
 
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    // Pre-activation: softfork not active → attack script admitted to mempool.
+    checkMempoolAdmitted(MakeTransactionRef(tokenIssueTx));
+#else
     testTx(this, MakeTransactionRef(tokenIssueTx), false, "bad-txns-nonstandard-opcolor");
+#endif
 
     //test colorid in coinbase utxo
     //"CreateNewBlock: TestBlockValidity failed: bad-cb-issuetoken, coinbase cannot issue tokens"
     BOOST_CHECK_THROW(CreateAndProcessBlock({}, scriptPubKey), std::runtime_error);
 }
+
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+BOOST_FIXTURE_TEST_CASE(tx_invalid_token_issue_post_activation, TestChainSetupPostActivation)
+{
+    const unsigned char vchKey[32] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0};
+    CKey key;
+    key.Set(vchKey, vchKey + 32, true);
+    CPubKey pubkey = key.GetPubKey();
+    std::vector<unsigned char> pubkeyHash(20);
+    std::vector<unsigned char> vchPubKey(pubkey.begin(), pubkey.end());
+    CHash160().Write(pubkey.data(), pubkey.size()).Finalize(pubkeyHash.data());
+
+    CMutableTransaction coinbaseSpendTx;
+    coinbaseSpendTx.nFeatures = 1;
+    coinbaseSpendTx.vin.resize(1);
+    coinbaseSpendTx.vout.resize(1);
+    coinbaseSpendTx.vin[0].prevout.hashMalFix = m_coinbase_txns[3]->GetHashMalFix();
+    coinbaseSpendTx.vin[0].prevout.n = 0;
+    coinbaseSpendTx.vout[0].nValue = 100 * CENT;
+    coinbaseSpendTx.vout[0].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(pubkeyHash) << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    std::vector<unsigned char> vchSig;
+    CMutableTransaction coinbaseIn(*m_coinbase_txns[3]);
+    Sign(vchSig, coinbaseKey, m_coinbase_txns[3]->vout[0].scriptPubKey, coinbaseIn, 0, coinbaseSpendTx, 0);
+    coinbaseSpendTx.vin[0].scriptSig = CScript() << vchSig;
+    testTx(this, MakeTransactionRef(coinbaseSpendTx), true);
+
+    CScript scriptPubKey = CScript() << ColorIdentifier().toVector() << OP_COLOR << OP_DUP << OP_HASH160 << ToByteVector(pubkeyHash) << OP_EQUALVERIFY << OP_CHECKSIG;
+    CMutableTransaction tokenIssueTx;
+    tokenIssueTx.nFeatures = 1;
+    tokenIssueTx.vin.resize(1);
+    tokenIssueTx.vout.resize(1);
+    tokenIssueTx.vin[0].prevout.hashMalFix = coinbaseSpendTx.GetHashMalFix();
+    tokenIssueTx.vin[0].prevout.n = 0;
+    tokenIssueTx.vout[0].nValue = 100 * CENT;
+    tokenIssueTx.vout[0].scriptPubKey = scriptPubKey;
+
+    Sign(vchSig, key, coinbaseSpendTx.vout[0].scriptPubKey, coinbaseSpendTx, 0, tokenIssueTx, 0);
+    tokenIssueTx.vin[0].scriptSig = CScript() << vchSig << vchPubKey;
+
+    // Post-activation: softfork active → attack script rejected.
+    testTx(this, MakeTransactionRef(tokenIssueTx), false, "bad-txns-nonstandard-opcolor");
+}
+#endif
 
 /*
 Test token type REISSUABLE
@@ -866,8 +945,44 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_swap_color_script, TestChainSetup)
     CMutableTransaction coinbaseIn(*m_coinbase_txns[2]);
     Sign(vchSig, coinbaseKey, m_coinbase_txns[2]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
     fundTx.vin[0].scriptSig = CScript() << vchSig;
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    // Pre-activation: softfork not active → swap-color attack script admitted.
+    checkMempoolAdmitted(MakeTransactionRef(fundTx));
+#else
+    testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
+#endif
+}
+
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+BOOST_FIXTURE_TEST_CASE(tx_mempool_swap_color_script_post_activation, TestChainSetupPostActivation)
+{
+    initKeys();
+
+    ColorIdentifier validCid(CScript() << ToByteVector(pubkey0) << OP_CHECKSIG);
+    std::vector<unsigned char> invalidC4Cid(33);
+    invalidC4Cid[0] = 0xc4;
+    for (int i = 1; i < 33; i++) invalidC4Cid[i] = static_cast<unsigned char>(i);
+
+    CScript swapColorScript;
+    swapColorScript << invalidC4Cid << OP_SWAP << OP_COLOR << OP_DROP << OP_1;
+
+    CMutableTransaction fundTx;
+    fundTx.nFeatures = 1;
+    fundTx.vin.resize(1);
+    fundTx.vout.resize(1);
+    fundTx.vin[0].prevout.hashMalFix = m_coinbase_txns[2]->GetHashMalFix();
+    fundTx.vin[0].prevout.n = 0;
+    fundTx.vout[0].nValue = 100 * CENT;
+    fundTx.vout[0].scriptPubKey = swapColorScript;
+
+    std::vector<unsigned char> vchSig;
+    CMutableTransaction coinbaseIn(*m_coinbase_txns[2]);
+    Sign(vchSig, coinbaseKey, m_coinbase_txns[2]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
+    fundTx.vin[0].scriptSig = CScript() << vchSig;
+    // Post-activation: softfork active → swap-color attack script rejected.
     testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
 }
+#endif
 
 /*
  * tx_mempool_altstack_color_script
@@ -924,8 +1039,44 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_altstack_color_script, TestChainSetup)
     CMutableTransaction coinbaseIn(*m_coinbase_txns[4]);
     Sign(vchSig, coinbaseKey, m_coinbase_txns[4]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
     fundTx.vin[0].scriptSig = CScript() << vchSig;
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    // Pre-activation: softfork not active → altstack-color attack script admitted.
+    checkMempoolAdmitted(MakeTransactionRef(fundTx));
+#else
+    testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
+#endif
+}
+
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+BOOST_FIXTURE_TEST_CASE(tx_mempool_altstack_color_script_post_activation, TestChainSetupPostActivation)
+{
+    initKeys();
+
+    ColorIdentifier reissuableCid(CScript() << ToByteVector(pubkey0) << OP_CHECKSIG);
+    COutPoint nftOutpoint(m_coinbase_txns[3]->GetHashMalFix(), 0);
+    ColorIdentifier nftCid(nftOutpoint, TokenTypes::NFT);
+
+    CScript altStackColorScript;
+    altStackColorScript << nftCid.toVector() << OP_TOALTSTACK
+                        << reissuableCid.toVector() << OP_COLOR << OP_FROMALTSTACK;
+
+    CMutableTransaction fundTx;
+    fundTx.nFeatures = 1;
+    fundTx.vin.resize(1);
+    fundTx.vout.resize(1);
+    fundTx.vin[0].prevout.hashMalFix = m_coinbase_txns[4]->GetHashMalFix();
+    fundTx.vin[0].prevout.n = 0;
+    fundTx.vout[0].nValue = 100 * CENT;
+    fundTx.vout[0].scriptPubKey = altStackColorScript;
+
+    std::vector<unsigned char> vchSig;
+    CMutableTransaction coinbaseIn(*m_coinbase_txns[4]);
+    Sign(vchSig, coinbaseKey, m_coinbase_txns[4]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
+    fundTx.vin[0].scriptSig = CScript() << vchSig;
+    // Post-activation: softfork active → altstack-color attack script rejected.
     testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
 }
+#endif
 
 /*
  * tx_mempool_drop_decoy_nft_script
@@ -978,8 +1129,43 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_drop_decoy_nft_script, TestChainSetup)
     CMutableTransaction coinbaseIn(*m_coinbase_txns[0]);
     Sign(vchSig, coinbaseKey, m_coinbase_txns[0]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
     fundTx.vin[0].scriptSig = CScript() << vchSig;
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    // Pre-activation: softfork not active → drop-decoy NFT attack script admitted.
+    checkMempoolAdmitted(MakeTransactionRef(fundTx));
+#else
+    testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
+#endif
+}
+
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+BOOST_FIXTURE_TEST_CASE(tx_mempool_drop_decoy_nft_script_post_activation, TestChainSetupPostActivation)
+{
+    initKeys();
+
+    ColorIdentifier reissuableCid(CScript() << ToByteVector(pubkey0) << OP_CHECKSIG);
+    COutPoint nftOutpoint(uint256S("3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"), 0);
+    ColorIdentifier nftCid(nftOutpoint, TokenTypes::NFT);
+
+    CScript dropDecoyNFT;
+    dropDecoyNFT << nftCid.toVector() << reissuableCid.toVector() << OP_COLOR << OP_DROP << OP_1;
+
+    CMutableTransaction fundTx;
+    fundTx.nFeatures = 1;
+    fundTx.vin.resize(1);
+    fundTx.vout.resize(1);
+    fundTx.vin[0].prevout.hashMalFix = m_coinbase_txns[0]->GetHashMalFix();
+    fundTx.vin[0].prevout.n = 0;
+    fundTx.vout[0].nValue = 100 * CENT;
+    fundTx.vout[0].scriptPubKey = dropDecoyNFT;
+
+    std::vector<unsigned char> vchSig;
+    CMutableTransaction coinbaseIn(*m_coinbase_txns[0]);
+    Sign(vchSig, coinbaseKey, m_coinbase_txns[0]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
+    fundTx.vin[0].scriptSig = CScript() << vchSig;
+    // Post-activation: softfork active → drop-decoy NFT attack script rejected.
     testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
 }
+#endif
 
 /*
  * tx_mempool_rot_decoy_script
@@ -1032,8 +1218,43 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_rot_decoy_script, TestChainSetup)
     CMutableTransaction coinbaseIn(*m_coinbase_txns[1]);
     Sign(vchSig, coinbaseKey, m_coinbase_txns[1]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
     fundTx.vin[0].scriptSig = CScript() << vchSig;
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    // Pre-activation: softfork not active → ROT-decoy attack script admitted.
+    checkMempoolAdmitted(MakeTransactionRef(fundTx));
+#else
+    testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
+#endif
+}
+
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+BOOST_FIXTURE_TEST_CASE(tx_mempool_rot_decoy_script_post_activation, TestChainSetupPostActivation)
+{
+    initKeys();
+
+    ColorIdentifier reissuableCid(CScript() << ToByteVector(pubkey0) << OP_CHECKSIG);
+    COutPoint nftOutpoint(uint256S("3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"), 0);
+    ColorIdentifier nftCid(nftOutpoint, TokenTypes::NFT);
+
+    CScript rotDecoy;
+    rotDecoy << nftCid.toVector() << reissuableCid.toVector() << OP_1 << OP_ROT << OP_COLOR << OP_1;
+
+    CMutableTransaction fundTx;
+    fundTx.nFeatures = 1;
+    fundTx.vin.resize(1);
+    fundTx.vout.resize(1);
+    fundTx.vin[0].prevout.hashMalFix = m_coinbase_txns[1]->GetHashMalFix();
+    fundTx.vin[0].prevout.n = 0;
+    fundTx.vout[0].nValue = 100 * CENT;
+    fundTx.vout[0].scriptPubKey = rotDecoy;
+
+    std::vector<unsigned char> vchSig;
+    CMutableTransaction coinbaseIn(*m_coinbase_txns[1]);
+    Sign(vchSig, coinbaseKey, m_coinbase_txns[1]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
+    fundTx.vin[0].scriptSig = CScript() << vchSig;
+    // Post-activation: softfork active → ROT-decoy attack script rejected.
     testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
 }
+#endif
 
 /*
  * tx_mempool_drop_decoy_same_type_script
@@ -1084,8 +1305,45 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_drop_decoy_same_type_script, TestChainSetup)
     CMutableTransaction coinbaseIn(*m_coinbase_txns[2]);
     Sign(vchSig, coinbaseKey, m_coinbase_txns[2]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
     fundTx.vin[0].scriptSig = CScript() << vchSig;
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    // Pre-activation: softfork not active → same-type decoy attack script admitted.
+    checkMempoolAdmitted(MakeTransactionRef(fundTx));
+#else
+    testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
+#endif
+}
+
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+BOOST_FIXTURE_TEST_CASE(tx_mempool_drop_decoy_same_type_script_post_activation, TestChainSetupPostActivation)
+{
+    initKeys();
+
+    COutPoint realOutpoint(uint256S("3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"), 0);
+    ColorIdentifier realNonReissuableCid(realOutpoint, TokenTypes::NON_REISSUABLE);
+    COutPoint decoyOutpoint(uint256S("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 1);
+    ColorIdentifier decoyNonReissuableCid(decoyOutpoint, TokenTypes::NON_REISSUABLE);
+
+    CScript dropDecoySameType;
+    dropDecoySameType << decoyNonReissuableCid.toVector() << realNonReissuableCid.toVector()
+                      << OP_COLOR << OP_DROP << OP_1;
+
+    CMutableTransaction fundTx;
+    fundTx.nFeatures = 1;
+    fundTx.vin.resize(1);
+    fundTx.vout.resize(1);
+    fundTx.vin[0].prevout.hashMalFix = m_coinbase_txns[2]->GetHashMalFix();
+    fundTx.vin[0].prevout.n = 0;
+    fundTx.vout[0].nValue = 100 * CENT;
+    fundTx.vout[0].scriptPubKey = dropDecoySameType;
+
+    std::vector<unsigned char> vchSig;
+    CMutableTransaction coinbaseIn(*m_coinbase_txns[2]);
+    Sign(vchSig, coinbaseKey, m_coinbase_txns[2]->vout[0].scriptPubKey, coinbaseIn, 0, fundTx, 0);
+    fundTx.vin[0].scriptSig = CScript() << vchSig;
+    // Post-activation: softfork active → same-type decoy attack script rejected.
     testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
 }
+#endif
 
 /*
  * tx_mempool_cltv_colored_coin
@@ -1131,7 +1389,12 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_cltv_colored_coin, TestChainSetup)
     CMutableTransaction coinbaseIn0(*m_coinbase_txns[0]);
     Sign(vchSig, coinbaseKey, coinbasePk, coinbaseIn0, 0, fundTx, 0);
     fundTx.vin[0].scriptSig = CScript() << vchSig;
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+    // Pre-activation: softfork not active → direct-CLTV colored attack script admitted.
+    checkMempoolAdmitted(MakeTransactionRef(fundTx));
+#else
     testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
+#endif
 
     // Part 2: CP2SH colored output with CLTV inside the redeem script → accepted.
     CScript redeemScript;
@@ -1160,6 +1423,63 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_cltv_colored_coin, TestChainSetup)
     cp2shFundTx.vin[0].scriptSig = CScript() << vchSig;
     testTx(this, MakeTransactionRef(cp2shFundTx), true);
 }
+
+#ifdef CP2SH_ACTIVATION_TEST_HEIGHT
+BOOST_FIXTURE_TEST_CASE(tx_mempool_cltv_colored_coin_post_activation, TestChainSetupPostActivation)
+{
+    initKeys();
+
+    CScript coinbasePk = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    ColorIdentifier reissuableCid(coinbasePk);
+    const int64_t locktime = 3;
+
+    // Part 1: direct CLTV in colored script — rejected post-activation.
+    CScript cltvColorScript;
+    cltvColorScript << reissuableCid.toVector() << OP_COLOR
+                    << locktime << OP_CHECKLOCKTIMEVERIFY << OP_DROP
+                    << OP_DUP << OP_HASH160 << ToByteVector(pubkeyHash0)
+                    << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    CMutableTransaction fundTx;
+    fundTx.nFeatures = 1;
+    fundTx.vin.resize(1);
+    fundTx.vout.resize(1);
+    fundTx.vin[0].prevout.hashMalFix = m_coinbase_txns[0]->GetHashMalFix();
+    fundTx.vin[0].prevout.n = 0;
+    fundTx.vout[0].nValue = 100 * CENT;
+    fundTx.vout[0].scriptPubKey = cltvColorScript;
+
+    std::vector<unsigned char> vchSig;
+    CMutableTransaction coinbaseIn0(*m_coinbase_txns[0]);
+    Sign(vchSig, coinbaseKey, coinbasePk, coinbaseIn0, 0, fundTx, 0);
+    fundTx.vin[0].scriptSig = CScript() << vchSig;
+    testTx(this, MakeTransactionRef(fundTx), false, "bad-txns-nonstandard-opcolor");
+
+    // Part 2: CP2SH colored output with CLTV in redeem script — accepted post-activation.
+    CScript redeemScript;
+    redeemScript << locktime << OP_CHECKLOCKTIMEVERIFY << OP_DROP
+                 << OP_DUP << OP_HASH160 << ToByteVector(pubkeyHash0)
+                 << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    CScriptID redeemScriptId(redeemScript);
+    CScript cp2shColorScript = CScript() << reissuableCid.toVector() << OP_COLOR
+                                         << OP_HASH160 << ToByteVector(redeemScriptId) << OP_EQUAL;
+
+    CMutableTransaction cp2shFundTx;
+    cp2shFundTx.nFeatures = 1;
+    cp2shFundTx.vin.resize(1);
+    cp2shFundTx.vout.resize(1);
+    cp2shFundTx.vin[0].prevout.hashMalFix = m_coinbase_txns[1]->GetHashMalFix();
+    cp2shFundTx.vin[0].prevout.n = 0;
+    cp2shFundTx.vout[0].nValue = 100 * CENT;
+    cp2shFundTx.vout[0].scriptPubKey = cp2shColorScript;
+
+    CMutableTransaction coinbaseIn1(*m_coinbase_txns[1]);
+    Sign(vchSig, coinbaseKey, coinbasePk, coinbaseIn1, 0, cp2shFundTx, 0);
+    cp2shFundTx.vin[0].scriptSig = CScript() << vchSig;
+    testTx(this, MakeTransactionRef(cp2shFundTx), true);
+}
+#endif
 
 /*
  * Test token balance enforcement with an explicit partial-burn destination.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -439,7 +439,7 @@ static bool DoAllInputsExist(const CTransaction& tx, CValidationState& state, CT
     return true;
 }
 
-bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& state, CCoinsViewCache &inputs)
+bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& state, CCoinsViewCache &inputs, int32_t blockHeight)
 {
     // Track NFT colorId output count across the whole tx (must be exactly 1).
     std::map<ColorIdentifier, unsigned int> nftOutputCount;
@@ -451,24 +451,12 @@ bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& stat
 
         ColorIdentifier outColorId(GetColorIdFromScript(txout.scriptPubKey));
 
-        // GetColorIdFromScript() returned NONE for an OP_COLOR script.
-        // Two cases: (a) the script is structurally CP2PKH/CP2SH but carries an
-        // invalid colorId type byte — rejected as "invalid-colorid" with no DoS,
-        // (b) the script is not CP2PKH/CP2SH at all — rejected with DoS 100.
-        // Note: IsColoredPayToPubkeyHash and IsColoredPayToScriptHash both
-        // validate the type byte, so we check structure directly here.
+        // outColorId is NONE: IsColoredPayToPubkeyHash / IsColoredPayToScriptHash
+        // check both structure and type byte; reaching here means neither matched.
         if (outColorId.type == TokenTypes::NONE) {
-            const CScript& s = txout.scriptPubKey;
-            // Structural CP2PKH: 0x21 <33B colorId> OP_COLOR OP_DUP OP_HASH160 <20B hash> OP_EQUALVERIFY OP_CHECKSIG
-            bool isCP2PKHForm = (s.size() == 60 && s[0] == 0x21 && s[34] == OP_COLOR &&
-                                 s[35] == OP_DUP && s[36] == OP_HASH160 && s[37] == 20 &&
-                                 s[58] == OP_EQUALVERIFY && s[59] == OP_CHECKSIG);
-            // Structural CP2SH: 0x21 <33B colorId> OP_COLOR OP_HASH160 <20B hash> OP_EQUAL
-            bool isCP2SHForm  = (s.size() == 58 && s[0] == 0x21 && s[34] == OP_COLOR &&
-                                 s[35] == OP_HASH160 && s[36] == 0x14 && s[57] == OP_EQUAL);
-            if (!isCP2PKHForm && !isCP2SHForm)
+            if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, blockHeight))
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-nonstandard-opcolor");
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-invalid-colorid");
+            continue;
         }
 
         // Zero or negative token values are not allowed.
@@ -487,11 +475,11 @@ bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& stat
             ColorIdentifier coinColorId;
             ColorIdentifier cid = GetColorIdFromScript(coin.out.scriptPubKey);
 
-            // If the input UTXO's script has OP_COLOR but its colorId is NONE,
-            // it was created before the CP2PKH/CP2SH-only restriction or is
-            // otherwise non-standard.  Reject any attempt to spend such UTXOs.
-            if (cid.type == TokenTypes::NONE && coin.out.scriptPubKey.IsColoredScript())
-                return state.DoS(100, false, REJECT_INVALID, "bad-txns-nonstandard-opcolor");
+            if (cid.type == TokenTypes::NONE && coin.out.scriptPubKey.IsColoredScript()) {
+                if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, blockHeight))
+                    return state.DoS(100, false, REJECT_INVALID, "bad-txns-nonstandard-opcolor");
+                continue;
+            }
 
             switch(cid.type)
             {
@@ -550,7 +538,7 @@ bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& stat
     return true;
 }
 
-bool VerifyTokenBalances(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAmount minrelayFee, std::set<ColorIdentifier>* newIssuances)
+bool VerifyTokenBalances(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAmount minrelayFee, std::set<ColorIdentifier>* newIssuances, int32_t blockHeight)
 {
     // Build input balance map from the UTXO view.
     // Simultaneously collect TPC input outpoints for issuance detection.
@@ -559,12 +547,10 @@ bool VerifyTokenBalances(const CTransaction& tx, CValidationState& state, const 
     for (const auto& txin : tx.vin) {
         const Coin& coin = inputs.AccessCoin(txin.prevout);
         ColorIdentifier cid = GetColorIdFromScript(coin.out.scriptPubKey);
-        // A legacy custom-OP_COLOR UTXO (created before the CP2PKH/CP2SH-only
-        // restriction) maps to colorId NONE under current rules.  Its nValue is a
-        // raw token amount; adding it to the TPC balance bucket would let the
-        // spender claim more TPC than they own.  Reject regardless of whether the
-        // spending tx has any colored outputs
-        if (cid.type == TokenTypes::NONE && coin.out.scriptPubKey.IsColoredScript())
+        // A legacy non-standard OP_COLOR UTXO (colorId resolves to NONE) is rejected
+        // post-activation.  Pre-activation its nValue falls through to the TPC bucket.
+        if (cid.type == TokenTypes::NONE && coin.out.scriptPubKey.IsColoredScript() &&
+            GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, blockHeight))
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-nonstandard-opcolor");
         auto it = inColoredCoinBalances.find(cid);
         if (it == inColoredCoinBalances.end())
@@ -648,12 +634,8 @@ unsigned int GetBlockScriptFlags(const CBlockIndex* pindex) {
 
     unsigned int flags = SCRIPT_VERIFY_NONE;
 
-    // CP2SH colored softfork: enforce redeem-script evaluation for colored P2SH outputs.
-    // Activation is governed entirely by the softfork manager — each registered entry's
-    // HeightActivation predicate is the canonical IsActive check for that network.
-    // Unregistered networks (no manager entry) are active from genesis by default.
-    const auto& sfm = FederationParams().SoftForkManager();
-    if (sfm.IsActive(FederationParams().NetworkId(), SCRIPT_VERIFY_CP2SH_COLORED, pindex->nHeight))
+    // Activation logic and network-id lookup are encapsulated in the softfork manager.
+    if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, pindex->nHeight))
         flags |= SCRIPT_VERIFY_CP2SH_COLORED;
 
     return flags;
@@ -723,7 +705,7 @@ static bool AcceptToMemoryPoolWorker(const CTransactionRef &ptx, CTxMempoolAccep
             return false;
 
         //if there are colored coins in the output verify their colorids
-        if(!CheckColorIdentifierValidity(tx, state, view))
+        if(!CheckColorIdentifierValidity(tx, state, view, chainActive.Tip()->nHeight + 1))
             return false;
 
         // Bring the best block into scope
@@ -955,31 +937,25 @@ static bool AcceptToMemoryPoolWorker(const CTransactionRef &ptx, CTxMempoolAccep
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
         PrecomputedTransactionData txdata(tx);
-        if (!CheckInputs(tx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS, true, false, txdata)) {
+        // Include softfork-governed flags (e.g. SCRIPT_VERIFY_CP2SH_COLORED) so that
+        // mempool validation rejects transactions that would be invalid in the next block.
+        const unsigned int mempoolScriptFlags = STANDARD_SCRIPT_VERIFY_FLAGS |
+                                                GetBlockScriptFlags(chainActive.Tip());
+        if (!CheckInputs(tx, state, view, true, mempoolScriptFlags, true, false, txdata)) {
             return false; // state filled in by CheckInputs
         }
 
-        // Check again against the current block tip's script verification
-        // flags to cache our script execution flags. This is, of course,
-        // useless if the next block has different script flags from the
-        // previous one, but because the cache tracks script flags for us it
-        // will auto-invalidate and we'll just have a few blocks of extra
-        // misses on soft-fork activation.
-        //
-        // This is also useful in case of bugs in the standard flags that cause
-        // transactions to pass as valid when they're actually invalid. For
-        // instance the STRICTENC flag was incorrectly allowing certain
-        // CHECKSIG NOT scripts to pass, even though they were invalid.
-        //
-        // There is a similar check in CreateNewBlock() to prevent creating
-        // invalid blocks (using TestBlockValidity), however allowing such
-        // transactions into the mempool can be exploited as a DoS attack.
-        if (!CheckInputsFromMempoolAndCache(opt.context, tx, opt.state, view, pool, SCRIPT_VERIFY_NONE, true, txdata)) {
+        // Check again against the current block tip's script verification flags to
+        // cache our script execution results for the likely-next-block flags.
+        // If the tip's flags differ from mempoolScriptFlags (e.g. mid-softfork), the
+        // script cache auto-invalidates so we pay a few extra misses on activation.
+        const unsigned int tipScriptFlags = GetBlockScriptFlags(chainActive.Tip());
+        if (!CheckInputsFromMempoolAndCache(opt.context, tx, opt.state, view, pool, tipScriptFlags, true, txdata)) {
             return error("%s: BUG! PLEASE REPORT THIS! CheckInputs failed against latest-block but not STANDARD flags %s, %s",
                     __func__, hash.ToString(), FormatStateMessage(state));
         }
 
-        if (!VerifyTokenBalances(tx, opt.state, view, ::minRelayTxFee.GetFee(nSize)))
+        if (!VerifyTokenBalances(tx, opt.state, view, ::minRelayTxFee.GetFee(nSize), nullptr, chainActive.Tip()->nHeight + 1))
             return false;
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -629,16 +629,20 @@ bool VerifyTokenBalances(const CTransaction& tx, CValidationState& state, const 
     return true;
 }
 
-unsigned int GetBlockScriptFlags(const CBlockIndex* pindex) {
+unsigned int GetBlockScriptFlags(int32_t blockHeight) {
     AssertLockHeld(cs_main);
 
     unsigned int flags = SCRIPT_VERIFY_NONE;
 
     // Activation logic and network-id lookup are encapsulated in the softfork manager.
-    if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, pindex->nHeight))
+    if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, blockHeight))
         flags |= SCRIPT_VERIFY_CP2SH_COLORED;
 
     return flags;
+}
+
+unsigned int GetBlockScriptFlags(const CBlockIndex* pindex) {
+    return GetBlockScriptFlags(pindex->nHeight);
 }
 
 
@@ -937,19 +941,20 @@ static bool AcceptToMemoryPoolWorker(const CTransactionRef &ptx, CTxMempoolAccep
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
         PrecomputedTransactionData txdata(tx);
-        // Include softfork-governed flags (e.g. SCRIPT_VERIFY_CP2SH_COLORED) so that
-        // mempool validation rejects transactions that would be invalid in the next block.
+        // Query flags for the *next* block (tip+1), not the tip, so that softfork
+        // activation at height H is enforced by the mempool at tip == H-1.
+        // Using tip height here would admit txs that are valid pre-activation but
+        // invalid post-activation, producing an invalid block at height H.
+        const int32_t nextBlockHeight = chainActive.Tip()->nHeight + 1;
         const unsigned int mempoolScriptFlags = STANDARD_SCRIPT_VERIFY_FLAGS |
-                                                GetBlockScriptFlags(chainActive.Tip());
+                                                GetBlockScriptFlags(nextBlockHeight);
         if (!CheckInputs(tx, state, view, true, mempoolScriptFlags, true, false, txdata)) {
             return false; // state filled in by CheckInputs
         }
 
-        // Check again against the current block tip's script verification flags to
-        // cache our script execution results for the likely-next-block flags.
-        // If the tip's flags differ from mempoolScriptFlags (e.g. mid-softfork), the
-        // script cache auto-invalidates so we pay a few extra misses on activation.
-        const unsigned int tipScriptFlags = GetBlockScriptFlags(chainActive.Tip());
+        // Cache script execution results using the same next-block flags so the
+        // cache entries are valid when ConnectBlock runs at height nextBlockHeight.
+        const unsigned int tipScriptFlags = GetBlockScriptFlags(nextBlockHeight);
         if (!CheckInputsFromMempoolAndCache(opt.context, tx, opt.state, view, pool, tipScriptFlags, true, txdata)) {
             return error("%s: BUG! PLEASE REPORT THIS! CheckInputs failed against latest-block but not STANDARD flags %s, %s",
                     __func__, hash.ToString(), FormatStateMessage(state));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -648,6 +648,14 @@ unsigned int GetBlockScriptFlags(const CBlockIndex* pindex) {
 
     unsigned int flags = SCRIPT_VERIFY_NONE;
 
+    // CP2SH colored softfork: enforce redeem-script evaluation for colored P2SH outputs.
+    // Activation is governed entirely by the softfork manager — each registered entry's
+    // HeightActivation predicate is the canonical IsActive check for that network.
+    // Unregistered networks (no manager entry) are active from genesis by default.
+    const auto& sfm = FederationParams().SoftForkManager();
+    if (sfm.IsActive(FederationParams().NetworkId(), SCRIPT_VERIFY_CP2SH_COLORED, pindex->nHeight))
+        flags |= SCRIPT_VERIFY_CP2SH_COLORED;
+
     return flags;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -390,11 +390,13 @@ bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex();
 
-/** Verify coloured coin type related consensus rules */
-bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& state, CCoinsViewCache &inputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+/** Verify coloured coin type related consensus rules.
+ *  blockHeight is used to query the softfork manager; pass INT32_MAX to always enforce. */
+bool CheckColorIdentifierValidity(const CTransaction& tx, CValidationState& state, CCoinsViewCache &inputs, int32_t blockHeight = INT32_MAX);
 
-/** Check token input and output amounts within a trasnaction */
-bool VerifyTokenBalances(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAmount minrelayFee, std::set<ColorIdentifier>* newIssuances = nullptr);
+/** Check token input and output amounts within a transaction.
+ *  blockHeight is used to query the softfork manager; pass INT32_MAX to always enforce. */
+bool VerifyTokenBalances(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAmount minrelayFee, std::set<ColorIdentifier>* newIssuances = nullptr, int32_t blockHeight = INT32_MAX);
 
 /** Replay blocks that aren't fully applied to the database. */
 bool ReplayBlocks(CCoinsView* view);

--- a/src/validation.h
+++ b/src/validation.h
@@ -443,6 +443,7 @@ static const unsigned int REJECT_HIGHFEE = 0x100;
 CBlockFileInfo* GetBlockFileInfo(size_t n);
 
 unsigned int GetBlockScriptFlags(const CBlockIndex* pindex);
+unsigned int GetBlockScriptFlags(int32_t blockHeight);
 
 //! Check whether the block associated with this index entry is pruned or not.
 inline bool IsBlockPruned(const CBlockIndex* pblockindex)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4280,12 +4280,12 @@ UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& script,
     if (!pwallet->IsLocked())
         pwallet->TopUpKeyPool();
 
-    // Reuse an existing CColorScriptID for this color if one is already in the
+    // Reuse an existing CColorKeyID for this color if one is already in the
     // address book (happens on reissue). This prevents duplicate table entries.
     CTxDestination colorDest;
     bool foundExisting = false;
     for (const auto& entry : pwallet->mapAddressBook) {
-        const CColorScriptID* existing = std::get_if<CColorScriptID>(&entry.first);
+        const CColorKeyID* existing = std::get_if<CColorKeyID>(&entry.first);
         if (existing && existing->color == coin_control.m_colorId) {
             colorDest = *existing;
             foundExisting = true;
@@ -4300,9 +4300,7 @@ UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& script,
             throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
 
         CKeyID key_id = newKey.GetID();
-        CScript redeemScript = GetScriptForDestination(key_id);
-        CColorScriptID colorscriptid(CScriptID(redeemScript), coin_control.m_colorId);
-        colorDest = CColorScriptID(colorscriptid, coin_control.m_colorId);
+        colorDest = CColorKeyID(key_id, coin_control.m_colorId);
     }
 
     // Verify the wallet is still unlocked before committing any transaction.
@@ -4413,9 +4411,7 @@ UniValue IssueToken(CWallet* const pwallet, CAmount tokenValue, CCoinControl& co
     }
 
     CKeyID key_id = newKey.GetID();
-    CScript redeemScript = GetScriptForDestination(key_id);
-    CColorScriptID colorscriptid(CScriptID(redeemScript), coin_control.m_colorId);
-    CTxDestination colorDest = CColorScriptID(colorscriptid, coin_control.m_colorId);
+    CTxDestination colorDest = CColorKeyID(key_id, coin_control.m_colorId);
 
     CScript scriptpubkey = GetScriptForDestination(colorDest);
     pwallet->SetAddressBook(colorDest, coin_control.m_colorId.toHexString(), "receive");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2881,7 +2881,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
                 entry.pushKV("label", i->second.name);
             }
 
-            if (scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsColoredPayToScriptHash()) {
+            if (scriptPubKey.IsPayToScriptHash()) {
                 const CScriptID& hash = std::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwallet->GetCScript(hash, redeemScript)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2881,7 +2881,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
                 entry.pushKV("label", i->second.name);
             }
 
-            if (scriptPubKey.IsPayToScriptHash()) {
+            if (scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsColoredPayToScriptHash()) {
                 const CScriptID& hash = std::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwallet->GetCScript(hash, redeemScript)) {

--- a/src/wallet/test/test_tapyrus_wallet.cpp
+++ b/src/wallet/test/test_tapyrus_wallet.cpp
@@ -136,7 +136,7 @@ bool TestWalletSetup::IssueNonReissunableColoredCoin(const CAmount amount, Color
     issueTx.vout[0].nValue = amount;
     issueTx.vout[0].scriptPubKey = GetScriptForDestination(colorkeyid);
     {
-        LOCK(wallet->cs_wallet);
+        LOCK2(cs_main, wallet->cs_wallet);
         if(!wallet->SignTransaction(issueTx)) {
             return false;
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2543,7 +2543,11 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
 
 bool CWallet::SignTransaction(CMutableTransaction &tx)
 {
+    AssertLockHeld(cs_main);
     AssertLockHeld(cs_wallet); // mapWallet
+
+    unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+    if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
 
     // sign the new tx
     int nIn = 0;
@@ -2555,9 +2559,6 @@ bool CWallet::SignTransaction(CMutableTransaction &tx)
         const CScript& scriptPubKey = mi->second.tx->vout[input.prevout.n].scriptPubKey;
         const CAmount& amount = mi->second.tx->vout[input.prevout.n].nValue;
         SignatureData sigdata;
-        AssertLockHeld(cs_main);
-        unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
-        if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
         if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&tx, nIn, amount, SIGHASH_ALL), scriptPubKey, sigdata, signVerifyFlags)) {
             return false;
         }
@@ -3073,14 +3074,15 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
 
         if (sign)
         {
+            AssertLockHeld(cs_main);
+            unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+            if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
+
             int nIn = 0;
             for (const auto& coin : selected_coins)
             {
                 const CScript& scriptPubKey = coin.txout.scriptPubKey;
                 SignatureData sigdata;
-                AssertLockHeld(cs_main);
-                unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
-                if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
                 if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&txNew, nIn, coin.txout.nValue, SIGHASH_ALL), scriptPubKey, sigdata, signVerifyFlags))
                 {
                     strFailReason = _("Signing transaction failed");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2555,8 +2555,9 @@ bool CWallet::SignTransaction(CMutableTransaction &tx)
         const CScript& scriptPubKey = mi->second.tx->vout[input.prevout.n].scriptPubKey;
         const CAmount& amount = mi->second.tx->vout[input.prevout.n].nValue;
         SignatureData sigdata;
+        AssertLockHeld(cs_main);
         unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
-        { LOCK(cs_main); if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED; }
+        if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
         if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&tx, nIn, amount, SIGHASH_ALL), scriptPubKey, sigdata, signVerifyFlags)) {
             return false;
         }
@@ -3077,8 +3078,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
             {
                 const CScript& scriptPubKey = coin.txout.scriptPubKey;
                 SignatureData sigdata;
+                AssertLockHeld(cs_main);
                 unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
-                { LOCK(cs_main); if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED; }
+                if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED;
                 if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&txNew, nIn, coin.txout.nValue, SIGHASH_ALL), scriptPubKey, sigdata, signVerifyFlags))
                 {
                     strFailReason = _("Signing transaction failed");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -16,6 +16,7 @@
 #include <key.h>
 #include <key_io.h>
 #include <keystore.h>
+#include <softforkmanager.h>
 #include <validation.h>
 #include <net.h>
 #include <policy/fees.h>
@@ -2554,7 +2555,9 @@ bool CWallet::SignTransaction(CMutableTransaction &tx)
         const CScript& scriptPubKey = mi->second.tx->vout[input.prevout.n].scriptPubKey;
         const CAmount& amount = mi->second.tx->vout[input.prevout.n].nValue;
         SignatureData sigdata;
-        if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&tx, nIn, amount, SIGHASH_ALL), scriptPubKey, sigdata)) {
+        unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+        { LOCK(cs_main); if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED; }
+        if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&tx, nIn, amount, SIGHASH_ALL), scriptPubKey, sigdata, signVerifyFlags)) {
             return false;
         }
         UpdateInput(input, sigdata);
@@ -3074,8 +3077,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
             {
                 const CScript& scriptPubKey = coin.txout.scriptPubKey;
                 SignatureData sigdata;
-
-                if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&txNew, nIn, coin.txout.nValue, SIGHASH_ALL), scriptPubKey, sigdata))
+                unsigned int signVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+                { LOCK(cs_main); if (GetSoftForkManager().IsActive(SCRIPT_VERIFY_CP2SH_COLORED, chainActive.Height() + 1)) signVerifyFlags |= SCRIPT_VERIFY_CP2SH_COLORED; }
+                if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&txNew, nIn, coin.txout.nValue, SIGHASH_ALL), scriptPubKey, sigdata, signVerifyFlags))
                 {
                     strFailReason = _("Signing transaction failed");
                     return false;

--- a/test/functional/feature_cp2sh_softfork.py
+++ b/test/functional/feature_cp2sh_softfork.py
@@ -17,9 +17,9 @@ evaluation for colored P2SH outputs:
     The redeemScript must also evaluate to true.  The same transaction is
     rejected; a spend with OP_1 (truthy) is accepted.
 
-The -cp2shcoloredactivationheight hidden argument overrides the per-network
-default so the test can exercise the transition without mining hundreds of
-thousands of blocks.
+Requires CP2SH_ACTIVATION_TEST_HEIGHT=120 to be defined at compile time
+(set by the CI build) so the activation boundary can be crossed without
+mining hundreds of thousands of blocks.
 """
 
 import struct
@@ -56,7 +56,6 @@ class CP2SHSoftforkTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        # No extra_args needed: CP2SH_ACTIVATION_TEST_HEIGHT=120 is compiled in by CI.
 
     # ------------------------------------------------------------------ helpers
 
@@ -104,24 +103,43 @@ class CP2SHSoftforkTest(BitcoinTestFramework):
         assert signed['complete'], "Signing failed: %s" % signed.get('errors')
         return FromHex(CTransaction(), signed['hex']), cid
 
-    def _spend_cp2sh(self, issue_tx, vout, redeem_bytes):
+    def _spend_cp2sh(self, issue_tx, vout, redeem_bytes, tpc_utxo):
         """
         Build a spending transaction for a CP2SH colored UTXO.
 
-        scriptSig = push(redeemScript bytes only):
+        Includes a TPC fee input (tpc_utxo) — VerifyTokenBalances requires
+        tpcin > 0 for any transaction that moves colored coins.
+
+        scriptSig for the colored input = push(redeemScript bytes only):
           pre-activation  — hash matches → accepted (no redeem-script eval)
           post-activation — hash matches then redeemScript is evaluated;
                             OP_0 (falsy) will cause rejection, OP_1 passes.
 
         The colored tokens are burned (OP_RETURN output with 0 value).
         """
+        node = self.nodes[0]
+        fee = 10_000
+        change = int(tpc_utxo['amount'] * COIN) - fee
+
         tx = CTransaction()
         tx.nFeatures = 1
+        # Input 0: the CP2SH colored coin (scriptSig = push(redeemScript))
         tx.vin.append(CTxIn(
             COutPoint(int(issue_tx.hashMalFix, 16), vout),
             CScript([redeem_bytes]),
         ))
+        # Input 1: TPC input to satisfy the fee requirement
+        tx.vin.append(CTxIn(COutPoint(int(tpc_utxo['txid'], 16), tpc_utxo['vout'])))
+        # Output 0: burn the colored tokens
         tx.vout.append(CTxOut(0, CScript([OP_RETURN])))
+        # Output 1: TPC change
+        tx.vout.append(CTxOut(change, CScript(hex_str_to_bytes(tpc_utxo['scriptPubKey']))))
+
+        # Let the wallet sign the TPC input; it will skip the colored input.
+        signed = node.signrawtransactionwithwallet(ToHex(tx))
+        tx = FromHex(CTransaction(), signed['hex'])
+        # Restore the colored input's scriptSig (wallet may have cleared it).
+        tx.vin[0].scriptSig = CScript([redeem_bytes])
         return tx
 
     # ------------------------------------------------------------------ test
@@ -155,7 +173,12 @@ class CP2SHSoftforkTest(BitcoinTestFramework):
         self._wrap_submit(issue_pre)                          # block 102
         issue_pre.rehash()
 
-        spend_pre = self._spend_cp2sh(issue_pre, 0, bad_redeem)
+        # Get a fresh TPC UTXO (change from issue_pre is now confirmed).
+        fee_utxo_pre = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )[0]
+        spend_pre = self._spend_cp2sh(issue_pre, 0, bad_redeem, fee_utxo_pre)
         self._wrap_submit(spend_pre)                          # block 103 — must succeed
         self.log.info("  ✓ accepted at block %d" % node.getblockcount())
 
@@ -181,14 +204,21 @@ class CP2SHSoftforkTest(BitcoinTestFramework):
         self.log.info("Issued bad/good CP2SH UTXOs at activation block %d" % ACTIVATION_HEIGHT)
 
         # ── post-activation: bad redeemScript rejected ───────────────────────
+        # Get fresh TPC UTXOs for the post-activation spends.
+        fee_utxos_post = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )
         self.log.info("Post-activation: spend with OP_0 redeemScript rejected")
-        spend_bad = self._spend_cp2sh(issue_bad, 0, bad_redeem)
-        self._wrap_submit(spend_bad, expect_reject="mandatory-script-verify-flag-failed")
+        spend_bad = self._spend_cp2sh(issue_bad, 0, bad_redeem, fee_utxos_post[0])
+        self._wrap_submit(spend_bad, expect_reject="block-validation-failed")
         self.log.info("  ✓ rejected (chain stays at block %d)" % node.getblockcount())
 
         # ── post-activation: valid redeemScript accepted ─────────────────────
+        # spend_bad's block was rejected so fee_utxos_post[0] is still unspent;
+        # use a different UTXO for spend_good to avoid any double-spend risk.
         self.log.info("Post-activation: spend with OP_1 redeemScript accepted")
-        spend_good = self._spend_cp2sh(issue_good, 0, good_redeem)
+        spend_good = self._spend_cp2sh(issue_good, 0, good_redeem, fee_utxos_post[1])
         self._wrap_submit(spend_good)                         # must succeed
         self.log.info("  ✓ accepted at block %d" % node.getblockcount())
 

--- a/test/functional/feature_cp2sh_softfork.py
+++ b/test/functional/feature_cp2sh_softfork.py
@@ -33,7 +33,7 @@ from test_framework.script import (
     hash160,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, bytes_to_hex_str, hex_str_to_bytes
+from test_framework.util import assert_equal, assert_raises_rpc_error, bytes_to_hex_str, hex_str_to_bytes
 
 # Activation height used throughout the test.  Low enough to reach quickly.
 ACTIVATION_HEIGHT = 120
@@ -182,11 +182,45 @@ class CP2SHSoftforkTest(BitcoinTestFramework):
         self._wrap_submit(spend_pre)                          # block 103 — must succeed
         self.log.info("  ✓ accepted at block %d" % node.getblockcount())
 
-        # ── advance to activation height - 1 ────────────────────────────────
-        blocks_needed = ACTIVATION_HEIGHT - 1 - node.getblockcount()
+        # ── advance to activation height - 2 ────────────────────────────────
+        # Stop one block early so we can confirm a boundary CP2SH UTXO at
+        # exactly ACTIVATION_HEIGHT - 1 and then test mempool admission there.
+        blocks_needed = ACTIVATION_HEIGHT - 2 - node.getblockcount()
         if blocks_needed > 0:
             node.generate(blocks_needed, self.signblockprivkey_wif)
+        assert_equal(node.getblockcount(), ACTIVATION_HEIGHT - 2)
+
+        # ── mempool boundary: tip == ACTIVATION_HEIGHT - 1 ──────────────────
+        # Confirm a CP2SH UTXO with bad redeemScript (OP_0) at block
+        # ACTIVATION_HEIGHT - 1, then attempt to spend it via sendrawtransaction
+        # while the tip is still at that height.
+        #
+        # With the fix (mempoolScriptFlags queried at tip+1 = ACTIVATION_HEIGHT),
+        # SCRIPT_VERIFY_CP2SH_COLORED is already active and the tx is rejected at
+        # mempool admission with mandatory-script-verify-flag-failed.
+        # Without the fix the tx would be admitted and only fail when the
+        # activation block tries to include it.
+        tpc_boundary = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )[0]
+        boundary_issue, _ = self._issue_cp2sh(tpc_boundary, bad_redeem)
+        self._wrap_submit(boundary_issue)                       # block ACTIVATION_HEIGHT - 1
         assert_equal(node.getblockcount(), ACTIVATION_HEIGHT - 1)
+        boundary_issue.rehash()
+
+        fee_boundary = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )[0]
+        boundary_spend = self._spend_cp2sh(boundary_issue, 0, bad_redeem, fee_boundary)
+
+        self.log.info("Boundary: mempool rejects bad redeemScript at tip == ACTIVATION_HEIGHT - 1")
+        assert_raises_rpc_error(
+            -26, "mandatory-script-verify-flag-failed",
+            node.sendrawtransaction, ToHex(boundary_spend),
+        )
+        self.log.info("  ✓ rejected at mempool admission (not deferred to block validation)")
 
         # ── issue post-activation UTXOs at the activation block ─────────────
         # Get fresh UTXOs (earlier ones may be spent or confirmed as change).

--- a/test/functional/feature_cp2sh_softfork.py
+++ b/test/functional/feature_cp2sh_softfork.py
@@ -29,7 +29,8 @@ from test_framework.messages import (
     COIN, COutPoint, CTransaction, CTxIn, CTxOut, FromHex, ToHex, sha256,
 )
 from test_framework.script import (
-    CScript, OP_0, OP_1, OP_COLOR, OP_EQUAL, OP_HASH160, OP_RETURN,
+    CScript, OP_0, OP_1, OP_CHECKSIG, OP_COLOR, OP_DUP, OP_EQUAL,
+    OP_EQUALVERIFY, OP_HASH160, OP_RETURN,
     hash160,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -141,6 +142,72 @@ class CP2SHSoftforkTest(BitcoinTestFramework):
         # Restore the colored input's scriptSig (wallet may have cleared it).
         tx.vin[0].scriptSig = CScript([redeem_bytes])
         return tx
+
+    # ------------------------------------------------------------------ helpers (continued)
+
+    def _test_signrpc_cp2sh(self):
+        """
+        regression: signrawtransactionwithkey must produce a valid
+        CP2SH colored signature post-activation and the result must be accepted
+        by sendrawtransaction
+        """
+        node = self.nodes[0]
+        assert node.getblockcount() >= ACTIVATION_HEIGHT, "must run post-activation"
+
+        # Derive a key from the wallet; build a P2PKH redeemScript around it.
+        addr = node.getnewaddress()
+        pubkey = hex_str_to_bytes(node.getaddressinfo(addr)['pubkey'])
+        privkey = node.dumpprivkey(addr)
+        redeem_bytes = bytes(CScript([
+            OP_DUP, OP_HASH160, hash160(pubkey), OP_EQUALVERIFY, OP_CHECKSIG,
+        ]))
+
+        # Issue a CP2SH colored output using this redeemScript.
+        utxo = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )[0]
+        issue_tx, colorid = self._issue_cp2sh(utxo, redeem_bytes)
+        self._wrap_submit(issue_tx)
+        issue_tx.rehash()
+
+        # TPC fee input for the spend.
+        fee_utxo = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )[0]
+        fee_privkey = node.dumpprivkey(fee_utxo['address'])
+        fee = 10_000
+        change = int(fee_utxo['amount'] * COIN) - fee
+
+        # Build raw spend (burn the colored tokens, keep TPC change).
+        spend_tx = CTransaction()
+        spend_tx.nFeatures = 1
+        spend_tx.vin.append(CTxIn(COutPoint(int(issue_tx.hashMalFix, 16), 0)))
+        spend_tx.vin.append(CTxIn(COutPoint(int(fee_utxo['txid'], 16), fee_utxo['vout'])))
+        spend_tx.vout.append(CTxOut(0, CScript([OP_RETURN])))
+        spend_tx.vout.append(CTxOut(change, CScript(hex_str_to_bytes(fee_utxo['scriptPubKey']))))
+
+        cp2sh_spk = _cp2sh_colored_spk(colorid, redeem_bytes)
+        prevtxs = [{
+            'txid': issue_tx.hashMalFix,
+            'vout': 0,
+            'scriptPubKey': bytes_to_hex_str(bytes(cp2sh_spk)),
+            'redeemScript': bytes_to_hex_str(redeem_bytes),
+            'amount': 100 / COIN,
+        }]
+
+        # Sign both inputs with their respective private keys.
+        # signrawtransactionwithkey goes through the SignTransaction() helper
+        # in rawtransaction.cpp — exactly the path fixed for signrpc_cp2sh.
+        signed = node.signrawtransactionwithkey(ToHex(spend_tx), [privkey, fee_privkey], prevtxs)
+        assert signed['complete'], "signrpc_cp2sh regression: signing incomplete: %s" % signed.get('errors')
+
+        # The critical assertion: 'complete': true is not enough.
+        # The signed tx must actually be accepted by the network.
+        txid = node.sendrawtransaction(signed['hex'])
+        assert txid, "signrpc_cp2sh regression: sendrawtransaction rejected signed tx"
+        self.log.info("  ✓ signrpc_cp2sh: signrawtransactionwithkey produces valid CP2SH colored signature post-activation")
 
     # ------------------------------------------------------------------ test
 
@@ -255,6 +322,10 @@ class CP2SHSoftforkTest(BitcoinTestFramework):
         spend_good = self._spend_cp2sh(issue_good, 0, good_redeem, fee_utxos_post[1])
         self._wrap_submit(spend_good)                         # must succeed
         self.log.info("  ✓ accepted at block %d" % node.getblockcount())
+
+        # ── signrpc_cp2sh regression: RPC signing path is activation-aware ─────────────
+        self.log.info("signrpc_cp2sh regression: signrawtransactionwithkey is activation-aware")
+        self._test_signrpc_cp2sh()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_cp2sh_softfork.py
+++ b/test/functional/feature_cp2sh_softfork.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Chaintope Inc.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+CP2SH colored coin softfork activation test.
+
+Verifies that SCRIPT_VERIFY_CP2SH_COLORED correctly gates redeem-script
+evaluation for colored P2SH outputs:
+
+  Before activation height
+    Only the OP_HASH160 equality check is enforced.  A spending transaction
+    whose scriptSig pushes a redeemScript whose hash matches but whose body
+    evaluates to false (OP_0) is accepted.
+
+  At and after activation height
+    The redeemScript must also evaluate to true.  The same transaction is
+    rejected; a spend with OP_1 (truthy) is accepted.
+
+The -cp2shcoloredactivationheight hidden argument overrides the per-network
+default so the test can exercise the transition without mining hundreds of
+thousands of blocks.
+"""
+
+import struct
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import (
+    COIN, COutPoint, CTransaction, CTxIn, CTxOut, FromHex, ToHex, sha256,
+)
+from test_framework.script import (
+    CScript, OP_0, OP_1, OP_COLOR, OP_EQUAL, OP_HASH160, OP_RETURN,
+    hash160,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, bytes_to_hex_str, hex_str_to_bytes
+
+# Activation height used throughout the test.  Low enough to reach quickly.
+ACTIVATION_HEIGHT = 120
+
+NON_REISSUABLE = 0xc2
+
+
+def _color_id(txid_hex, vout):
+    """NON_REISSUABLE colorId: 0xc2 || sha256(outpoint_le)."""
+    txid_le = hex_str_to_bytes(txid_hex)[::-1]
+    return bytes([NON_REISSUABLE]) + sha256(txid_le + struct.pack('<I', vout))
+
+
+def _cp2sh_colored_spk(colorid_bytes, redeem_bytes):
+    """OP_COLOR <colorid> OP_HASH160 <hash160(redeemScript)> OP_EQUAL"""
+    return CScript([colorid_bytes, OP_COLOR, OP_HASH160, hash160(redeem_bytes), OP_EQUAL])
+
+
+class CP2SHSoftforkTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        # No extra_args needed: CP2SH_ACTIVATION_TEST_HEIGHT=120 is compiled in by CI.
+
+    # ------------------------------------------------------------------ helpers
+
+    def _wrap_submit(self, *txs, expect_reject=None):
+        """Wrap one or more transactions in a block and call submitblock."""
+        node = self.nodes[0]
+        tip = node.getbestblockhash()
+        height = node.getblockcount() + 1
+        cb = create_coinbase(height)
+        blk = create_block(int(tip, 16), cb, node.getblock(tip)['time'] + 1)
+        for tx in txs:
+            tx.rehash()
+            blk.vtx.append(tx)
+        blk.hashMerkleRoot = blk.calc_merkle_root()
+        blk.hashImMerkleRoot = blk.calc_immutable_merkle_root()
+        blk.solve(self.signblockprivkey)
+        result = node.submitblock(bytes_to_hex_str(blk.serialize()))
+        if expect_reject is None:
+            assert result is None, "Block unexpectedly rejected: %s" % result
+        else:
+            assert expect_reject in (result or ''), \
+                "Expected '%s' in submitblock result, got: %s" % (expect_reject, result)
+
+    def _issue_cp2sh(self, utxo, redeem_bytes):
+        """
+        Build and wallet-sign a NON_REISSUABLE issuance that creates a single
+        CP2SH colored output (100 satoshis / 100 tokens).
+
+        Returns (CTransaction, colorid_bytes).  The wallet signs only the TPC
+        input; the colored output needs no signature at creation time.
+        """
+        node = self.nodes[0]
+        cid = _color_id(utxo['txid'], utxo['vout'])
+        spk = _cp2sh_colored_spk(cid, redeem_bytes)
+        fee = 10_000
+        change = int(utxo['amount'] * COIN) - 100 - fee
+
+        tx = CTransaction()
+        tx.nFeatures = 1
+        tx.vin.append(CTxIn(COutPoint(int(utxo['txid'], 16), utxo['vout'])))
+        tx.vout.append(CTxOut(100, spk))
+        tx.vout.append(CTxOut(change, CScript(hex_str_to_bytes(utxo['scriptPubKey']))))
+
+        signed = node.signrawtransactionwithwallet(ToHex(tx))
+        assert signed['complete'], "Signing failed: %s" % signed.get('errors')
+        return FromHex(CTransaction(), signed['hex']), cid
+
+    def _spend_cp2sh(self, issue_tx, vout, redeem_bytes):
+        """
+        Build a spending transaction for a CP2SH colored UTXO.
+
+        scriptSig = push(redeemScript bytes only):
+          pre-activation  — hash matches → accepted (no redeem-script eval)
+          post-activation — hash matches then redeemScript is evaluated;
+                            OP_0 (falsy) will cause rejection, OP_1 passes.
+
+        The colored tokens are burned (OP_RETURN output with 0 value).
+        """
+        tx = CTransaction()
+        tx.nFeatures = 1
+        tx.vin.append(CTxIn(
+            COutPoint(int(issue_tx.hashMalFix, 16), vout),
+            CScript([redeem_bytes]),
+        ))
+        tx.vout.append(CTxOut(0, CScript([OP_RETURN])))
+        return tx
+
+    # ------------------------------------------------------------------ test
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Mine enough blocks for coinbase maturity.
+        node.generate(101, self.signblockprivkey_wif)
+        assert_equal(node.getblockcount(), 101)
+
+        # Two distinct TPC UTXOs for the two issuance transactions.
+        tpc_utxos = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )
+
+        # redeemScript that evaluates to false: OP_0 pushes [] (falsy).
+        bad_redeem  = bytes(CScript([OP_0]))   # b'\x00'
+        # redeemScript that evaluates to true: OP_1 pushes 1 (truthy).
+        good_redeem = bytes(CScript([OP_1]))   # b'\x51'
+
+        # ── pre-activation ──────────────────────────────────────────────────
+        # Issue a CP2SH colored output with a bad redeemScript (OP_0).
+        # Spending it before the activation height must succeed because only
+        # the hash comparison is enforced.
+
+        self.log.info("Pre-activation: spend with OP_0 redeemScript accepted (hash-match only)")
+
+        issue_pre, _ = self._issue_cp2sh(tpc_utxos[0], bad_redeem)
+        self._wrap_submit(issue_pre)                          # block 102
+        issue_pre.rehash()
+
+        spend_pre = self._spend_cp2sh(issue_pre, 0, bad_redeem)
+        self._wrap_submit(spend_pre)                          # block 103 — must succeed
+        self.log.info("  ✓ accepted at block %d" % node.getblockcount())
+
+        # ── advance to activation height - 1 ────────────────────────────────
+        blocks_needed = ACTIVATION_HEIGHT - 1 - node.getblockcount()
+        if blocks_needed > 0:
+            node.generate(blocks_needed, self.signblockprivkey_wif)
+        assert_equal(node.getblockcount(), ACTIVATION_HEIGHT - 1)
+
+        # ── issue post-activation UTXOs at the activation block ─────────────
+        # Get fresh UTXOs (earlier ones may be spent or confirmed as change).
+        tpc_utxos_post = sorted(
+            [u for u in node.listunspent() if u.get('token') == 'TPC'],
+            key=lambda u: u['amount'], reverse=True,
+        )
+        issue_bad,  _ = self._issue_cp2sh(tpc_utxos_post[0], bad_redeem)
+        issue_good, _ = self._issue_cp2sh(tpc_utxos_post[1], good_redeem)
+
+        # Both issuances go in block ACTIVATION_HEIGHT.
+        self._wrap_submit(issue_bad, issue_good)
+        assert_equal(node.getblockcount(), ACTIVATION_HEIGHT)
+        issue_bad.rehash(); issue_good.rehash()
+        self.log.info("Issued bad/good CP2SH UTXOs at activation block %d" % ACTIVATION_HEIGHT)
+
+        # ── post-activation: bad redeemScript rejected ───────────────────────
+        self.log.info("Post-activation: spend with OP_0 redeemScript rejected")
+        spend_bad = self._spend_cp2sh(issue_bad, 0, bad_redeem)
+        self._wrap_submit(spend_bad, expect_reject="mandatory-script-verify-flag-failed")
+        self.log.info("  ✓ rejected (chain stays at block %d)" % node.getblockcount())
+
+        # ── post-activation: valid redeemScript accepted ─────────────────────
+        self.log.info("Post-activation: spend with OP_1 redeemScript accepted")
+        spend_good = self._spend_cp2sh(issue_good, 0, good_redeem)
+        self._wrap_submit(spend_good)                         # must succeed
+        self.log.info("  ✓ accepted at block %d" % node.getblockcount())
+
+
+if __name__ == '__main__':
+    CP2SHSoftforkTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -182,6 +182,7 @@ BASE_SCRIPTS = [
     'feature_help.py',
     'feature_help.py --usecli',
     'feature_coloredcoin.py',
+    'feature_cp2sh_softfork.py',
     'rpc_dumptxoutset.py',
     'feature_reindex_outoforder_block.py'
     # Don't append tests at the end to avoid merge conflicts

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -77,16 +77,16 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[1].generatetoaddress(1, RANDOM_COINBASE_ADDRESS, self.signblockprivkey_wif)
         self.sync_all()
 
-        assert_equal(self.nodes[0].getbalance(), Decimal('49.99995520'))
+        assert_equal(self.nodes[0].getbalance(), Decimal('49.99995480'))
         wallet_bal = self.nodes[0].getwalletinfo()['balance']
         assert_equal(wallet_bal[colorid1], 100)
-        assert_equal(self.nodes[1].getbalance(), Decimal('49.99995520'))
+        assert_equal(self.nodes[1].getbalance(), Decimal('49.99995480'))
         wallet_bal = self.nodes[1].getwalletinfo()['balance']
         assert_equal(wallet_bal[colorid2], 100)
 
         self.log.info("Test getbalance with different arguments")
-        assert_equal(self.nodes[0].getbalance(True), Decimal('49.99995520'))
-        assert_equal(self.nodes[1].getbalance(True), Decimal('49.99995520'))
+        assert_equal(self.nodes[0].getbalance(True), Decimal('49.99995480'))
+        assert_equal(self.nodes[1].getbalance(True), Decimal('49.99995480'))
 
         # Send 40 TPC from 0 to 1 and 60 BTC from 1 to 0.
         txs = create_transactions(self.nodes[0], 'TPC', self.nodes[1].getnewaddress(), 40, [Decimal('0.01')])
@@ -162,7 +162,7 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(wallet_bal[colorid2], 100)
 
         # Send total balance away from node 1
-        txs = create_transactions(self.nodes[1], 'TPC', self.nodes[0].getnewaddress(), Decimal('29.94995520'), [Decimal('0.01')])
+        txs = create_transactions(self.nodes[1], 'TPC', self.nodes[0].getnewaddress(), Decimal('29.94995480'), [Decimal('0.01')])
         self.nodes[1].sendrawtransaction(txs[0]['hex'])
         self.nodes[1].generatetoaddress(2, RANDOM_COINBASE_ADDRESS, self.signblockprivkey_wif)
         self.sync_all()

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -353,6 +353,7 @@ def test_bumpfee_no_tpc_change(rbf_node, peer_node, signblockprivkey_wif):
 
 
 
+
 def spend_one_input(node, dest_address):
     tx_input = dict(
         sequence=BIP125_SEQUENCE_NUMBER, **next(u for u in node.listunspent() if u["amount"] == Decimal("0.00100000")))

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -352,6 +352,7 @@ def test_bumpfee_no_tpc_change(rbf_node, peer_node, signblockprivkey_wif):
     assert_equal(rbf_node.getwalletinfo()['balance'][color], 100)
 
 
+
 def spend_one_input(node, dest_address):
     tx_input = dict(
         sequence=BIP125_SEQUENCE_NUMBER, **next(u for u in node.listunspent() if u["amount"] == Decimal("0.00100000")))


### PR DESCRIPTION
Introduces CSoftForkManager with HeightActivation functor to manage per-network softfork activation without scattering #ifdefs through validation logic.

Key design decisions:
- CSoftFork stores a HeightActivation functor (operator()) as the canonical activation predicate; no raw lambdas at call sites.
- Manager stores only networks with deferred activation (Chaintope testnet 1939510133 at block 261594). All other networks activate CP2SH colored from genesis — IsActive returns true when no entry is found.
- VerifyScript no longer hardcodes (flags & SCRIPT_VERIFY_CP2SH_COLORED); it calls FederationParams().SoftForkManager().IsEnforced() so all softfork-dependent code goes through the manager API.
- CI builds inject -DCP2SH_ACTIVATION_TEST_HEIGHT=120 via CMake so feature_cp2sh_softfork.py can exercise the pre/post-activation transition at a low block height. GUIX/release builds never define this macro; production testnet activates at 261594.

New files:
  src/softforkmanager.h          — HeightActivation, CSoftFork, CSoftForkManager
  test/functional/feature_cp2sh_softfork.py — activation transition test