### PR TITLE
V72 423 vulnerability fix

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -1,7 +1,12 @@
-# Strip Darwin version suffix from build triplet so native-build detection works.
-# config.guess returns e.g. arm64-apple-darwin24.5.0 while HOST is arm64-apple-darwin,
-# so strip the trailing version to make the $(host) == $(build) comparison succeed.
-build:=$(shell echo "$(build)" | sed 's/\(.*-apple-darwin\)[0-9.]*$$/\1/')
+# Normalize the build triplet so native-build detection works.
+# config.guess on Apple Silicon returns aarch64-apple-darwin25.x.x; the CI sets
+# HOST=arm64-apple-darwin (from uname -m).  Two normalizations are needed:
+#   1. Strip the Darwin version suffix (24.5.0 → nothing)
+#   2. Rename aarch64 → arm64 to match the HOST naming convention
+# Without both, $(host) != $(build) and a native arm64 build is wrongly treated
+# as cross-compilation, causing the GNU-only `sed -i` in qt.mk to run under
+# BSD sed and fail with "extra characters at the end of q command".
+build:=$(shell echo "$(build)" | sed 's/\(.*-apple-darwin\)[0-9.]*$$/\1/' | sed 's/^aarch64-apple-darwin$$/arm64-apple-darwin/')
 
 build_darwin_CC:=$(shell xcrun -f clang) -isysroot$(shell xcrun --show-sdk-path)
 build_darwin_CXX:=$(shell xcrun -f clang++) -isysroot$(shell xcrun --show-sdk-path)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -270,10 +270,15 @@ ifeq ($(host),$(build))
 endif
 # Fix CGDisplayCreateImageForRect obsoleted in macOS 15.0
 # Comment out the call and return empty pixmap (screen grab will fail gracefully)
-# Only needed for cross-compilation (native macOS builds use BSD sed which requires -i '')
+# Cross-compilation only (native darwin builds already satisfy host==build and are excluded).
+# BSD sed (build machine is macOS) needs -i '' while GNU sed (Linux build machine) uses -i.
 ifeq ($(host_os),darwin)
 ifneq ($(host),$(build))
+ifeq ($(build_os),darwin)
+  $(package)_preprocess_cmds += && sed -i '' 's/CGDisplayCreateImageForRect(displayId, grabRect.toCGRect())/nullptr \/* CGDisplayCreateImageForRect obsoleted in macOS 15 *\//' qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
+else
   $(package)_preprocess_cmds += && sed -i 's/CGDisplayCreateImageForRect(displayId, grabRect.toCGRect())/nullptr \/* CGDisplayCreateImageForRect obsoleted in macOS 15 *\//' qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
