### PR TITLE
Fix native qt build and ci

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -523,24 +523,9 @@ jobs:
 
           # Common CMake configuration options
           CMAKE_OPTS=(
-            "-DENABLE_ZMQ=ON"
             "-DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}"
             -DCMAKE_PREFIX_PATH="$DEPENDS_PREFIX"
           )
-
-          # Set Qt6_DIR explicitly if GUI is enabled to help CMake find Qt6
-          if [ "${{ matrix.config.enable_gui }}" == "true" ]; then
-            QT6_CMAKE_DIR="$DEPENDS_PREFIX/lib/cmake/Qt6"
-            if [ -d "$QT6_CMAKE_DIR" ]; then
-              export Qt6_DIR="$QT6_CMAKE_DIR"
-              CMAKE_OPTS+=("-DQt6_DIR=$QT6_CMAKE_DIR")
-              echo "Set Qt6_DIR=$QT6_CMAKE_DIR"
-            else
-              echo "Warning: Qt6 CMake directory not found at $QT6_CMAKE_DIR"
-              echo "Contents of $DEPENDS_PREFIX/lib/cmake:"
-              ls -la "$DEPENDS_PREFIX/lib/cmake/" 2>/dev/null || echo "cmake directory not found"
-            fi
-          fi
 
           # Set test and benchmark options based on build type
           if [ "${{ matrix.config.target_platform }}" != "" ] && [ "${{ matrix.config.target_platform }}" != "${{ matrix.config.platform }}" ]; then
@@ -603,17 +588,9 @@ jobs:
             CMAKE_OPTS+=("-DWARN_INCOMPATIBLE_BDB=OFF")
           fi
 
-          # Set dependency paths for depends build
-          CMAKE_OPTS+=("-DBOOST_ROOT=$DEPENDS_PREFIX")
-          CMAKE_OPTS+=("-DBOOST_INCLUDEDIR=$DEPENDS_PREFIX/include")
-          CMAKE_OPTS+=("-DBOOST_LIBRARYDIR=$DEPENDS_PREFIX/lib")
-          CMAKE_OPTS+=("-DZEROMQ_ROOT=$DEPENDS_PREFIX")
-          CMAKE_OPTS+=("-DZEROMQ_INCLUDE_DIR=$DEPENDS_PREFIX/include")
-          CMAKE_OPTS+=("-DZEROMQ_LIBRARY=$DEPENDS_PREFIX/lib/libzmq.a")
-
-          # Set Berkeley DB paths if wallet is enabled
+          # Berkeley DB explicit include/lib paths (toolchain sets BerkeleyDB_ROOT
+          # but not the specific header/library paths).
           if [ "${{ matrix.config.enable_wallet }}" == "true" ]; then
-            CMAKE_OPTS+=("-DBerkeleyDB_ROOT=$DEPENDS_PREFIX")
             CMAKE_OPTS+=("-DBerkeleyDB_INCLUDE_DIR=$DEPENDS_PREFIX/include")
             CMAKE_OPTS+=("-DBerkeleyDB_LIBRARY=$DEPENDS_PREFIX/lib/libdb_cxx-4.8.a")
           fi

