### PR TITLE
Port Bitcoin Core PR#28280: O(dirty) BatchWrite via linked list

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -221,10 +221,12 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 
 bool CCoinsViewCache::Flush() {
     bool fOk = base->BatchWrite(cacheCoins, hashBlock);
-    if (fOk) {
-        cacheCoins.clear();
-        ReallocateCache();
-    }
+    // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
+    // cacheCoins unconditionally during iteration, so the map is always empty
+    // clear() here is defensive; ReallocateCache() returns the pool backing memory.
+    // All three are safe to call on failure and success.
+    cacheCoins.clear();
+    ReallocateCache();
     cachedCoinsUsage = 0;
     return fOk;
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -221,12 +221,15 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 
 bool CCoinsViewCache::Flush() {
     bool fOk = base->BatchWrite(cacheCoins, hashBlock);
-    // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
-    // cacheCoins unconditionally during iteration, so the map is always empty
-    // clear() here is defensive; ReallocateCache() returns the pool backing memory.
-    // All three are safe to call on failure and success.
-    cacheCoins.clear();
-    ReallocateCache();
+    if (fOk) {
+        // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
+        // cacheCoins inside the iteration loop, so the map must be empty here.
+        // The assertion catches any future refactor that breaks that invariant.
+        if (!cacheCoins.empty()) {
+            throw std::logic_error("Not all cached coins were erased");
+        }
+        ReallocateCache();
+    }
     cachedCoinsUsage = 0;
     return fOk;
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -237,12 +237,11 @@ bool CCoinsViewCache::Flush() {
     auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/true)};
     bool fOk = base->BatchWrite(cursor, hashBlock);
     if (fOk) {
-        // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
-        // cacheCoins inside the iteration loop, so the map must be empty here.
-        // The assertion catches any future refactor that breaks that invariant.
-        if (!cacheCoins.empty()) {
-            throw std::logic_error("Not all cached coins were erased");
-        }
+        // With will_erase=true the cursor does not touch the map during iteration;
+        // entries (dirty and clean) are still present. Clear them all now so their
+        // CCoinsCacheEntry destructors call ClearFlags(), emptying the linked list
+        // before ReallocateCache() reconstructs the pool.
+        cacheCoins.clear();
         ReallocateCache();
     }
     cachedCoinsUsage = 0;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2012-2018 The Bitcoin Core developers
-// Copyright (c) 2019-2021 Chaintope Inc.
+// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Copyright (c) 2019-2024 Chaintope Inc.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,7 +12,7 @@
 bool CCoinsView::GetCoin(const COutPoint &outpoint, Coin &coin) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 std::vector<uint256> CCoinsView::GetHeadBlocks() const { return std::vector<uint256>(); }
-bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return false; }
+bool CCoinsView::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) { return false; }
 CCoinsViewCursor *CCoinsView::Cursor() const { return nullptr; }
 
 bool CCoinsView::HaveCoin(const COutPoint &outpoint) const