+endif
 endif
 endif
 

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -625,13 +625,13 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         if (!tx.IsCoinBase())
         {
             if (!Consensus::CheckTxInputs(tx, state, view, pindex->nHeight, txfee)) {
-                // Capture the inner reject code and reason set by CheckTxInputs before
-                // state.DoS() overwrites them, so the specific reason is preserved.
-                unsigned int innerCode = state.GetRejectCode();
-                std::string innerReason = state.GetRejectReason();
-                return state.DoS(100, error("%s: Consensus::CheckTxInputs: %s, %s", __func__,
-                                            tx.GetHashMalFix().ToString(), FormatStateMessage(state)),
-                                 innerCode, innerReason);
+                // Do not add to the DoS score already set by CheckTxInputs.
+                // "bad-txns-premature-spend-of-coinbase" deliberately uses DoS=0
+                // (via state.Invalid) so that a peer relaying a block during a
+                // reorg race is not banned.  Calling state.DoS(100,...) here
+                // would accumulate on top of that and cause an unjust instant ban.
+                return error("%s: Consensus::CheckTxInputs: %s, %s", __func__,
+                             tx.GetHashMalFix().ToString(), FormatStateMessage(state));
             }
             nFees += txfee;
             if (!MoneyRange(nFees)) {

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -18,6 +18,7 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <atomic>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -81,11 +82,16 @@ struct AuthFailState {
 };
 
 // Max number of IP entries kept in the backoff table.
-// When exceeded, expired entries are pruned; if still over, all are cleared.
+// When exceeded, expired entries are pruned; if still over, the worst offender is evicted.
 static constexpr size_t AUTH_FAIL_CACHE_MAX = 1024;
 
 static Mutex g_auth_fail_mutex;
 static std::map<std::string, AuthFailState> g_failed_auths GUARDED_BY(g_auth_fail_mutex);
+// Mirror of g_failed_auths.size(), readable without the mutex for the success-path fast path.
+// All writes are performed under g_auth_fail_mutex; only the lock-free read on the success
+// path races — a stale zero causes a missed erase (entry expires naturally) and a stale
+// nonzero causes a no-op erase under the lock.  Both are harmless.
+static std::atomic<size_t> g_failed_auths_size{0};
 
 // Backoff for the n-th consecutive failure: 250ms, 500ms, 1s, … capped at 32s.
 static int64_t AuthBackoffMs(int n)
@@ -199,42 +205,58 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
     if (!RPCAuthorized(authHeader.second, jreq.authUser)) {
         const std::string peerIP = peer.ToStringIP();
         const int64_t now = GetTimeMillis();
-        LOCK(g_auth_fail_mutex);
-        // Keep the table bounded: first remove expired entries, then if still full
-        // evict the single entry whose backoff expires soonest (cheapest to lose).
-        // Never clear() the entire table — that would let an attacker with 1025 IPs
-        // reset all throttled peers simultaneously.
-        if (g_failed_auths.size() >= AUTH_FAIL_CACHE_MAX) {
-            for (auto it = g_failed_auths.begin(); it != g_failed_auths.end(); ) {
-                it = (it->second.next_allowed_ms <= now) ? g_failed_auths.erase(it) : ++it;
-            }
+        bool in_backoff = false;
+        {
+            LOCK(g_auth_fail_mutex);
+            // Keep the table bounded: first remove expired entries, then if still full
+            // evict the worst offender (largest next_allowed_ms = deepest backoff).
+            // Evicting the highest-backoff entry removes an attacker, preserving
+            // legitimate users whose backoff is smallest.  Never clear() the entire
+            // table — that would let an attacker with 1025 IPs reset all throttled
+            // peers simultaneously.
             if (g_failed_auths.size() >= AUTH_FAIL_CACHE_MAX) {
-                auto victim = std::min_element(g_failed_auths.begin(), g_failed_auths.end(),
-                    [](const auto& a, const auto& b) {
-                        return a.second.next_allowed_ms < b.second.next_allowed_ms;
-                    });
-                g_failed_auths.erase(victim);
+                for (auto it = g_failed_auths.begin(); it != g_failed_auths.end(); ) {
+                    if (it->second.next_allowed_ms <= now) {
+                        it = g_failed_auths.erase(it);
+                        --g_failed_auths_size;
+                    } else {
+                        ++it;
+                    }
+                }
+                if (g_failed_auths.size() >= AUTH_FAIL_CACHE_MAX) {
+                    auto victim = std::max_element(g_failed_auths.begin(), g_failed_auths.end(),
+                        [](const auto& a, const auto& b) {
+                            return a.second.next_allowed_ms < b.second.next_allowed_ms;
+                        });
+                    g_failed_auths.erase(victim);
+                    --g_failed_auths_size;
+                }
             }
+            auto [it, inserted] = g_failed_auths.emplace(peerIP, AuthFailState{});
+            if (inserted) ++g_failed_auths_size;
+            AuthFailState& state = it->second;
+            if (now < state.next_allowed_ms) {
+                in_backoff = true;
+            } else {
+                state.consecutive++;
+                state.next_allowed_ms = now + AuthBackoffMs(state.consecutive);
+            }
+        } // g_auth_fail_mutex released; I/O runs unlocked
+        if (!in_backoff) {
+            LogPrintf("ThreadRPCServer incorrect password attempt from %s\n", jreq.peerAddr);
         }
-        AuthFailState& state = g_failed_auths[peerIP];
-        if (now < state.next_allowed_ms) {
-            // Within backoff window: reject silently (suppress log spam)
-            req->WriteHeader("WWW-Authenticate", WWW_AUTH_HEADER_DATA);
-            req->WriteReply(HTTP_UNAUTHORIZED);
-            return false;
-        }
-        state.consecutive++;
-        state.next_allowed_ms = now + AuthBackoffMs(state.consecutive);
-        LogPrintf("ThreadRPCServer incorrect password attempt from %s\n", jreq.peerAddr);
         req->WriteHeader("WWW-Authenticate", WWW_AUTH_HEADER_DATA);
         req->WriteReply(HTTP_UNAUTHORIZED);
         return false;
     }
-    // Successful auth: clear any backoff for this IP
-    {
+    // Successful auth: clear any backoff for this IP.
+    // Fast path: skip the lock entirely when the table is empty (common case for
+    // legitimate users who have never triggered a failure entry).
+    if (g_failed_auths_size.load(std::memory_order_relaxed) > 0) {
         const std::string peerIP = peer.ToStringIP();
         LOCK(g_auth_fail_mutex);
-        g_failed_auths.erase(peerIP);
+        if (g_failed_auths.erase(peerIP))
+            --g_failed_auths_size;
     }
 
     try {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1993,6 +1993,14 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         std::vector<CAddress> vAddr;
         vRecv >> vAddr;
 
+        // Skip address processing when the address book is already well-populated.
+        // We stop issuing GETADDR once the book exceeds 1000 entries (see VERACK handler
+        // above), so any ADDR arriving after that point is an unsolicited push we don't
+        // need.  The early return avoids the shuffle + token-bucket loop on up to 1000
+        // entries per message.
+        if (connman->GetAddressCount() > MAX_ADDR_TO_SEND)
+            return true;
+
         if (vAddr.size() > MAX_ADDR_TO_SEND)
         {
             LOCK(cs_main);
@@ -2679,6 +2687,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     } else {
                         // Give up for this peer and wait for other peer(s)
                         MarkBlockAsReceived(pindex->GetBlockHash(), pfrom->GetId());
+                        return true;
                     }
                 }
                 std::vector<CTransactionRef> dummy;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -214,7 +214,7 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
             cond_blockchange.wait(lock, [&block]{return latestblock.height != block.height || latestblock.hash != block.hash || !IsRPCRunning(); });
         } else {
             // Negative timeout clamps to 0: polls once and returns immediately (preserves pre-audit script behavior).
-            const int64_t ms = std::max(0LL, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
+            const int64_t ms = std::max((int64_t)0, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
             cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&block]{return latestblock.height != block.height || latestblock.hash != block.hash || !IsRPCRunning(); });
         }
         block = latestblock;
@@ -258,7 +258,7 @@ static UniValue waitforblock(const JSONRPCRequest& request)
             cond_blockchange.wait(lock, [&hash]{return latestblock.hash == hash || !IsRPCRunning(); });
         } else {
             // Negative timeout clamps to 0: polls once and returns immediately (preserves pre-audit script behavior).
-            const int64_t ms = std::max(0LL, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
+            const int64_t ms = std::max((int64_t)0, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
             cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&hash]{return latestblock.hash == hash || !IsRPCRunning();});
         }
         block = latestblock;
@@ -304,7 +304,7 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
             cond_blockchange.wait(lock, [&height]{return latestblock.height >= height || !IsRPCRunning(); });
         } else {
             // Negative timeout clamps to 0: polls once and returns immediately (preserves pre-audit script behavior).
-            const int64_t ms = std::max(0LL, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
+            const int64_t ms = std::max((int64_t)0, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
             cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&height]{return latestblock.height >= height || !IsRPCRunning();});
         }
         block = latestblock;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -192,7 +192,7 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
             "\nWaits for a specific new block and returns useful info about it.\n"
             "\nReturns the current block on timeout or exit.\n"
             "\nArguments:\n"
-            "1. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values are rejected.\n"
+            "1. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values return immediately.\n"
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"hash\" : {       (string) The blockhash\n"
@@ -205,10 +205,7 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
     int timeout = 0;
     if (!request.params[0].isNull())
         timeout = request.params[0].get_int();
-    if (timeout < 0)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "timeout must be non-negative (0 means wait indefinitely)");
 