--- a/cmake/module/FindLibevent.cmake
+++ b/cmake/module/FindLibevent.cmake
@@ -53,6 +53,13 @@ find_package(Libevent ${Libevent_FIND_VERSION} QUIET
 
 include(FindPackageHandleStandardArgs)
 if(Libevent_FOUND)
+  # Promote config-mode imported targets to GLOBAL so target_compile_definitions
+  # and check_cxx_source_compiles (try_compile) can access them in cmake >= 3.28.
+  foreach(_comp IN LISTS _libevent_components)
+    if(TARGET libevent::${_comp})
+      set_target_properties(libevent::${_comp} PROPERTIES IMPORTED_GLOBAL TRUE)
+    endif()
+  endforeach()
   find_package_handle_standard_args(Libevent
     REQUIRED_VARS Libevent_DIR
     VERSION_VAR Libevent_VERSION
@@ -70,7 +77,9 @@ else()
 
     if(Libevent_${component}_LIBRARY AND Libevent_INCLUDE_DIR)
       if(NOT TARGET libevent::${component})
-        add_library(libevent::${component} UNKNOWN IMPORTED)
+        # GLOBAL is required for target_compile_definitions on imported targets
+        # and for check_cxx_source_compiles compatibility with cmake >= 3.28.
+        add_library(libevent::${component} UNKNOWN IMPORTED GLOBAL)
         set_target_properties(libevent::${component} PROPERTIES
           IMPORTED_LOCATION "${Libevent_${component}_LIBRARY}"
           INTERFACE_INCLUDE_DIRECTORIES "${Libevent_INCLUDE_DIR}"

--- a/cmake/module/FindQt.cmake
+++ b/cmake/module/FindQt.cmake
@@ -56,8 +56,12 @@ else()
 endif()
 
 include(FindPackageHandleStandardArgs)
+# Check Qt${Qt_FIND_VERSION_MAJOR}_FOUND (not just _DIR) so that a component
+# failure (e.g. Qt6::Core not created) properly propagates the error through
+# this MODULE wrapper rather than silently reporting "Found Qt" while Qt6_DIR
+# was cached from the toolchain.
 find_package_handle_standard_args(Qt
-  REQUIRED_VARS Qt${Qt_FIND_VERSION_MAJOR}_DIR
+  REQUIRED_VARS Qt${Qt_FIND_VERSION_MAJOR}_FOUND
   VERSION_VAR Qt${Qt_FIND_VERSION_MAJOR}_VERSION
 )
 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,5 +1,13 @@
 .NOTPARALLEL :
 
+# Harden: disable implicit rules/variables that can silently shadow our own.
+MAKEFLAGS += --no-builtin-rules --no-builtin-variables
+
+# Prevent command-line overrides (e.g. CC=..., HOST=...) from leaking into
+# package sub-makes via MAKEOVERRIDES/MAKEFLAGS.  Only the verbosity flag is
+# intentionally propagated.
+MAKEOVERRIDES := $(filter V=%,$(MAKEOVERRIDES))
+
 # Fix perl locale warnings during tar extraction and other commands
 export LC_ALL=C
 export LANG=C
@@ -20,7 +28,7 @@ FALLBACK_DOWNLOAD_PATH ?= https://s3-ap-northeast-1.amazonaws.com/repo.tapyrus.c
 C_STANDARD ?= c11
 CXX_STANDARD ?= c++20
 
-BUILD = $(shell ./config.guess)
+BUILD = $(shell unset CC CXX && ./config.guess)
 HOST ?= $(BUILD)
 PATCHES_PATH = $(BASEDIR)/patches
 BASEDIR = $(CURDIR)

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -1,12 +1,16 @@
 # Normalize the build triplet so native-build detection works.
-# config.guess on Apple Silicon returns aarch64-apple-darwin25.x.x; the CI sets
-# HOST=arm64-apple-darwin (from uname -m).  Two normalizations are needed:
+# config.guess on Apple Silicon returns aarch64-apple-darwin[version]; the CI
+# sets HOST=arm64-apple-darwin (from uname -m, no version).  Two normalizations:
 #   1. Strip the Darwin version suffix (24.5.0 → nothing)
 #   2. Rename aarch64 → arm64 to match the HOST naming convention
-# Without both, $(host) != $(build) and a native arm64 build is wrongly treated
-# as cross-compilation, causing the GNU-only `sed -i` in qt.mk to run under
-# BSD sed and fail with "extra characters at the end of q command".
-build:=$(shell echo "$(build)" | sed 's/\(.*-apple-darwin\)[0-9.]*$$/\1/' | sed 's/^aarch64-apple-darwin$$/arm64-apple-darwin/')
+# Use pure make variable operations (build_arch, build_vendor) instead of a
+# $(shell sed ...) pipeline: the pipeline is sensitive to which sed is first in
+# PATH after Homebrew auto-updates, causing intermittent CI failures.
+ifeq ($(build_arch),aarch64)
+build:=arm64-$(build_vendor)-darwin
+else
+build:=$(build_arch)-$(build_vendor)-darwin
+endif
 
 build_darwin_CC:=$(shell xcrun -f clang) -isysroot$(shell xcrun --show-sdk-path)
 build_darwin_CXX:=$(shell xcrun -f clang++) -isysroot$(shell xcrun --show-sdk-path)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -36,7 +36,7 @@ endef
 define fetch_file
     ( test -f $$($(1)_source_dir)/$(4) || \
     ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
-      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
+      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(4),$(4),$(5))))
 endef
 
 define int_get_build_recipe_hash
@@ -85,7 +85,7 @@ $(1)_download_path_fixed=$(subst :,\:,$$($(1)_download_path))
 #default commands
 # The default behavior for tar will try to set ownership when running as uid 0 and may not succeed, --no-same-owner disables this behavior
 $(1)_fetch_cmds ?= $(call fetch_file,$(1),$(subst \:,:,$$($(1)_download_path_fixed)),$$($(1)_download_file),$($(1)_file_name),$($(1)_sha256_hash))
-$(1)_extract_cmds ?= mkdir -p $$($(1)_extract_dir) && echo "$$($(1)_sha256_hash)  $$($(1)_source)" > $$($(1)_extract_dir)/.$$($(1)_file_name).hash &&  $(build_SHA256SUM) -c $$($(1)_extract_dir)/.$$($(1)_file_name).hash && tar --no-same-owner --strip-components=1 -x -f $$($(1)_source)
+$(1)_extract_cmds ?= mkdir -p $$($(1)_extract_dir) && echo "$$($(1)_sha256_hash)  $$($(1)_source)" > $$($(1)_extract_dir)/.$$($(1)_file_name).hash &&  $(build_SHA256SUM) -c $$($(1)_extract_dir)/.$$($(1)_file_name).hash && $(build_TAR) --no-same-owner --strip-components=1 -x -f $$($(1)_source)
 $(1)_preprocess_cmds ?= true
 $(1)_build_cmds ?= true
 $(1)_config_cmds ?= true
@@ -199,6 +199,7 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                CXXFLAGS="$$($(1)_cppflags) $$($(1)_cxxflags)" \
                LDFLAGS="$$($(1)_ldflags)" \
                cmake -G "Unix Makefiles" \
+               -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY:BOOL=TRUE \
                -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" \
                -DCMAKE_AR=`which $$($(1)_ar)` \
                -DCMAKE_NM=`which $$($(1)_nm)` \
@@ -243,7 +244,7 @@ $($(1)_preprocessed): | $($(1)_extracted)
 	touch $$@
 $($(1)_configured): | $($(1)_dependencies) $($(1)_preprocessed)
 	echo Configuring $(1)...
-	rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar --no-same-owner -x -f $($(package)_cached); )
+	rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), $(build_TAR) --no-same-owner -x -f $($(package)_cached); )
 	mkdir -p $$($(1)_build_dir)
 	+{ cd $$($(1)_build_dir); export $($(1)_config_env); $($(1)_config_cmds); } $$($(1)_logging)
 ifneq ($(strip $($(1)_cmake_config_cmds)),true)
