### PR TITLE
Accept arm64 or aarch64 as the arch type in depends build

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -1,7 +1,12 @@
-# Strip Darwin version suffix from build triplet so native-build detection works.
-# config.guess returns e.g. arm64-apple-darwin24.5.0 while HOST is arm64-apple-darwin,
-# so strip the trailing version to make the $(host) == $(build) comparison succeed.
-build:=$(shell echo "$(build)" | sed 's/\(.*-apple-darwin\)[0-9.]*$$/\1/')
+# Normalize the build triplet so native-build detection works.
+# config.guess on Apple Silicon returns aarch64-apple-darwin25.x.x; the CI sets
+# HOST=arm64-apple-darwin (from uname -m).  Two normalizations are needed:
+#   1. Strip the Darwin version suffix (24.5.0 → nothing)
+#   2. Rename aarch64 → arm64 to match the HOST naming convention
+# Without both, $(host) != $(build) and a native arm64 build is wrongly treated
+# as cross-compilation, causing the GNU-only `sed -i` in qt.mk to run under
+# BSD sed and fail with "extra characters at the end of q command".
+build:=$(shell echo "$(build)" | sed 's/\(.*-apple-darwin\)[0-9.]*$$/\1/' | sed 's/^aarch64-apple-darwin$$/arm64-apple-darwin/')
 
 build_darwin_CC:=$(shell xcrun -f clang) -isysroot$(shell xcrun --show-sdk-path)
 build_darwin_CXX:=$(shell xcrun -f clang++) -isysroot$(shell xcrun --show-sdk-path)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -270,10 +270,15 @@ ifeq ($(host),$(build))
 endif
 # Fix CGDisplayCreateImageForRect obsoleted in macOS 15.0
 # Comment out the call and return empty pixmap (screen grab will fail gracefully)
-# Only needed for cross-compilation (native macOS builds use BSD sed which requires -i '')
+# Cross-compilation only (native darwin builds already satisfy host==build and are excluded).
+# BSD sed (build machine is macOS) needs -i '' while GNU sed (Linux build machine) uses -i.
 ifeq ($(host_os),darwin)
 ifneq ($(host),$(build))
+ifeq ($(build_os),darwin)
+  $(package)_preprocess_cmds += && sed -i '' 's/CGDisplayCreateImageForRect(displayId, grabRect.toCGRect())/nullptr \/* CGDisplayCreateImageForRect obsoleted in macOS 15 *\//' qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
+else
   $(package)_preprocess_cmds += && sed -i 's/CGDisplayCreateImageForRect(displayId, grabRect.toCGRect())/nullptr \/* CGDisplayCreateImageForRect obsoleted in macOS 15 *\//' qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
+endif
 endif
 endif
 


### PR DESCRIPTION
When CI was running on macos-14 (darwin24), and config.guess there returned `arm64-apple-darwin24..`
GitHub Actions recently upgraded macos-latest to macOS 15 (darwin25). On macOS 15, the newer config.guess switched to the GNU canonical name `aarch64-apple-darwin25...` So the build is not identified correctly.