-    const int64_t effective_timeout = timeout > 0 ? timeout : MAX_WAIT_FOR_BLOCK_MS;
     CUpdatedBlock block;
     {
         std::unique_lock<std::mutex> lock(cs_blockchange);
@@ -216,7 +213,8 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
         if (timeout == 0) {
             cond_blockchange.wait(lock, [&block]{return latestblock.height != block.height || latestblock.hash != block.hash || !IsRPCRunning(); });
         } else {
-            const int64_t ms = std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS);
+            // Negative timeout clamps to 0: polls once and returns immediately (preserves pre-audit script behavior).
+            const int64_t ms = std::max(0LL, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
             cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&block]{return latestblock.height != block.height || latestblock.hash != block.hash || !IsRPCRunning(); });
         }
         block = latestblock;
@@ -236,7 +234,7 @@ static UniValue waitforblock(const JSONRPCRequest& request)
             "\nReturns the current block on timeout or exit.\n"
             "\nArguments:\n"
             "1. \"blockhash\" (required, string) Block hash to wait for.\n"
-            "2. timeout       (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values are rejected.\n"
+            "2. timeout       (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values return immediately.\n"
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"hash\" : {       (string) The blockhash\n"
@@ -252,17 +250,15 @@ static UniValue waitforblock(const JSONRPCRequest& request)
 
     if (!request.params[1].isNull())
         timeout = request.params[1].get_int();
-    if (timeout < 0)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "timeout must be non-negative (0 means wait indefinitely)");
 
-    const int64_t effective_timeout = timeout > 0 ? timeout : MAX_WAIT_FOR_BLOCK_MS;
     CUpdatedBlock block;
     {
         std::unique_lock<std::mutex> lock(cs_blockchange);
         if (timeout == 0) {
             cond_blockchange.wait(lock, [&hash]{return latestblock.hash == hash || !IsRPCRunning(); });
         } else {
-            const int64_t ms = std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS);
+            // Negative timeout clamps to 0: polls once and returns immediately (preserves pre-audit script behavior).
+            const int64_t ms = std::max(0LL, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
             cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&hash]{return latestblock.hash == hash || !IsRPCRunning();});
         }
         block = latestblock;
@@ -284,7 +280,7 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
             "\nReturns the current block on timeout or exit.\n"
             "\nArguments:\n"
             "1. height  (required, int) Block height to wait for (int)\n"
-            "2. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values are rejected.\n"
+            "2. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values return immediately.\n"
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"hash\" : {       (string) The blockhash\n"
@@ -300,17 +296,15 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
 
     if (!request.params[1].isNull())
         timeout = request.params[1].get_int();
-    if (timeout < 0)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "timeout must be non-negative (0 means wait indefinitely)");
 
-    const int64_t effective_timeout = timeout > 0 ? timeout : MAX_WAIT_FOR_BLOCK_MS;
     CUpdatedBlock block;
     {
         std::unique_lock<std::mutex> lock(cs_blockchange);
         if (timeout == 0) {
             cond_blockchange.wait(lock, [&height]{return latestblock.height >= height || !IsRPCRunning(); });
         } else {
-            const int64_t ms = std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS);
+            // Negative timeout clamps to 0: polls once and returns immediately (preserves pre-audit script behavior).
+            const int64_t ms = std::max(0LL, std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS));
             cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&height]{return latestblock.height >= height || !IsRPCRunning();});
         }
         block = latestblock;
@@ -2293,10 +2287,11 @@ static UniValue dumptxoutset(const JSONRPCRequest& request)
             const fs::path canonical_parent = fs::canonical(parent);
             const fs::path canonical_datadir = fs::canonical(GetDataDir());
             // fs::relative returns ".." components when canonical_parent is outside
-            // canonical_datadir, so any result whose first component is ".." means
-            // the path escapes the data directory.
+            // canonical_datadir, or an empty path when the two roots differ (e.g.
+            // different drive letters on Windows).  Either case means the path
+            // escapes the data directory.
             const fs::path rel = fs::relative(canonical_parent, canonical_datadir);