@@ -273,8 +274,8 @@ $($(1)_postprocessed): | $($(1)_staged)
 $($(1)_cached): | $($(1)_dependencies) $($(1)_postprocessed)
 	echo Caching $(1)...
 	cd $$($(1)_staging_dir)/$(host_prefix); \
-	  find . ! -name '.stamp_postprocessed' -print0 | TZ=UTC xargs -0r touch -h -m -t 200001011200; \
-	  find . ! -name '.stamp_postprocessed' | LC_ALL=C sort | tar --numeric-owner --no-recursion -c -z -f $$($(1)_staging_dir)/$$(@F) -T -
+	  find . ! -name '.stamp_postprocessed' -print0 | TZ=UTC xargs -0r $(build_TOUCH); \
+	  find . ! -name '.stamp_postprocessed' | LC_ALL=C sort | $(build_TAR) --numeric-owner --no-recursion -c -z -f $$($(1)_staging_dir)/$$(@F) -T -
 	mkdir -p $$(@D)
 	@if [ -d "$$(@D)" ]; then \
 		if [ "$$(@D)" != "." ] && [ "$$(@D)" != ".." ]; then \

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,6 +1,6 @@
 package=miniupnpc
 $(package)_version=2.3.3
-$(package)_download_path=https://miniupnp.tuxfamily.org/files/
+$(package)_download_path=https://github.com/miniupnp/miniupnp/releases/download/miniupnpc_2_3_3/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=d52a0afa614ad6c088cc9ddff1ae7d29c8c595ac5fdd321170a05f41e634bd1a
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -283,6 +283,13 @@ endef
 define $(package)_stage_cmds
   cmake --install . --prefix $($(package)_staging_prefix_dir) --strip
 endef