@@ -27,7 +27,7 @@ bool CCoinsViewBacked::HaveCoin(const COutPoint &outpoint) const { return base->
 uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 std::vector<uint256> CCoinsViewBacked::GetHeadBlocks() const { return base->GetHeadBlocks(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
-bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return base->BatchWrite(mapCoins, hashBlock); }
+bool CCoinsViewBacked::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) { return base->BatchWrite(cursor, hashBlock); }
 CCoinsViewCursor *CCoinsViewBacked::Cursor() const { return base->Cursor(); }
 size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
@@ -35,7 +35,10 @@ SaltedOutpointHasher::SaltedOutpointHasher() : k0(GetRand(std::numeric_limits<ui
 
 CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn),
     cacheCoins(0, SaltedOutpointHasher{}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource),
-    cachedCoinsUsage(0) {}
+    cachedCoinsUsage(0)
+{
+    m_sentinel.second.SelfRef(m_sentinel);
+}
 
 size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
@@ -52,7 +55,7 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
     if (ret->second.coin.IsSpent()) {
         // The parent only has an empty entry for this outpoint; we can consider our
         // version as fresh.
-        ret->second.flags = CCoinsCacheEntry::FRESH;
+        ret->second.AddFlags(CCoinsCacheEntry::FRESH, *ret, m_sentinel);
     }
     cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
     return ret;
@@ -81,19 +84,19 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         if (!it->second.coin.IsSpent()) {
             throw std::logic_error("Adding new coin that replaces non-pruned entry");
         }
-        fresh = !(it->second.flags & CCoinsCacheEntry::DIRTY);
+        fresh = !it->second.IsDirty();
     }
     it->second.coin = std::move(coin);
-    it->second.flags |= CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0);
+    it->second.AddFlags(CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0), *it, m_sentinel);
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
 
     TRACE6(utxocache, utxocache_add,
         outpoint.hashMalFix.GetHex().c_str(),
         (uint32_t)outpoint.n,
         GetColorIdFromScript(coin.out.scriptPubKey).toHexString().c_str(),
-        (uint32_t)coin.nHeight,
-        (int64_t)coin.out.nValue,
-        (bool)coin.IsCoinBase());
+        (uint32_t)it->second.coin.nHeight,
+        (int64_t)it->second.coin.out.nValue,
+        (bool)it->second.coin.IsCoinBase());
 }
 
 void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool check) {
@@ -121,10 +124,12 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     if (moveout) {
         *moveout = std::move(it->second.coin);
     }
-    if (it->second.flags & CCoinsCacheEntry::FRESH) {
+    if (it->second.IsFresh()) {
+        // FRESH coins have no representation in the parent cache; erase entirely.
+        // The destructor will call ClearFlags() removing it from the linked list.
         cacheCoins.erase(it);
     } else {
-        it->second.flags |= CCoinsCacheEntry::DIRTY;
+        it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
         it->second.coin.Clear();
     }
     return true;
@@ -161,28 +166,33 @@ void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn) {
     hashBlock = hashBlockIn;
 }
 
-bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn) {
-    for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); it = mapCoins.erase(it)) {
+bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlockIn) {
+    for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
         // Ignore non-dirty entries (optimization).
-        if (!(it->second.flags & CCoinsCacheEntry::DIRTY)) {
+        if (!it->second.IsDirty()) {
             continue;
         }
         CCoinsMap::iterator itUs = cacheCoins.find(it->first);
         if (itUs == cacheCoins.end()) {
             // The parent cache does not have an entry, while the child does
             // We can ignore it if it's both FRESH and pruned in the child
-            if (!(it->second.flags & CCoinsCacheEntry::FRESH && it->second.coin.IsSpent())) {
+            if (!(it->second.IsFresh() && it->second.coin.IsSpent())) {
                 // Otherwise we will need to create it in the parent
                 // and move the data up and mark it as dirty
-                CCoinsCacheEntry& entry = cacheCoins[it->first];
-                entry.coin = std::move(it->second.coin);
+                itUs = cacheCoins.try_emplace(it->first).first;
+                CCoinsCacheEntry& entry = itUs->second;
+                if (cursor.WillErase(*it)) {
+                    entry.coin = std::move(it->second.coin);
+                } else {
+                    entry.coin = it->second.coin;
+                }
                 cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
-                entry.flags = CCoinsCacheEntry::DIRTY;
+                entry.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // We can mark it FRESH in the parent if it was FRESH in the child
                 // Otherwise it might have just been flushed from the parent's cache
                 // and already exist in the grandparent
-                if (it->second.flags & CCoinsCacheEntry::FRESH) {
-                    entry.flags |= CCoinsCacheEntry::FRESH;
+                if (it->second.IsFresh()) {
+                    entry.AddFlags(CCoinsCacheEntry::FRESH, *itUs, m_sentinel);
                 }
             }
         } else {
@@ -190,12 +200,12 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
             // parent cache entry has unspent outputs. If this ever happens,
             // it means the FRESH flag was misapplied and there is a logic
             // error in the calling code.
-            if ((it->second.flags & CCoinsCacheEntry::FRESH) && !itUs->second.coin.IsSpent()) {
+            if (it->second.IsFresh() && !itUs->second.coin.IsSpent()) {
                 throw std::logic_error("FRESH flag misapplied to cache entry for base transaction with spendable outputs");
             }
 
             // Found the entry in the parent cache
-            if ((itUs->second.flags & CCoinsCacheEntry::FRESH) && it->second.coin.IsSpent()) {
+            if (itUs->second.IsFresh() && it->second.coin.IsSpent()) {
                 // The grandparent does not have an entry, and the child is
                 // modified and being pruned. This means we can just delete
                 // it from the parent.
@@ -204,9 +214,13 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
             } else {
                 // A normal modification.
                 cachedCoinsUsage -= itUs->second.coin.DynamicMemoryUsage();
-                itUs->second.coin = std::move(it->second.coin);
+                if (cursor.WillErase(*it)) {
+                    itUs->second.coin = std::move(it->second.coin);
+                } else {
+                    itUs->second.coin = it->second.coin;
+                }
                 cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
-                itUs->second.flags |= CCoinsCacheEntry::DIRTY;
+                itUs->second.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // NOTE: It is possible the child has a FRESH flag here in
                 // the event the entry we found in the parent is pruned. But
                 // we must not copy that FRESH flag to the parent as that
@@ -220,7 +234,8 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 }
 
 bool CCoinsViewCache::Flush() {
-    bool fOk = base->BatchWrite(cacheCoins, hashBlock);
+    auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/true)};
+    bool fOk = base->BatchWrite(cursor, hashBlock);
     if (fOk) {
         // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
         // cacheCoins inside the iteration loop, so the map must be empty here.
@@ -253,10 +268,22 @@ void CCoinsViewCache::ReallocateCache()
     ::new (&cacheCoins) CCoinsMap{0, SaltedOutpointHasher{}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource};
 }
 
+bool CCoinsViewCache::Sync()
+{
+    auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/false)};
+    bool fOk = base->BatchWrite(cursor, hashBlock);
+    if (fOk) {
+        if (m_sentinel.second.Next() != &m_sentinel) {
+            throw std::logic_error("Not all unspent flagged entries were cleared after Sync");
+        }
+    }
+    return fOk;
+}
+
 void CCoinsViewCache::Uncache(const COutPoint& hash)
 {
     CCoinsMap::iterator it = cacheCoins.find(hash);
-    if (it != cacheCoins.end() && it->second.flags == 0) {
+    if (it != cacheCoins.end() && !it->second.IsDirty() && !it->second.IsFresh()) {
         cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
         TRACE6(utxocache, utxocache_uncache,
             hash.hashMalFix.GetHex().c_str(),

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -222,12 +222,7 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 bool CCoinsViewCache::Flush() {
     bool fOk = base->BatchWrite(cacheCoins, hashBlock);
     if (fOk) {
-        // BatchWrite (both CCoinsViewDB and CCoinsViewCache) erases entries from
-        // cacheCoins inside the iteration loop, so the map must be empty here.
-        // The assertion catches any future refactor that breaks that invariant.
-        if (!cacheCoins.empty()) {
-            throw std::logic_error("Not all cached coins were erased");
-        }
+        cacheCoins.clear();
         ReallocateCache();
     }
     cachedCoinsUsage = 0;

--- a/src/coins.h
+++ b/src/coins.h
@@ -226,6 +226,7 @@ protected:
      * declared as "const".
      */
     mutable uint256 hashBlock;
+<<<<<<< HEAD
     // Note: declaration order is load-bearing. m_cache_coins_memory_resource
     // must precede cacheCoins because cacheCoins's allocator stores a pointer
     // to it, which is dereferenced from cacheCoins's destructor (and from
@@ -234,6 +235,9 @@ protected:
     // cacheCoins (and the underlying memory resource) must only be accessed
     // while cs_main is held. PoolResource is not thread-safe — concurrent
     // access from multiple threads is undefined behavior.
+=======
+    mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
+>>>>>>> 596893f92a (Port Bitcoin Core PR#25325: Pool-based memory resource for CCoinsMap)
     mutable CCoinsMap cacheCoins;
 
     /* Cached dynamic memory usage for the inner Coin objects. */

--- a/src/coins.h
+++ b/src/coins.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
-// Copyright (c) 2019-2021 Chaintope Inc.
+// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2019-2024 Chaintope Inc.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -104,10 +104,38 @@ public:
     }
 };
 
+// Forward-declare CCoinsCacheEntry so CoinsCachePair can be defined before
+// CCoinsCacheEntry is complete. The linked-list pointers in CCoinsCacheEntry
+// are pointer types that only require CoinsCachePair to be declared, not complete.
+struct CCoinsCacheEntry;
+using CoinsCachePair = std::pair<const COutPoint, CCoinsCacheEntry>;
+
+/**
+ * A Coin in one level of the coins database caching hierarchy.
+ *
+ * A coin can either be:
+ * - unspent or spent (in which case the Coin object will be nulled out - see Coin.Clear())
+ * - DIRTY or not DIRTY
+ * - FRESH or not FRESH
+ */
 struct CCoinsCacheEntry
 {
+private:
+    /**
+     * These are used to create a doubly linked list of flagged entries.
+     * They are set in AddFlags and unset in ClearFlags.
+     * A flagged entry is any entry that is either DIRTY, FRESH, or both.
+     *
+     * DIRTY entries are tracked so that only modified entries can be passed to
+     * the parent cache for batch writing. This is a performance optimization
+     * compared to iterating the entire cache to find modified entries.
+     */
+    CoinsCachePair* m_prev{nullptr};
+    CoinsCachePair* m_next{nullptr};
+    uint8_t m_flags{0};
+
+public:
     Coin coin; // The actual cached data.
-    unsigned char flags;
 
     enum Flags {
         DIRTY = (1 << 0), // This cache entry is potentially different from the version in the parent view.
@@ -119,8 +147,65 @@ struct CCoinsCacheEntry
          */
     };
 
-    CCoinsCacheEntry() : flags(0) {}
-    explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
+    CCoinsCacheEntry() noexcept = default;
+    explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
+    ~CCoinsCacheEntry()
+    {
+        ClearFlags();
+    }
+
+    //! Add flags and, if this is the first time any flags are set, insert
+    //! this entry into the doubly linked list of flagged entries.
+    //! Requires a reference to the CoinsCachePair containing this entry (self)
+    //! and the sentinel of the linked list (sentinel).
+    inline void AddFlags(uint8_t flags, CoinsCachePair& self, CoinsCachePair& sentinel) noexcept
+    {
+        assert(&self.second == this);
+        if (!m_flags && flags) {
+            // Insert at the tail of the list (just before the sentinel).
+            m_prev = sentinel.second.m_prev;
+            m_next = &sentinel;
+            sentinel.second.m_prev = &self;
+            m_prev->second.m_next = &self;
+        }
+        m_flags |= flags;
+    }
+
+    //! Clear all flags and remove this entry from the doubly linked list.
+    inline void ClearFlags() noexcept
+    {
+        if (!m_flags) return;
+        m_next->second.m_prev = m_prev;
+        m_prev->second.m_next = m_next;
+        m_flags = 0;
+    }
+
+    inline uint8_t GetFlags() const noexcept { return m_flags; }
+    inline bool IsDirty() const noexcept { return m_flags & DIRTY; }
+    inline bool IsFresh() const noexcept { return m_flags & FRESH; }
+
+    //! Only call Next when this entry is DIRTY, FRESH, or both.
+    inline CoinsCachePair* Next() const noexcept {
+        assert(m_flags);
+        return m_next;
+    }
+
+    //! Only call Prev when this entry is DIRTY, FRESH, or both.
+    inline CoinsCachePair* Prev() const noexcept {
+        assert(m_flags);
+        return m_prev;
+    }
+
+    //! Only use this for initializing the linked list sentinel.
+    //! Sets m_prev and m_next to point to self, and sets m_flags to DIRTY
+    //! so that Next() can be called on the sentinel.
+    inline void SelfRef(CoinsCachePair& self) noexcept
+    {
+        assert(&self.second == this);
+        m_prev = &self;
+        m_next = &self;
+        m_flags = DIRTY;
+    }
 };
 
 /**
@@ -140,6 +225,61 @@ using CCoinsMap = std::unordered_map<COutPoint,
                                                    alignof(void*)>>;
 
 using CCoinsMapMemoryResource = CCoinsMap::allocator_type::ResourceType;
+
+/**
+ * Cursor for iterating over the linked list of flagged entries in CCoinsViewCache.
+ *
+ * This encapsulates the diverging cleanup logic between CCoinsViewCache::Sync
+ * (non-erasing: keep the cache warm, only remove spent coins and clear flags)
+ * and CCoinsViewCache::Flush (erasing: caller will wipe the entire map).
+ *
+ * BatchWrite receivers can call WillErase() to decide whether to move or copy
+ * the coin out of the entry.
+ */
+struct CoinsViewCacheCursor
+{
+    //! If will_erase is false (Sync), iterating clears flags on unspent entries
+    //! and erases spent entries from the map.
+    //! If will_erase is true (Flush), the map is not touched during iteration;
+    //! the caller is expected to call cacheCoins.clear() afterwards.
+    CoinsViewCacheCursor(size_t& usage,
+                         CoinsCachePair& sentinel,
+                         CCoinsMap& map,
+                         bool will_erase) noexcept
+        : m_usage(usage), m_sentinel(sentinel), m_map(map), m_will_erase(will_erase) {}
+
+    inline CoinsCachePair* Begin() const noexcept { return m_sentinel.second.Next(); }
+    inline CoinsCachePair* End()   const noexcept { return &m_sentinel; }
+
+    //! Advance past current, possibly erasing or unflagging it.
+    //! Must be called with each entry returned by Begin()/NextAndMaybeErase().
+    inline CoinsCachePair* NextAndMaybeErase(CoinsCachePair& current) noexcept
+    {
+        const auto next_entry{current.second.Next()};
+        if (!m_will_erase) {
+            if (current.second.coin.IsSpent()) {
+                m_usage -= current.second.coin.DynamicMemoryUsage();
+                m_map.erase(current.first);
+            } else {
+                current.second.ClearFlags();
+            }
+        }
+        return next_entry;
+    }
+
+    //! Returns true if the caller will erase this entry (either because
+    //! will_erase is set, or because the coin is spent and will be erased anyway).
+    inline bool WillErase(CoinsCachePair& current) const noexcept
+    {
+        return m_will_erase || current.second.coin.IsSpent();
+    }
+
+private:
+    size_t& m_usage;
+    CoinsCachePair& m_sentinel;
+    CCoinsMap& m_map;
+    bool m_will_erase;
+};
 
 /** Cursor for iterating over CoinsView state */
 class CCoinsViewCursor
@@ -184,8 +324,8 @@ public:
     virtual std::vector<uint256> GetHeadBlocks() const;
 
     //! Do a bulk modification (multiple Coin changes + BestBlock change).
-    //! The passed mapCoins can be modified.
-    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    //! The cursor iterates only over dirty/flagged entries in the child cache.
+    virtual bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256& hashBlock);
 
     //! Get a cursor to iterate over the whole state
     virtual CCoinsViewCursor *Cursor() const;
@@ -211,7 +351,7 @@ public:
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) override;
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
     CCoinsViewCursor *Cursor() const override;
     size_t EstimateSize() const override;
 };
@@ -231,9 +371,11 @@ protected:
     // to it, which is dereferenced from cacheCoins's destructor (and from
     // every allocate/deallocate). Reordering these is undefined behavior.
     mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
-    // cacheCoins (and the underlying memory resource) must only be accessed
-    // while cs_main is held. PoolResource is not thread-safe — concurrent
+    // cacheCoins, m_sentinel (and the underlying memory resource) must only be
+    // accessed while cs_main is held. PoolResource is not thread-safe — concurrent
     // access from multiple threads is undefined behavior.
+    /* The starting sentinel of the flagged entry circular doubly linked list. */
+    mutable CoinsCachePair m_sentinel;
     mutable CCoinsMap cacheCoins;
 
     /* Cached dynamic memory usage for the inner Coin objects. */
@@ -252,7 +394,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) override;
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
     CCoinsViewCursor* Cursor() const override {
         throw std::logic_error("CCoinsViewCache cursor iteration not supported.");
     }
@@ -290,8 +432,9 @@ public:
     bool SpendCoin(const COutPoint &outpoint, Coin* moveto = nullptr);
 
     /**
-     * Push the modifications applied to this cache to its base.
-     * Failure to call this method before destruction will cause the changes to be forgotten.
+     * Push the modifications applied to this cache to its base and wipe local state.
+     * Failure to call this method or Sync() before destruction will cause the changes
+     * to be forgotten.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
     bool Flush();
@@ -302,6 +445,15 @@ public:
      * the next IBD flush cycle with a clean pool.
      */
     void ReallocateCache();
+
+    /**
+     * Push the modifications applied to this cache to its base while retaining
+     * the contents of this cache (except for spent coins, which are erased).
+     * Failure to call this method or Flush() before destruction will cause the changes
+     * to be forgotten.
+     * If false is returned, the state of this cache (and its backing view) will be undefined.
+     */
+    bool Sync();
 
     /**
      * Removes the UTXO with the given outpoint from the cache, if it is

--- a/src/coins.h
+++ b/src/coins.h
@@ -226,7 +226,6 @@ protected:
      * declared as "const".
      */
     mutable uint256 hashBlock;
-<<<<<<< HEAD
     // Note: declaration order is load-bearing. m_cache_coins_memory_resource
     // must precede cacheCoins because cacheCoins's allocator stores a pointer
     // to it, which is dereferenced from cacheCoins's destructor (and from
@@ -235,9 +234,6 @@ protected:
     // cacheCoins (and the underlying memory resource) must only be accessed
     // while cs_main is held. PoolResource is not thread-safe — concurrent
     // access from multiple threads is undefined behavior.
-=======
-    mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
->>>>>>> 596893f92a (Port Bitcoin Core PR#25325: Pool-based memory resource for CCoinsMap)
     mutable CCoinsMap cacheCoins;
 
     /* Cached dynamic memory usage for the inner Coin objects. */

--- a/src/coins.h
+++ b/src/coins.h
@@ -149,6 +149,12 @@ public:
 
     CCoinsCacheEntry() noexcept = default;
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
+
+    CCoinsCacheEntry(const CCoinsCacheEntry&) = delete;
+    CCoinsCacheEntry& operator=(const CCoinsCacheEntry&) = delete;
+    CCoinsCacheEntry(CCoinsCacheEntry&&) = delete;
+    CCoinsCacheEntry& operator=(CCoinsCacheEntry&&) = delete;
+
     ~CCoinsCacheEntry()
     {
         ClearFlags();

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -441,12 +441,13 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode, int nManualP
         // It's been very long since we flushed the cache. Do this infrequently, to optimize cache usage.
         bool fPeriodicFlush = mode == FlushStateMode::PERIODIC && nNow > nLastFlush + (int64_t)DATABASE_FLUSH_INTERVAL * 1000000;
         // Combine all conditions that result in a full cache flush.
-        // Note: fFlushForPrune is intentionally excluded here. Prune flushes use
-        // Sync() to keep the cache warm, avoiding the cost of clearing and reloading
-        // the UTXO cache after every prune. See CCoinsViewCache::Sync().
+        // fFlushForPrune is excluded from fDoFullFlush so that a prune flush uses
+        // Sync() (writes dirty entries, keeps the cache warm) rather than Flush()
+        // (wipes the cache entirely). fFlushForPrune is kept in the outer gate below
+        // so that UnlinkPrunedFiles() and the block-index write still run on prune.
         fDoFullFlush = (mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fPeriodicFlush;
         // Write blocks and block index to disk.
-        if (fDoFullFlush || fPeriodicWrite) {
+        if (fDoFullFlush || fFlushForPrune || fPeriodicWrite) {
             // Depend on nMinDiskSpace to ensure we can write block index
             if (!CheckDiskSpace(0, true))
                 return state.Error("out of disk space");

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -441,7 +441,10 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode, int nManualP
         // It's been very long since we flushed the cache. Do this infrequently, to optimize cache usage.
         bool fPeriodicFlush = mode == FlushStateMode::PERIODIC && nNow > nLastFlush + (int64_t)DATABASE_FLUSH_INTERVAL * 1000000;
         // Combine all conditions that result in a full cache flush.
-        fDoFullFlush = (mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fPeriodicFlush || fFlushForPrune;
+        // Note: fFlushForPrune is intentionally excluded here. Prune flushes use
+        // Sync() to keep the cache warm, avoiding the cost of clearing and reloading
+        // the UTXO cache after every prune. See CCoinsViewCache::Sync().
+        fDoFullFlush = (mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fPeriodicFlush;
         // Write blocks and block index to disk.
         if (fDoFullFlush || fPeriodicWrite) {
             // Depend on nMinDiskSpace to ensure we can write block index
@@ -473,7 +476,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode, int nManualP
             nLastWrite = nNow;
         }
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
-        if (fDoFullFlush && !pcoinsTip->GetBestBlock().IsNull()) {
+        if ((fDoFullFlush || fFlushForPrune) && !pcoinsTip->GetBestBlock().IsNull()) {
             // Typical Coin structures on disk are around 48 bytes in size.
             // Pushing a new one to the database can cause it to be written
             // twice (once in the log, and once in the tables). This is already
@@ -481,11 +484,12 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode, int nManualP
             // overwrite one. Still, use a conservative safety factor of 2.
             if (!CheckDiskSpace(48 * 2 * 2 * pcoinsTip->GetCacheSize()))
                 return state.Error("out of disk space");
-            // Flush the chainstate (which may refer to block index entries).
-            if (!pcoinsTip->Flush())
+            // For a full flush, wipe the entire cache; for a prune flush, use Sync()
+            // to write dirty entries while keeping the cache warm for faster block connection.
+            if (fDoFullFlush ? !pcoinsTip->Flush() : !pcoinsTip->Sync())
                 return AbortNode(state, "Failed to write to coin database");
             nLastFlush = nNow;
-            full_flush_completed = true;
+            full_flush_completed = fDoFullFlush;
             TRACE5(utxocache, utxocache_flush,
                 (int64_t)(GetTimeMicros() - nNow), // in microseconds (µs)
                 (uint32_t)mode,

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -578,12 +578,11 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, CAmo
         return 0;
     }
     assert(flags != NO_ENTRY);
-    CCoinsCacheEntry entry;
-    SetCoinsValue(value, entry.coin);
-    auto inserted = map.emplace(OUTPOINT, std::move(entry));
-    assert(inserted.second);
-    inserted.first->second.AddFlags(flags, *inserted.first, sentinel);
-    return inserted.first->second.coin.DynamicMemoryUsage();
+    auto [it, inserted] = map.try_emplace(OUTPOINT);
+    assert(inserted);
+    SetCoinsValue(value, it->second.coin);
+    it->second.AddFlags(flags, *it, sentinel);
+    return it->second.coin.DynamicMemoryUsage();
 }
 
 void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -51,10 +51,10 @@ public:
 
     uint256 GetBestBlock() const override { return hashBestBlock_; }
 
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) override
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256& hashBlock) override
     {
-        for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); ) {
-            if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+        for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
+            if (it->second.IsDirty()) {
                 // Same optimization used in CCoinsViewDB is to only write dirty entries.
                 map_[it->first] = it->second.coin;
                 if (it->second.coin.IsSpent() && InsecureRandRange(3) == 0) {
@@ -62,7 +62,6 @@ public:
                     map_.erase(it->first);
                 }
             }
-            mapCoins.erase(it++);
         }
         if (!hashBlock.IsNull())
             hashBestBlock_ = hashBlock;
@@ -89,6 +88,7 @@ public:
     }
 
     CCoinsMap& map() const { return cacheCoins; }
+    CoinsCachePair& sentinel() const { return m_sentinel; }
     size_t& usage() const { return cachedCoinsUsage; }
 };
 
@@ -571,7 +571,7 @@ static void SetCoinsValue(CAmount value, Coin& coin)
     }
 }
 
-static size_t InsertCoinsMapEntry(CCoinsMap& map, CAmount value, char flags)
+static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, CAmount value, char flags)
 {
     if (value == ABSENT) {
         assert(flags == NO_ENTRY);
@@ -579,10 +579,10 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CAmount value, char flags)
     }
     assert(flags != NO_ENTRY);
     CCoinsCacheEntry entry;
-    entry.flags = flags;
     SetCoinsValue(value, entry.coin);
     auto inserted = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted.second);
+    inserted.first->second.AddFlags(flags, *inserted.first, sentinel);
     return inserted.first->second.coin.DynamicMemoryUsage();
 }
 
@@ -598,7 +598,7 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags)
         } else {
             value = it->second.coin.out.nValue;
         }