-            if (!rel.empty() && *rel.begin() == "..") {
+            if (rel.empty() || *rel.begin() == "..") {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Path resolves outside the data directory");
             }
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -179,9 +179,10 @@ void RPCNotifyBlockChange(bool ibd, const CBlockIndex * pindex)
     cond_blockchange.notify_all();
 }
 
-// Maximum wait for the wait* RPCs when caller passes timeout=0.
-// Prevents indefinite thread-pool exhaustion via concurrent wait calls.
-static constexpr int64_t MAX_WAIT_FOR_BLOCK_MS = 10 * 60 * 1000; // 10 minutes
+// Maximum milliseconds any wait* RPC will block a thread.  Callers may pass
+// a smaller positive timeout; larger values are silently capped.  Zero means
+// "wait indefinitely" (the documented default) and is NOT capped.
+static const int64_t MAX_WAIT_FOR_BLOCK_MS = 600000; // 10 minutes
 
 static UniValue waitfornewblock(const JSONRPCRequest& request)
 {
@@ -191,7 +192,7 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
             "\nWaits for a specific new block and returns useful info about it.\n"
             "\nReturns the current block on timeout or exit.\n"
             "\nArguments:\n"
-            "1. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout.\n"
+            "1. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values are rejected.\n"
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"hash\" : {       (string) The blockhash\n"
@@ -204,13 +205,20 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
     int timeout = 0;
     if (!request.params[0].isNull())
         timeout = request.params[0].get_int();
+    if (timeout < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "timeout must be non-negative (0 means wait indefinitely)");
 
     const int64_t effective_timeout = timeout > 0 ? timeout : MAX_WAIT_FOR_BLOCK_MS;
     CUpdatedBlock block;
     {
         std::unique_lock<std::mutex> lock(cs_blockchange);
         block = latestblock;
-        cond_blockchange.wait_for(lock, std::chrono::milliseconds(effective_timeout), [&block]{return latestblock.height != block.height || latestblock.hash != block.hash || !IsRPCRunning(); });
+        if (timeout == 0) {
+            cond_blockchange.wait(lock, [&block]{return latestblock.height != block.height || latestblock.hash != block.hash || !IsRPCRunning(); });
+        } else {
+            const int64_t ms = std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS);
+            cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&block]{return latestblock.height != block.height || latestblock.hash != block.hash || !IsRPCRunning(); });
+        }
         block = latestblock;
     }
     UniValue ret(UniValue::VOBJ);
@@ -228,7 +236,7 @@ static UniValue waitforblock(const JSONRPCRequest& request)
             "\nReturns the current block on timeout or exit.\n"
             "\nArguments:\n"
             "1. \"blockhash\" (required, string) Block hash to wait for.\n"
-            "2. timeout       (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout.\n"
+            "2. timeout       (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values are rejected.\n"
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"hash\" : {       (string) The blockhash\n"
@@ -244,12 +252,19 @@ static UniValue waitforblock(const JSONRPCRequest& request)
 
     if (!request.params[1].isNull())
         timeout = request.params[1].get_int();
+    if (timeout < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "timeout must be non-negative (0 means wait indefinitely)");
 
     const int64_t effective_timeout = timeout > 0 ? timeout : MAX_WAIT_FOR_BLOCK_MS;
     CUpdatedBlock block;
     {
         std::unique_lock<std::mutex> lock(cs_blockchange);
-        cond_blockchange.wait_for(lock, std::chrono::milliseconds(effective_timeout), [&hash]{return latestblock.hash == hash || !IsRPCRunning();});
+        if (timeout == 0) {
+            cond_blockchange.wait(lock, [&hash]{return latestblock.hash == hash || !IsRPCRunning(); });
+        } else {
+            const int64_t ms = std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS);
+            cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&hash]{return latestblock.hash == hash || !IsRPCRunning();});
+        }
         block = latestblock;
     }
 
@@ -269,7 +284,7 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
             "\nReturns the current block on timeout or exit.\n"
             "\nArguments:\n"
             "1. height  (required, int) Block height to wait for (int)\n"
-            "2. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout.\n"
+            "2. timeout (int, optional, default=0) Time in milliseconds to wait for a response. 0 indicates no timeout. Positive values are capped at 600000 (10 min). Negative values are rejected.\n"
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"hash\" : {       (string) The blockhash\n"
@@ -285,12 +300,19 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
 
     if (!request.params[1].isNull())
         timeout = request.params[1].get_int();
+    if (timeout < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "timeout must be non-negative (0 means wait indefinitely)");
 
     const int64_t effective_timeout = timeout > 0 ? timeout : MAX_WAIT_FOR_BLOCK_MS;
     CUpdatedBlock block;
     {
         std::unique_lock<std::mutex> lock(cs_blockchange);
-        cond_blockchange.wait_for(lock, std::chrono::milliseconds(effective_timeout), [&height]{return latestblock.height >= height || !IsRPCRunning();});
+        if (timeout == 0) {
+            cond_blockchange.wait(lock, [&height]{return latestblock.height >= height || !IsRPCRunning(); });
+        } else {
+            const int64_t ms = std::min((int64_t)timeout, MAX_WAIT_FOR_BLOCK_MS);
+            cond_blockchange.wait_for(lock, std::chrono::milliseconds(ms), [&height]{return latestblock.height >= height || !IsRPCRunning();});
+        }
         block = latestblock;
     }
     UniValue ret(UniValue::VOBJ);

