### PR TITLE
Upgrade GitHub Actions from Node20 (@v4) to Node24 (@v5)

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -170,7 +170,7 @@ jobs:
       DEPENDS_DIR: ${{ github.workspace }}/depends
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Use manual input if provided, otherwise use current branch (for PRs) or master (for scheduled runs)
           ref: ${{ github.event.inputs.test_branch || github.ref || 'master' }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Restore Ccache cache
         id: ccache-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.CCACHE_DIR }}
           key: daily-${{ matrix.config.platform }}-${{ matrix.config.arch }}-${{ matrix.config.build_type }}-${{ matrix.config.enable_gui }}-${{ matrix.config.enable_usdt }}-${{ matrix.config.enable_wallet }}-ccache-${{ github.run_id }}
@@ -186,7 +186,7 @@ jobs:
 
       - name: Restore Depends cache
         id: depends-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.DEPENDS_DIR }}
           key: depends-v6-qt6-${{ matrix.config.platform }}-${{ matrix.config.arch }}-${{ hashFiles('depends/packages/*', 'depends/hosts/*.mk', 'depends/builders/*.mk', 'depends/funcs.mk', 'depends/toolchain.cmake.in', 'depends/patches/**') }}
@@ -195,7 +195,7 @@ jobs:
       - name: Restore Benchmark History cache
         if: (matrix.config.platform == 'linux' && matrix.config.arch == 'x86_64') || (matrix.config.platform == 'macos' && matrix.config.arch == 'arm64')
         id: benchmark-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/benchmark_results/data
           key: benchmark-history-${{ matrix.config.platform }}-${{ matrix.config.arch }}-${{ github.run_id }}
@@ -429,7 +429,7 @@ jobs:
 
       - name: Save Depends cache
         if: github.ref == 'refs/heads/master'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: ${{ env.DEPENDS_DIR }}
@@ -437,7 +437,7 @@ jobs:
 
       - name: Save Benchmark History cache
         if: always() && ((matrix.config.platform == 'linux' && matrix.config.arch == 'x86_64') || (matrix.config.platform == 'macos' && matrix.config.arch == 'arm64'))
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: ${{ github.workspace }}/benchmark_results/data
@@ -788,7 +788,7 @@ jobs:
           echo "---------------- DAILY TEST FINISHED ---------------------"
 
       - name: Save Ccache cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: steps.ccache-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
         continue-on-error: true
         with:
@@ -797,7 +797,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: daily-test-results-${{ matrix.config.name }}-${{ github.run_id }}
           path: |
@@ -809,7 +809,7 @@ jobs:
 
       - name: Upload coverage data
         if: matrix.config.build_type == 'Debug'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-data-${{ matrix.config.name }}-${{ github.run_id }}
           path: |
@@ -819,7 +819,7 @@ jobs:
 
       - name: Upload Windows binaries
         if: matrix.config.target_platform == 'windows' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tapyrus-windows-${{ matrix.config.target_arch }}-binaries-${{ github.run_id }}
           path: |
@@ -864,7 +864,7 @@ jobs:
 
       - name: Upload Core Dumps
         if: failure() && matrix.config.target_platform != 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: daily-core-dumps-${{ matrix.config.name }}-${{ github.run_id }}
           path: ${{ github.workspace }}/core_dumps/

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v4

--- a/.github/workflows/push_tapyrus-builder_image.yml
+++ b/.github/workflows/push_tapyrus-builder_image.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,7 +30,7 @@ jobs:
     name: Lint Check
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: false
@@ -85,14 +85,14 @@ jobs:
       BOOST_TEST_RANDOM: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Restore Ccache cache
         id: ccache-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.CCACHE_DIR }}
           key: smoke-${{ matrix.config.platform }}-${{ matrix.config.arch }}-ccache-${{ github.run_id }}
@@ -267,7 +267,7 @@ jobs:
           echo "---------------- SMOKE TEST COMPLETE ---------------------"
 
       - name: Save Ccache cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: steps.ccache-cache.outputs.cache-hit != 'true'
         continue-on-error: true
         with:
@@ -276,7 +276,7 @@ jobs:
 
       - name: Upload Windows binaries
         if: matrix.config.platform == 'windows' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tapyrus-windows-${{ matrix.config.arch }}-binaries
           path: |
@@ -286,7 +286,7 @@ jobs:
 
       - name: Upload test results
         if: matrix.config.platform != 'windows' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: smoke-test-results-${{ matrix.config.name }}
           path: |
@@ -332,7 +332,7 @@ jobs:
 
       - name: Upload Core Dumps
         if: failure() && matrix.config.platform != 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: smoke-core-dumps-${{ matrix.config.name }}
           path: ${{ github.workspace }}/core_dumps/


### PR DESCRIPTION
Edit daily ci on master branch so that #425 and #417can be re-run. Those CI are failing because the daily-ci is still run from master branch.