-        flags = it->second.flags;
+        flags = it->second.GetFlags();
         assert(flags != NO_ENTRY);
     }
 }
@@ -606,9 +606,12 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags)
 void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
 {
     CCoinsMapMemoryResource resource;
+    CoinsCachePair sentinel{};
+    sentinel.second.SelfRef(sentinel);
     CCoinsMap map(0, SaltedOutpointHasher{}, CCoinsMap::key_equal{}, &resource);
-    InsertCoinsMapEntry(map, value, flags);
-    view.BatchWrite(map, {});
+    size_t usage{InsertCoinsMapEntry(map, sentinel, value, flags)};
+    auto cursor{CoinsViewCacheCursor(usage, sentinel, map, /*will_erase=*/true)};
+    BOOST_CHECK(view.BatchWrite(cursor, {}));
 }
 
 class SingleEntryCacheTest
@@ -617,7 +620,7 @@ public:
     SingleEntryCacheTest(CAmount base_value, CAmount cache_value, char cache_flags)
     {
         WriteCoinsViewEntry(base, base_value, base_value == ABSENT ? NO_ENTRY : DIRTY);
-        cache.usage() += InsertCoinsMapEntry(cache.map(), cache_value, cache_flags);
+        cache.usage() += InsertCoinsMapEntry(cache.map(), cache.sentinel(), cache_value, cache_flags);
     }
 
     CCoinsView root;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -82,7 +82,7 @@ std::vector<uint256> CCoinsViewDB::GetHeadBlocks() const {
     return vhashHeadBlocks;
 }
 
-bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
+bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) {
     CDBBatch batch(db);
     size_t count = 0;
     size_t changed = 0;
@@ -107,8 +107,8 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
     batch.Erase(DB_BEST_BLOCK);
     batch.Write(DB_HEAD_BLOCKS, std::vector<uint256>{hashBlock, old_tip});
 
-    for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
-        if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+    for (auto it{cursor.Begin()}; it != cursor.End();) {
+        if (it->second.IsDirty()) {
             CoinEntry entry(&it->first);
             if (it->second.coin.IsSpent())
                 batch.Erase(entry);
@@ -117,8 +117,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
             changed++;
         }
         count++;
-        CCoinsMap::iterator itOld = it++;
-        mapCoins.erase(itOld);
+        it = cursor.NextAndMaybeErase(*it);
         if (batch.SizeEstimate() > batch_size) {
             LogPrint(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.SizeEstimate() * (1.0 / 1048576.0));
             db.WriteBatch(batch);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -101,7 +101,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
     CCoinsViewCursor *Cursor() const override;
 
     //! Attempt to update from an older database format. Returns whether an error occurred.

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -101,7 +101,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
-    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CCoinsViewCursor *Cursor() const override;
 
     //! Attempt to update from an older database format. Returns whether an error occurred.


### PR DESCRIPTION
  - Ports Bitcoin Core PR#28280 (commit 27a770b): replaces the O(n) full `CCoinsMap` scan in `BatchWrite` with O(dirty) iteration over a doubly-linked list of flagged entries
  - Adds `m_prev`/`m_next` intrusive list pointers to `CCoinsCacheEntry`; `AddFlags()` inserts on first flag, `ClearFlags()` removes, destructor calls `ClearFlags()` for safety; `m_sentinel` on `CCoinsViewCache` is the list head
  (self-referential via `SelfRef()`)
  - Replaces `CCoinsMap&` parameter in `BatchWrite` with `CoinsViewCacheCursor` encapsulating `Begin()`/`End()`/`NextAndMaybeErase()` — cursor owns the O(dirty) walk
  - Adds `Sync()` alongside `Flush()`: `Sync` keeps the cache warm (`will_erase=false`, unflags clean entries); prune flushes in `file_io.cpp::FlushStateToDisk` now call `Sync()` instead of `Flush()`, preserving in-memory UTXO cache across
  prune operations
  - Fixes a post-cherry-pick bug: with `will_erase=true`, dirty entries remain in `cacheCoins` after cursor iteration, so `Flush()` now calls `cacheCoins.clear()` before `ReallocateCache()` to correctly drain the linked list via destructors

  Tapyrus adaptations: `BatchWrite` in `CCoinsViewDB` retains `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` because `CommitToBatch` (called inside it) requires `cs_main`; `TRACE` macros use `hashMalFix`/`GetColorIdFromScript`.
  