--- a/src/test/chainstate_tests.cpp
+++ b/src/test/chainstate_tests.cpp
@@ -21,6 +21,7 @@
 #include <test/test_tapyrus.h>
 #include <validation.h>
 #include <consensus/validation.h>
+#include <consensus/tx_verify.h>
 #include <coins.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -933,6 +934,140 @@ BOOST_AUTO_TEST_CASE(duplicate_nonreissuable_issuance_rejected)
         BOOST_CHECK(!valid);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-colorid-already-issued");
     }
+}
+
+/**
+ * Regression test: VerifyTokenBalances must not use DoS=100 for tpcin<=0.
+ *
+ * PR #423 (TXV-4) changed "bad-txns-token-without-fee" from state.Invalid()
+ * (DoS=0) to state.DoS(100).  VerifyTokenBalances is called from both the
+ * mempool path (AcceptToMemoryPoolWorker) and ConnectBlock.
+ *
+ * In the mempool path, DoS=100 causes an instant ban of any peer that relays a
+ * colored-coin transfer with no TPC input — a fee-policy violation, not a
+ * consensus crime.  ConnectBlock already applies DoS=100 via its own wrapper
+ * (chainstate.cpp lines 701-703), so the in-function bump adds no extra
+ * consensus protection.
+ *
+ * The fix reverts the call to state.Invalid(false, REJECT_INSUFFICIENTFEE, ...)
+ * so that mempool rejection preserves DoS=0 (no peer ban) while block-level
+ * enforcement remains unchanged.
+ */
+BOOST_AUTO_TEST_CASE(verifytoken_no_tpc_input_dos_score_is_zero)
+{
+    // Build a colored CP2PKH UTXO with no TPC inputs.
+    CKey key;
+    key.MakeNewKey(true);
+    CPubKey pubkey = key.GetPubKey();
+    std::vector<unsigned char> pubkeyHash(20);
+    CHash160().Write(pubkey.data(), pubkey.size()).Finalize(pubkeyHash.data());
+
+    // Arbitrary outpoint used only to derive the colorId (not validated here).
+    COutPoint definingOutpoint(InsecureRand256(), 0);
+    ColorIdentifier colorId(definingOutpoint, TokenTypes::REISSUABLE);
+
+    // CP2PKH colored script: <colorId> OP_COLOR OP_DUP OP_HASH160 <hash> OP_EQUALVERIFY OP_CHECKSIG
+    CScript coloredScript = CScript() << colorId.toVector() << OP_COLOR
+                                      << OP_DUP << OP_HASH160
+                                      << ToByteVector(pubkeyHash)
+                                      << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    COutPoint coloredOutpoint(InsecureRand256(), 0);
+    CCoinsView dummy;
+    CCoinsViewCache view(&dummy);
+    {
+        Coin coin;
+        coin.out.scriptPubKey = coloredScript;
+        coin.out.nValue       = 100 * CENT;
+        coin.nHeight          = 5;
+        coin.fCoinBase        = false;
+        view.AddCoin(coloredOutpoint, std::move(coin), /*potential_overwrite=*/false);
+    }
+
+    // Tx: one colored coin input, one colored coin output — no TPC inputs.
+    CMutableTransaction tx;
+    tx.nFeatures = 1;
+    tx.vin.resize(1);
+    tx.vin[0].prevout = coloredOutpoint;
+    tx.vout.resize(1);
+    tx.vout[0].nValue       = 100 * CENT;
+    tx.vout[0].scriptPubKey = coloredScript;
+
+    CValidationState state;
+    CAmount minRelayFee = 1000;
+    bool ok = VerifyTokenBalances(CTransaction(tx), state, view, minRelayFee);
+
+    // Must be rejected …
+    BOOST_CHECK(!ok);
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-token-without-fee");
+
+    // … but with DoS=0 so that relaying peers are not banned.
+    int nDoS = -1;
+    state.IsInvalid(nDoS);
+    BOOST_CHECK_EQUAL(nDoS, 0);
+}
+
+/**
+ * Regression test: ConnectBlock must not escalate the DoS score set by CheckTxInputs.
+ *
+ * "bad-txns-premature-spend-of-coinbase" is set via state.Invalid() (DoS=0) so
+ * that a peer relaying a block during a reorg race is not banned.  A previous
+ * commit (CC-2/TXV-4) wrapped the CheckTxInputs call with state.DoS(100,...),
+ * which accumulated on top of that 0 and caused an unjust instant ban.
+ *
+ * The fix reverts ConnectBlock to plain error() which does not touch state.
+ * This test verifies the DoS score for a premature coinbase spend is exactly 0.
+ */
+BOOST_AUTO_TEST_CASE(connectblock_premature_coinbase_dos_score_is_zero)
+{
+    // Build a synthetic CCoinsViewCache containing one coinbase coin at height H.
+    const int coinbaseHeight = 10;
+
+    CMutableTransaction coinbaseTx;
+    coinbaseTx.nFeatures = 1;
+    coinbaseTx.vin.resize(1);
+    coinbaseTx.vin[0].prevout.SetNull();
+    coinbaseTx.vin[0].scriptSig = CScript() << coinbaseHeight << OP_0;
+    coinbaseTx.vout.resize(1);
+    coinbaseTx.vout[0].nValue = 50 * COIN;
+    coinbaseTx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+
+    COutPoint coinbaseOutpoint(CTransaction(coinbaseTx).GetHashMalFix(), 0);
+
+    CCoinsView dummy;
+    CCoinsViewCache view(&dummy);
+    {
+        Coin coin;
+        coin.out   = coinbaseTx.vout[0];
+        coin.nHeight    = coinbaseHeight;
+        coin.fCoinBase  = true;
+        view.AddCoin(coinbaseOutpoint, std::move(coin), /*potential_overwrite=*/false);
+    }
+
+    // Create a transaction spending that coinbase in the same block (nSpendHeight == coinbaseHeight).
+    CMutableTransaction spendTx;
+    spendTx.nFeatures = 1;
+    spendTx.vin.resize(1);
+    spendTx.vin[0].prevout = coinbaseOutpoint;
+    spendTx.vout.resize(1);
+    spendTx.vout[0].nValue = 40 * COIN;
+    spendTx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+
+    CValidationState state;
+    CAmount txfee = 0;
+    bool ok = Consensus::CheckTxInputs(
+        CTransaction(spendTx), state, view, coinbaseHeight, txfee);
+
+    // Must be rejected as a premature spend …
+    BOOST_CHECK(!ok);
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-premature-spend-of-coinbase");
+
+    // … but with DoS=0 so that relaying peers are not banned.
+    int nDoS = -1;
+    state.IsInvalid(nDoS);
+    BOOST_CHECK_EQUAL(nDoS, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -174,4 +174,53 @@ BOOST_AUTO_TEST_CASE(boolargno)
     BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
 }
 
+// InterpretBool must accept common boolean word spellings in any case.
+// Previously std::from_chars silently returned 0 for non-numeric strings,
+// so -persistmempool=true (and similar) were silently treated as false.
+BOOST_AUTO_TEST_CASE(boolarg_word_spellings)
+{
+    SetupArgs({"-foo"});
+
+    // True spellings
+    for (const std::string& s : {"-foo=true", "-foo=True", "-foo=TRUE",
+                                  "-foo=yes",  "-foo=Yes",  "-foo=YES",
+                                  "-foo=on",   "-foo=On",   "-foo=ON"}) {
+        ResetArgs(s);
+        BOOST_CHECK_MESSAGE(gArgs.GetBoolArg("-foo", false), s + " should be true");
+        BOOST_CHECK_MESSAGE(gArgs.GetBoolArg("-foo", true),  s + " should be true");
+    }
+
+    // False spellings
+    for (const std::string& s : {"-foo=false", "-foo=False", "-foo=FALSE",
+                                  "-foo=no",    "-foo=No",    "-foo=NO",
+                                  "-foo=off",   "-foo=Off",   "-foo=OFF"}) {
+        ResetArgs(s);
+        BOOST_CHECK_MESSAGE(!gArgs.GetBoolArg("-foo", false), s + " should be false");
+        BOOST_CHECK_MESSAGE(!gArgs.GetBoolArg("-foo", true),  s + " should be false");
+    }
+
+    // Numeric values still work
+    ResetArgs("-foo=1");
+    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
+    ResetArgs("-foo=0");
+    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
+    ResetArgs("-foo=42");
+    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
+
+    // Unrecognised value is treated as false (with a logged warning)
+    ResetArgs("-foo=banana");
+    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
+    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+
+    // -nofoo=true negates correctly: InterpretBool("true")==true, then negated → false
+    SetupArgs({"-foo", "-bar"});
+    ResetArgs("-nofoo=true");
+    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
+
+    ResetArgs("-nofoo=false");
+    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
+    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -260,6 +260,9 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArg)
     const char* avail_args[] = {"-a", "-b", "-c", "-d", "-e", "-f"};
     const char *argv_test[] = {
         "ignored", "-a", "-nob", "-c=0", "-d=1", "-e=false", "-f=true"};
+    // Note: "-e=false" and "-f=true" now correctly parse as false/true.
+    // Previously std::from_chars returned 0 for non-numeric strings, silently
+    // treating both as false.  That bug is fixed in InterpretBool.
     std::string error;
     testArgs.SetupArgs(6, avail_args);
     testArgs.ParseParameters(7, (char**)argv_test, error);
@@ -289,8 +292,8 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArg)
     BOOST_CHECK(testArgs.GetBoolArg("-b", true) == false);
     BOOST_CHECK(testArgs.GetBoolArg("-c", true) == false);
     BOOST_CHECK(testArgs.GetBoolArg("-d", false) == true);