+# For native builds (host == build) Qt does not install the host_tools cmake
+# component (Qt6CoreToolsConfig.cmake, Qt6LinguistToolsConfig.cmake, etc.) as
+# part of the default install.  Qt6CoreConfig.cmake requires Qt6CoreTools to
+# configure successfully, so we install that component explicitly.
+ifeq ($(host),$(build))
+  $(package)_stage_cmds += && cmake --install . --prefix $($(package)_staging_prefix_dir) --component host_tools
+endif
 
 define $(package)_postprocess_cmds
   rm -rf doc/

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -4,9 +4,7 @@ $(package)_version=$(qt_details_version)
 $(package)_download_path=$(qt_details_download_path)
 $(package)_file_name=$(qt_details_qtbase_file_name)
 $(package)_sha256_hash=$(qt_details_qtbase_sha256_hash)
-ifneq ($(host),$(build))
 $(package)_dependencies := native_$(package)
-endif
 $(package)_linux_dependencies := freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_cursor libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
 $(package)_patches_path := $(qt_details_patches_path)
 $(package)_patches := qtbase-moc-ignore-gcc-macro.patch
@@ -16,6 +14,9 @@ $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += skip_xcode_version_check.patch
 $(package)_patches += qttools_skip_dependencies.patch
 $(package)_patches += fix_qnetconmonitor_cross_compile.patch
+ifeq ($(host_os),darwin)
+$(package)_patches += fix_cgdisplay_macos15.patch
+endif
 
 $(package)_qttranslations_file_name=$(qt_details_qttranslations_file_name)
 $(package)_qttranslations_sha256_hash=$(qt_details_qttranslations_sha256_hash)
@@ -74,9 +75,7 @@ $(package)_config_opts += -nomake tests
 $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-doubleconversion
 $(package)_config_opts += -qt-harfbuzz
-ifneq ($(host),$(build))
 $(package)_config_opts += -qt-host-path $(build_prefix)
-endif
 $(package)_config_opts += -qt-libpng
 $(package)_config_opts += -qt-pcre
 $(package)_config_opts += -qt-zlib
@@ -268,18 +267,8 @@ endef
 ifeq ($(host),$(build))
   $(package)_preprocess_cmds += && patch -p1 -i $($(package)_patch_dir)/qttools_skip_dependencies.patch
 endif
-# Fix CGDisplayCreateImageForRect obsoleted in macOS 15.0
-# Comment out the call and return empty pixmap (screen grab will fail gracefully)
-# Cross-compilation only (native darwin builds already satisfy host==build and are excluded).
-# BSD sed (build machine is macOS) needs -i '' while GNU sed (Linux build machine) uses -i.
 ifeq ($(host_os),darwin)