-    BOOST_CHECK(testArgs.GetBoolArg("-e", true) == false);
-    BOOST_CHECK(testArgs.GetBoolArg("-f", true) == false);
+    BOOST_CHECK(testArgs.GetBoolArg("-e", true) == false);   // "-e=false" → false
+    BOOST_CHECK(testArgs.GetBoolArg("-f", false) == true);   // "-f=true"  → true (was broken before)
 }
 
 BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -172,7 +172,7 @@ static bool InterpretBool(const std::string& strValue)
     auto iequals = [](const std::string& s, std::string_view lower) {
         if (s.size() != lower.size()) return false;
         for (size_t i = 0; i < lower.size(); ++i)
-            if (tolower((unsigned char)s[i]) != (unsigned char)lower[i]) return false;
+            if (ToLower((unsigned char)s[i]) != (unsigned char)lower[i]) return false;
         return true;
     };
     if (iequals(strValue, "true")  || iequals(strValue, "yes") || iequals(strValue, "on"))  return true;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -14,6 +14,7 @@
 #include <stdarg.h>
 #include <charconv>
 #include <fstream>
+#include <string_view>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>
@@ -164,10 +165,29 @@ static bool InterpretBool(const std::string& strValue)
 {
     if (strValue.empty())
         return true;
-    // Use std::from_chars for locale-independent conversion
+
+    // Case-insensitive match against common boolean words.
+    // Operators writing -arg=true / -arg=yes / -arg=on (or their negations)
+    // are a common and reasonable expectation.
+    auto iequals = [](const std::string& s, std::string_view lower) {
+        if (s.size() != lower.size()) return false;
+        for (size_t i = 0; i < lower.size(); ++i)
+            if (tolower((unsigned char)s[i]) != (unsigned char)lower[i]) return false;
+        return true;
+    };
+    if (iequals(strValue, "true")  || iequals(strValue, "yes") || iequals(strValue, "on"))  return true;
+    if (iequals(strValue, "false") || iequals(strValue, "no")  || iequals(strValue, "off")) return false;
+
+    // Numeric fallback: "1" → true, "0" → false.
+    // Validate the full string was consumed so "1abc" is not silently treated as 1.
     int val = 0;
-    std::from_chars(strValue.data(), strValue.data() + strValue.size(), val);
-    return (val != 0);
+    auto [ptr, ec] = std::from_chars(strValue.data(), strValue.data() + strValue.size(), val);
+    if (ec == std::errc{} && ptr == strValue.data() + strValue.size())
+        return val != 0;
+
+    // Unrecognised value: warn so the operator notices the misconfiguration.
+    LogPrintf("Warning: unrecognized boolean value '%s'; treating as false.\n", strValue);
+    return false;
 }
 
 /** Internal helper functions for ArgsManager */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -585,7 +585,7 @@ bool VerifyTokenBalances(const CTransaction& tx, CValidationState& state, const 
             tpcout = iter->second;
 
     if(tpcin <= 0)
-        return state.DoS(100, false, REJECT_INVALID, "bad-txns-token-without-fee");
+        return state.Invalid(false, REJECT_INSUFFICIENTFEE, "bad-txns-token-without-fee");
 
     for(auto& out:outColoredCoinBalances)
     {

--- a/src/verifydb.cpp
+++ b/src/verifydb.cpp
@@ -105,8 +105,12 @@ bool CVerifyDB::VerifyDB(CCoinsView *coinsview, int nCheckLevel, int nCheckDepth
                 nGoodTransactions += block.vtx.size();
             }
         }
-        if (ShutdownRequested())
+        if (ShutdownRequested()) {
+            LogPrintf("[ABORTED].\n");
+            LogPrintf("VerifyDB(): interrupted by shutdown at height %d — level-%i verification incomplete\n",
+                      pindex->nHeight, nCheckLevel);
             return true;
+        }
     }
     if (pindexFailure)
         return error("VerifyDB(): *** coin database inconsistencies found (last %i blocks, %i good transactions before that)\n", chainActive.Height() - pindexFailure->nHeight + 1, nGoodTransactions);
@@ -117,8 +121,12 @@ bool CVerifyDB::VerifyDB(CCoinsView *coinsview, int nCheckLevel, int nCheckDepth
     // check level 4: try reconnecting blocks
     if (nCheckLevel >= 4) {
         while (pindex != chainActive.Tip()) {
-            if (ShutdownRequested())
+            if (ShutdownRequested()) {
+                LogPrintf("[ABORTED].\n");
+                LogPrintf("VerifyDB(): interrupted by shutdown at height %d — level-4 reconnect incomplete\n",
+                          pindex->nHeight);
                 return true;
+            }
             uiInterface.ShowProgress(_("Verifying blocks..."), std::max(1, std::min(99, 100 - (int)(((double)(chainActive.Height() - pindex->nHeight)) / (double)nCheckDepth * 50))), false);
             pindex = chainActive.Next(pindex);
             CBlock block;

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -103,6 +103,31 @@ class HTTPBasicsTest (BitcoinTestFramework):
         out1 = conn.getresponse()
         assert_equal(out1.status, http.client.BAD_REQUEST)
 
+        # ------------------------------------------------------------------
+        # Auth backoff: wrong credentials must return 401 and correct
+        # credentials must remain accepted after a run of failures.
+        # ------------------------------------------------------------------
+        url0 = urllib.parse.urlparse(self.nodes[0].url)
+        bad_headers = {"Authorization": "Basic " + str_to_b64str(url0.username + ":wrong_password")}
+        good_headers = {"Authorization": "Basic " + str_to_b64str(url0.username + ":" + url0.password)}
+        body = '{"method": "getbestblockhash"}'
+
+        for _ in range(5):
+            conn = http.client.HTTPConnection(url0.hostname, url0.port)
+            conn.connect()
+            conn.request('POST', '/', body, bad_headers)
+            resp = conn.getresponse()
+            assert_equal(resp.status, http.client.UNAUTHORIZED)
+            conn.close()
+
+        # Correct credentials must still be accepted after the failures
+        conn = http.client.HTTPConnection(url0.hostname, url0.port)
+        conn.connect()
+        conn.request('POST', '/', body, good_headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status, http.client.OK)
+        conn.close()
+
 
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -243,6 +243,7 @@ class BlockchainTest(BitcoinTestFramework):
         node.add_p2p_connection(P2PInterface(node.time_to_connect))
 
         current_height = node.getblock(node.getbestblockhash())['height']
+        current_hash   = node.getbestblockhash()
 
         # Create a fork somewhere below our current height, invalidate the tip
         # of that fork, and then ensure that waitforblockheight still
@@ -275,6 +276,55 @@ class BlockchainTest(BitcoinTestFramework):
         assert_waitforheight(current_height - 1)
         assert_waitforheight(current_height)
         assert_waitforheight(current_height + 1)
+
+        # ---------------------------------------------------------------
+        # Security: negative timeout must be rejected with -8
+        # (previously -1 was silently treated as a non-blocking sentinel)
+        # ---------------------------------------------------------------
+        self.log.info("Test wait* RPCs reject negative timeouts")
+        for bad_timeout in (-1, -100, -2147483648):
+            assert_raises_rpc_error(-8, "timeout must be non-negative",
+                node.waitforblockheight, current_height + 1, bad_timeout)
+            assert_raises_rpc_error(-8, "timeout must be non-negative",
+                node.waitfornewblock, bad_timeout)
+            assert_raises_rpc_error(-8, "timeout must be non-negative",
+                node.waitforblock, current_hash, bad_timeout)
+
+        # ---------------------------------------------------------------
+        # Security: large positive timeout (INT_MAX ≈ 25 days) must be
+        # accepted but capped internally at MAX_WAIT_FOR_BLOCK_MS (10 min).
+        # When the condition is already satisfied the call returns
+        # immediately regardless of timeout value, so we can exercise the
+        # code path safely without waiting 10 minutes.
+        # ---------------------------------------------------------------
+        self.log.info("Test wait* RPCs cap large positive timeouts")
+        INT_MAX = 2147483647
+
+        # waitforblockheight: height already reached → immediate return
+        result = node.waitforblockheight(current_height, INT_MAX)
+        assert_equal(result['height'], current_height)
+
+        # waitforblock: hash is the current tip → immediate return
+        result = node.waitforblock(current_hash, INT_MAX)
+        assert_equal(result['height'], current_height)
+
+        # waitfornewblock: always waits for a block newer than the
+        # snapshot captured at call time, so use a 1 ms timeout to verify
+        # it returns promptly and returns current tip state on timeout.
+        result = node.waitfornewblock(1)
+        assert_equal(result['height'], current_height)
+
+        # ---------------------------------------------------------------
+        # Zero timeout (indefinite) returns immediately when condition
+        # is already satisfied (predicate check before first wait).
+        # ---------------------------------------------------------------
+        self.log.info("Test wait* RPCs with timeout=0 return immediately when condition is met")
+        assert_equal(
+            node.waitforblockheight(current_height, 0)['height'],
+            current_height)
+        assert_equal(
+            node.waitforblock(current_hash, 0)['height'],
+            current_height)
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -278,17 +278,22 @@ class BlockchainTest(BitcoinTestFramework):
         assert_waitforheight(current_height + 1)
 
         # ---------------------------------------------------------------
-        # Security: negative timeout must be rejected with -8
-        # (previously -1 was silently treated as a non-blocking sentinel)
+        # Negative timeout clamps to 0: a single non-blocking predicate
+        # check, returning immediately with current state instead of
+        # waiting (preserves pre-audit script semantics where -1 was used
+        # as a non-blocking poll sentinel).
         # ---------------------------------------------------------------
-        self.log.info("Test wait* RPCs reject negative timeouts")
+        self.log.info("Test wait* RPCs treat negative timeouts as immediate, non-blocking polls")
         for bad_timeout in (-1, -100, -2147483648):
-            assert_raises_rpc_error(-8, "timeout must be non-negative",
-                node.waitforblockheight, current_height + 1, bad_timeout)
-            assert_raises_rpc_error(-8, "timeout must be non-negative",
-                node.waitfornewblock, bad_timeout)
-            assert_raises_rpc_error(-8, "timeout must be non-negative",
-                node.waitforblock, current_hash, bad_timeout)
+            assert_equal(
+                node.waitforblockheight(current_height + 1, bad_timeout)['height'],
+                current_height)
+            assert_equal(
+                node.waitfornewblock(bad_timeout)['height'],
+                current_height)
+            assert_equal(
+                node.waitforblock(current_hash, bad_timeout)['height'],
+                current_height)
 
         # ---------------------------------------------------------------
         # Security: large positive timeout (INT_MAX ≈ 25 days) must be


### PR DESCRIPTION
Fix issues seen in Pr#423:

- H1 — `wait*` RPC 10-min cap only fires when `timeout <= 0`; `INT_MAX` bypass exhausts the RPC thread pool
- H2 — `-persistmempool=true` still silently disables mempool persistence
- M1 — HTTPAUTH backoff LRU eviction picks the wrong victim
- M4 — `ConnectBlock` DoS-score wrapper bans honest relayers on `bad-txns-premature-spend-of-coinbase`
- M5 — `VerifyTokenBalances` `tpcin <= 0` upgraded from DoS=0 → DoS=100 at mempool level
- And all low priority feedback

M2 - IPv6 is not supported in tapyrus p2p layer too. this should be a separate feature in HTTP and P2P layers.
M3 - restricting body size might affect genuine large transactions. we should identify attach using persistent high memory or cpu usage 