-ifneq ($(host),$(build))
-ifeq ($(build_os),darwin)
-  $(package)_preprocess_cmds += && sed -i '' 's/CGDisplayCreateImageForRect(displayId, grabRect.toCGRect())/nullptr \/* CGDisplayCreateImageForRect obsoleted in macOS 15 *\//' qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
-else
-  $(package)_preprocess_cmds += && sed -i 's/CGDisplayCreateImageForRect(displayId, grabRect.toCGRect())/nullptr \/* CGDisplayCreateImageForRect obsoleted in macOS 15 *\//' qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
-endif
-endif
+  $(package)_preprocess_cmds += && patch -p1 -i $($(package)_patch_dir)/fix_cgdisplay_macos15.patch
 endif
 
 define $(package)_config_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -75,7 +75,9 @@ $(package)_config_opts += -nomake tests
 $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-doubleconversion
 $(package)_config_opts += -qt-harfbuzz
+ifneq ($(host),$(build))
 $(package)_config_opts += -qt-host-path $(build_prefix)
+endif
 $(package)_config_opts += -qt-libpng
 $(package)_config_opts += -qt-pcre
 $(package)_config_opts += -qt-zlib

--- a/depends/patches/qt/fix_cgdisplay_macos15.patch
+++ b/depends/patches/qt/fix_cgdisplay_macos15.patch
@@ -1,0 +1,11 @@
+--- a/qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
++++ b/qtbase/src/plugins/platforms/cocoa/qcocoascreen.mm
+@@ -608,7 +608,7 @@
+        identical visual results.
+     */
+     auto grabFromDisplay = [](CGDirectDisplayID displayId, const QRect &grabRect) -> QPixmap {
+-        QCFType<CGImageRef> image = CGDisplayCreateImageForRect(displayId, grabRect.toCGRect());
++        QCFType<CGImageRef> image = nullptr /* CGDisplayCreateImageForRect obsoleted in macOS 15 */;
+         const QCFType<CGColorSpaceRef> sRGBcolorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+         if (CGImageGetColorSpace(image) != sRGBcolorSpace) {
+             qCDebug(lcQpaScreen) << "applying color correction for display" << displayId;

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -115,6 +115,18 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(QT_TRANSLATIONS_DIR "${CMAKE_CURRENT_LIST_DIR}/translations")
 
+# CMAKE_FIND_ROOT_PATH restricts cmake's own find_library/find_path/find_package
+# calls, but pkg_check_modules (used by Qt's cmake to locate XCB/XKB deps like
+# xkbcommon-x11) reads PKG_CONFIG_PATH from the environment and ignores
+# CMAKE_FIND_ROOT_PATH.  Prepend the depends prefix so .pc files are found.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  if(DEFINED ENV{PKG_CONFIG_PATH})
+    set(ENV{PKG_CONFIG_PATH} "${CMAKE_CURRENT_LIST_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+  else()
+    set(ENV{PKG_CONFIG_PATH} "${CMAKE_CURRENT_LIST_DIR}/lib/pkgconfig")
+  endif()
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_HOST_APPLE)
   # The find_package(Qt ...) function internally uses find_library()
   # calls for all dependencies to ensure their availability.
@@ -129,6 +141,29 @@ set(qt_packages @qt_packages@)
 # Only set if Qt was built (qt_packages is not empty)
 if(NOT "${qt_packages}" STREQUAL "")
   set(Qt6_DIR "${CMAKE_CURRENT_LIST_DIR}/lib/cmake/Qt6" CACHE PATH "Qt6 installation directory")
+  # Qt6CoreConfig.cmake looks up Qt6CoreTools (moc, rcc, uic, lrelease …) via
+  # QT_HOST_PATH.  Without it Qt6CoreTools_DIR is unset and Qt6::Core fails to
+  # configure even on native (non-cross) builds.
+  #
+  # For cross-compilation QT_HOST_PATH points to the separate native-Qt prefix;
+  # for native builds it is the same prefix as the target libraries.
+  if(NOT DEFINED QT_HOST_PATH)
+    if(@depends_crosscompiling@)
+      # Cross-compilation: try the environment variable first (Guix sets it).
+      if(DEFINED ENV{QT_HOST_PATH})
+        set(QT_HOST_PATH "$ENV{QT_HOST_PATH}" CACHE PATH
+            "Native Qt host installation used for cross-compilation build tools")
+      endif()
+    else()
+      # Native build: tools live in the same prefix as the target libraries.
+      set(QT_HOST_PATH "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH
+          "Qt host installation (same prefix as target for native builds)")
+    endif()
+  endif()
+  if(DEFINED QT_HOST_PATH AND NOT DEFINED QT_HOST_PATH_CMAKE_DIR)
+    set(QT_HOST_PATH_CMAKE_DIR "${QT_HOST_PATH}/lib/cmake" CACHE PATH
+        "lib/cmake directory of the Qt host installation")
+  endif()
 endif()
 # Only set default if not already specified by user/CI or command line
 if(NOT DEFINED BUILD_GUI AND NOT DEFINED CACHE{BUILD_GUI})
@@ -139,29 +174,30 @@ if(NOT DEFINED BUILD_GUI AND NOT DEFINED CACHE{BUILD_GUI})
   endif()
 endif()
 
-set(qrencode_packages @qrencode_packages@)
 # Only set default if not already specified by user/CI or command line
 if(NOT DEFINED WITH_QRENCODE AND NOT DEFINED CACHE{WITH_QRENCODE})
-  if("${qrencode_packages}" STREQUAL "")
+  if("${qt_packages}" STREQUAL "")
     set(WITH_QRENCODE OFF CACHE BOOL "")
   else()
     set(WITH_QRENCODE ON CACHE BOOL "")
   endif()
 endif()
 
-set(zmq_packages @zmq_packages@)
-# Only set default if not already specified by user/CI or command line
+# zeromq has no NO_ZMQ toggle in depends/packages/packages.mk — it is always
+# built, so set its defaults unconditionally (mirrors BerkeleyDB_ROOT below).
 if(NOT DEFINED ENABLE_ZMQ AND NOT DEFINED CACHE{ENABLE_ZMQ})
-  if("${zmq_packages}" STREQUAL "")
-    set(ENABLE_ZMQ OFF CACHE BOOL "")
-  else()
-    set(ENABLE_ZMQ ON CACHE BOOL "")
-    # Provide static library paths for manual search
-    set(ZEROMQ_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "")
-    set(ZEROMQ_LIBRARY "${CMAKE_CURRENT_LIST_DIR}/lib/libzmq.a" CACHE FILEPATH "")
-    set(ZEROMQ_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/include" CACHE PATH "")
-  endif()
+  set(ENABLE_ZMQ ON CACHE BOOL "")
 endif()
+# Provide static library paths for manual search
+set(ZEROMQ_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "")
+set(ZEROMQ_LIBRARY "${CMAKE_CURRENT_LIST_DIR}/lib/libzmq.a" CACHE FILEPATH "")
+set(ZEROMQ_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/include" CACHE PATH "")
+
+# boost has no NO_BOOST toggle in depends/packages/packages.mk — it is always
+# built, so set its defaults unconditionally.
+set(BOOST_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "")
+set(BOOST_INCLUDEDIR "${CMAKE_CURRENT_LIST_DIR}/include" CACHE PATH "")
+set(BOOST_LIBRARYDIR "${CMAKE_CURRENT_LIST_DIR}/lib" CACHE PATH "")
 
 # Force use of static BerkeleyDB library from depends
 set(BerkeleyDB_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "")
@@ -177,10 +213,9 @@ if(NOT DEFINED ENABLE_WALLET)
   endif()
 endif()
 
-set(bdb_packages @bdb_packages@)
 # Only set default if not already specified by user/CI or command line
 if(NOT DEFINED WITH_BDB AND NOT DEFINED CACHE{WITH_BDB})
-  if("${wallet_packages}" STREQUAL "" OR "${bdb_packages}" STREQUAL "")
+  if("${wallet_packages}" STREQUAL "")
     set(WITH_BDB OFF CACHE BOOL "")
   else()
     set(WITH_BDB ON CACHE BOOL "")


### PR DESCRIPTION
Simplify cmake command in daily ci by moving depends library paths to toolchain file. 
Fix daily CI failure in macOS depends qt build on arm64 by using a patch file instead of the sed command which was failing