### PR TITLE
Port Bitcoin Core PR#31551: buffered block I/O reads and writes

### DIFF
--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -184,29 +184,29 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex *pindex)
 {
     CDiskBlockPos pos = pindex->GetUndoPos();
     if (pos.IsNull()) {
-        return error("%s: no undo data available", __func__);
+        return error("no undo data available for %s", pos.ToString());
     }
 
     // Open history file to read
-    CAutoFile filein(OpenUndoFile(pos, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile filein(OpenUndoFile(pos, /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull())
-        return error("%s: OpenUndoFile failed", __func__);
+        return error("OpenUndoFile failed for %s while reading block undo", pos.ToString());
 
-    // Read block
-    uint256 hashChecksum;
-    CHashVerifier<CAutoFile> verifier(&filein); // We need a CHashVerifier as reserializing may lose data
     try {
+        // Read block
+        CHashVerifier<CAutoFile> verifier(&filein); // Use CHashVerifier as reserializing may lose data, c.f. commit d342424301013ec47dc146a4beb49d5c9319d80a
         verifier << pindex->pprev->GetBlockHash();
         verifier >> blockundo;
-        filein >> hashChecksum;
-    }
-    catch (const std::exception& e) {
-        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
-    }
 
-    // Verify checksum
-    if (hashChecksum != verifier.GetHash())
-        return error("%s: Checksum mismatch", __func__);
+        uint256 hashChecksum;
+        filein >> hashChecksum;
+
+        // Verify checksum
+        if (hashChecksum != verifier.GetHash())
+            return error("Checksum mismatch at %s while reading block undo", pos.ToString());
+    } catch (const std::exception& e) {
+        return error("Deserialize or I/O error - %s at %s while reading block undo", e.what(), pos.ToString());
+    }
 
     return true;
 }
@@ -359,9 +359,9 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint256& hashBlock, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
-    CAutoFile fileout(OpenUndoFile(pos), SER_DISK, CLIENT_VERSION);
+    CAutoFile fileout(OpenUndoFile(pos, /*fReadOnly=*/false), SER_DISK, CLIENT_VERSION);
     if (fileout.IsNull())
-        return error("%s: OpenUndoFile failed", __func__);
+        return error("OpenUndoFile failed for %s while writing block undo", pos.ToString());
 
     // Write index header
     unsigned int nSize = GetSerializeSize(fileout, blockundo);
@@ -370,15 +370,15 @@ bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint
     // Write undo data
     long fileOutPos = ftell(fileout.Get());
     if (fileOutPos < 0)
-        return error("%s: ftell failed", __func__);
+        return error("ftell failed for %s while writing block undo", pos.ToString());
     pos.nPos = (unsigned int)fileOutPos;
-    fileout << blockundo;
 
-    // calculate & write checksum
-    CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
-    hasher << hashBlock;
-    hasher << blockundo;
-    fileout << hasher.GetHash();
+    {
+        // Calculate checksum and write undo data + checksum
+        CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
+        hasher << hashBlock << blockundo;
+        fileout << blockundo << hasher.GetHash();
+    }
 
     return true;
 }

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -375,6 +375,7 @@ bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint
         CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
         hasher << hashBlock << blockundo;
         fileout << blockundo << hasher.GetHash();
+        fileout.flush();
     }
 
     return true;

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -188,13 +188,14 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex *pindex)
     }
 
     // Open history file to read
-    CAutoFile filein(OpenUndoFile(pos, /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
-    if (filein.IsNull())
+    CAutoFile file(OpenUndoFile(pos, /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
+    if (file.IsNull())
         return error("OpenUndoFile failed for %s while reading block undo", pos.ToString());
+    BufferedReader<CAutoFile> filein(file);
 
     try {
         // Read block
-        CHashVerifier<CAutoFile> verifier(&filein); // Use CHashVerifier as reserializing may lose data, c.f. commit d342424301013ec47dc146a4beb49d5c9319d80a
+        CHashVerifier<BufferedReader<CAutoFile>> verifier(&filein); // Use CHashVerifier as reserializing may lose data, c.f. commit d342424301013ec47dc146a4beb49d5c9319d80a
         verifier << pindex->pprev->GetBlockHash();
         verifier >> blockundo;
 
@@ -359,21 +360,17 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint256& hashBlock, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
-    CAutoFile fileout(OpenUndoFile(pos, /*fReadOnly=*/false), SER_DISK, CLIENT_VERSION);
-    if (fileout.IsNull())
+    CAutoFile file(OpenUndoFile(pos, /*fReadOnly=*/false), SER_DISK, CLIENT_VERSION);
+    if (file.IsNull())
         return error("OpenUndoFile failed for %s while writing block undo", pos.ToString());
 
-    // Write index header
-    unsigned int nSize = GetSerializeSize(fileout, blockundo);
-    fileout << messageStart << nSize;
-
-    // Write undo data
-    long fileOutPos = ftell(fileout.Get());
-    if (fileOutPos < 0)
-        return error("ftell failed for %s while writing block undo", pos.ToString());
-    pos.nPos = (unsigned int)fileOutPos;
+    // Write index header (unbuffered: header must be on disk before we record pos.nPos)
+    unsigned int nSize = GetSerializeSize(file, blockundo);
+    file << messageStart << nSize;
+    pos.nPos += STORAGE_HEADER_BYTES;
 
     {
+        BufferedWriter<CAutoFile> fileout(file);
         // Calculate checksum and write undo data + checksum
         CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
         hasher << hashBlock << blockundo;

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -1810,7 +1810,7 @@ bool CChainState::LoadGenesisBlock()
             // would shrink blk00000.dat to 16MB) and skips WriteBlockToDisk
             // (genesis is already on disk). Block index and xfield history are
             // still initialized correctly below.
-            CDiskBlockPos genesisKnownPos(0, BLOCK_SERIALIZATION_HEADER_SIZE);
+            CDiskBlockPos genesisKnownPos(0, STORAGE_HEADER_BYTES);
             blockPos = SaveBlockToDisk(block, 0, &genesisKnownPos);
         } else {
             blockPos = SaveBlockToDisk(block, 0, nullptr);

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -346,9 +346,9 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
 static bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
-    CAutoFile fileout(OpenBlockFile(pos), SER_DISK, CLIENT_VERSION);
+    CAutoFile fileout(OpenBlockFile(pos, /*fReadOnly=*/false), SER_DISK, CLIENT_VERSION);
     if (fileout.IsNull())
-        return error("WriteBlockToDisk: OpenBlockFile failed");
+        return error("OpenBlockFile failed for %s while writing block", pos.ToString());
 
     // Write index header
     unsigned int nSize = GetSerializeSize(fileout, block);
@@ -357,7 +357,7 @@ static bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMes
     // Write block
     long fileOutPos = ftell(fileout.Get());
     if (fileOutPos < 0)
-        return error("WriteBlockToDisk: ftell failed");
+        return error("ftell failed for %s while writing block", pos.ToString());
     pos.nPos = (unsigned int)fileOutPos;
     fileout << block;
 
@@ -378,7 +378,7 @@ CDiskBlockPos SaveBlockToDisk(const CBlock& block, int nHeight, const CDiskBlock
         nBlockSize += static_cast<unsigned int>(BLOCK_SERIALIZATION_HEADER_SIZE);
     }
     if (!FindBlockPos(blockPos, nBlockSize, nHeight, block.GetBlockTime(), position_known)) {
-        error("%s: FindBlockPos failed", __func__);
+        error("FindBlockPos failed for %s while saving block", blockPos.ToString());
         return CDiskBlockPos();
     }
     if (!position_known) {
@@ -541,9 +541,9 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos,
 {
     CDiskBlockPos hpos = pos;
     hpos.nPos -= 8; // Seek back 8 bytes for meta header
-    CAutoFile filein(OpenBlockFile(hpos, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile filein(OpenBlockFile(hpos, /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
-        return error("%s: OpenBlockFile failed for %s", __func__, pos.ToString());
+        return error("OpenBlockFile failed for %s while reading raw block", pos.ToString());
     }
 
     try {
@@ -553,20 +553,21 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos,
         filein >> blk_start >> blk_size;
 
         if (memcmp(blk_start, message_start, CMessageHeader::MESSAGE_START_SIZE)) {
-            return error("%s: Block magic mismatch for %s: %s versus expected %s", __func__, pos.ToString(),
-                    HexStr(blk_start, blk_start + CMessageHeader::MESSAGE_START_SIZE),
-                    HexStr(message_start, message_start + CMessageHeader::MESSAGE_START_SIZE));
+            return error("Block magic mismatch for %s: %s versus expected %s while reading raw block",
+                pos.ToString(),
+                HexStr(blk_start, blk_start + CMessageHeader::MESSAGE_START_SIZE),
+                HexStr(message_start, message_start + CMessageHeader::MESSAGE_START_SIZE));
         }
 
         if (blk_size > MAX_SIZE) {
-            return error("%s: Block data is larger than maximum deserialization size for %s: %s versus %s", __func__, pos.ToString(),
-                    blk_size, MAX_SIZE);
+            return error("Block data is larger than maximum deserialization size for %s: %s versus %s while reading raw block",
+                pos.ToString(), blk_size, MAX_SIZE);
         }
 
         block.resize(blk_size); // Zeroing of memory is intentional here
         filein.read((char*)block.data(), blk_size);
     } catch(const std::exception& e) {
-        return error("%s: Read from block file failed: %s for %s", __func__, e.what(), pos.ToString());
+        return error("Read from block file failed: %s for %s while reading raw block", e.what(), pos.ToString());
     }
 
     return true;
@@ -578,16 +579,16 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
     block.SetNull();
 
     // Open history file to read
-    CAutoFile filein(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile filein(OpenBlockFile(pos, /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull())
-        return error("ReadBlockFromDisk: OpenBlockFile failed for %s", pos.ToString());
+        return error("OpenBlockFile failed for %s while reading block", pos.ToString());
 
     // Read block
     try {
         filein >> block;
     }
     catch (const std::exception& e) {
-        return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
+        return error("Deserialize or I/O error - %s at %s while reading block", e.what(), pos.ToString());
     }
 
     // Use nHeight from the trusted block index (pindex->nHeight) when available.
@@ -596,7 +597,7 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
     // Never use block.GetHeight() (coinbase prevout.n): that field is attacker-controlled.
     CValidationState state;
     if(!CheckBlockHeader(block.GetBlockHeader(), state, pxfieldHistory, nHeight, true))
-        return error("%s: ReadBlockFromDisk: %s", __func__, FormatStateMessage(state));
+        return error("Errors in block header at %s while reading block: %s nHeight = %d", pos.ToString(), FormatStateMessage(state), nHeight);
 
     return true;
 }
@@ -615,7 +616,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex)
     if (!ReadBlockFromDisk(block, blockPos, nullptr, pindex->nHeight))
         return false;
     if (block.GetHash() != pindex->GetBlockHash())
-        return error("ReadBlockFromDisk(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s",
+        return error("GetHash() doesn't match index for %s at %s while reading block",
                 pindex->ToString(), pindex->GetBlockPos().ToString());
     return true;
 }

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -358,6 +358,7 @@ static bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMes
     {
         BufferedWriter<CAutoFile> fileout(file);
         fileout << block;
+        fileout.flush();
     }
 
     return true;

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -346,20 +346,19 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp, CXFieldHistoryMap* 
 static bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
-    CAutoFile fileout(OpenBlockFile(pos, /*fReadOnly=*/false), SER_DISK, CLIENT_VERSION);
-    if (fileout.IsNull())
+    CAutoFile file(OpenBlockFile(pos, /*fReadOnly=*/false), SER_DISK, CLIENT_VERSION);
+    if (file.IsNull())
         return error("OpenBlockFile failed for %s while writing block", pos.ToString());
 
-    // Write index header
-    unsigned int nSize = GetSerializeSize(fileout, block);
-    fileout << messageStart << nSize;
+    // Write index header (unbuffered: header must be on disk before we record pos.nPos)
+    unsigned int nSize = GetSerializeSize(file, block);
+    file << messageStart << nSize;
+    pos.nPos += STORAGE_HEADER_BYTES;
 
-    // Write block
-    long fileOutPos = ftell(fileout.Get());
-    if (fileOutPos < 0)
-        return error("ftell failed for %s while writing block", pos.ToString());
-    pos.nPos = (unsigned int)fileOutPos;
-    fileout << block;
+    {
+        BufferedWriter<CAutoFile> fileout(file);
+        fileout << block;
+    }
 
     return true;
 }
@@ -581,16 +580,17 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
 {
     block.SetNull();
 
-    // Open history file to read
-    CAutoFile filein(OpenBlockFile(pos, /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
-    if (filein.IsNull())
-        return error("OpenBlockFile failed for %s while reading block", pos.ToString());
-
-    // Read block
-    try {
-        filein >> block;
+    // Read raw block bytes (handles header + checksum internally)
+    std::vector<uint8_t> block_data;
+    if (!ReadRawBlockFromDisk(block_data, pos)) {
+        return false;
     }
-    catch (const std::exception& e) {
+
+    // Deserialize from memory buffer
+    try {
+        SpanReader spanreader(SER_DISK, CLIENT_VERSION, block_data);
+        spanreader >> block;
+    } catch (const std::exception& e) {
         return error("Deserialize or I/O error - %s at %s while reading block", e.what(), pos.ToString());
     }
 

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -373,9 +373,9 @@ CDiskBlockPos SaveBlockToDisk(const CBlock& block, int nHeight, const CDiskBlock
         blockPos = *dbp;
     } else {
         // when known, blockPos.nPos points at the offset of the block data in the blk file. that already accounts for
-        // the serialization header present in the file (the 4 magic message start bytes + the 4 length bytes = 8 bytes = BLOCK_SERIALIZATION_HEADER_SIZE).
-        // we add BLOCK_SERIALIZATION_HEADER_SIZE only for new blocks since they will have the serialization header added when written to disk.
-        nBlockSize += static_cast<unsigned int>(BLOCK_SERIALIZATION_HEADER_SIZE);
+        // the serialization header present in the file (the 4 magic message start bytes + the 4 length bytes = 8 bytes = STORAGE_HEADER_BYTES).
+        // we add STORAGE_HEADER_BYTES only for new blocks since they will have the serialization header added when written to disk.
+        nBlockSize += static_cast<unsigned int>(STORAGE_HEADER_BYTES);
     }
     if (!FindBlockPos(blockPos, nBlockSize, nHeight, block.GetBlockTime(), position_known)) {
         error("FindBlockPos failed for %s while saving block", blockPos.ToString());
@@ -539,9 +539,12 @@ void  FlushBlockFile(bool fFinalize)
 
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& message_start)
 {
-    CDiskBlockPos hpos = pos;
-    hpos.nPos -= 8; // Seek back 8 bytes for meta header
-    CAutoFile filein(OpenBlockFile(hpos, /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
+    if (pos.nPos < STORAGE_HEADER_BYTES) {
+        // If nPos is less than STORAGE_HEADER_BYTES, we can't read the header that precedes the block data.
+        // This would cause an unsigned integer underflow when trying to position the file cursor.
+        return error("Failed for %s while reading raw block storage header", pos.ToString());
+    }
+    CAutoFile filein(OpenBlockFile(CDiskBlockPos(pos.nFile, pos.nPos - STORAGE_HEADER_BYTES), /*fReadOnly=*/true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
         return error("OpenBlockFile failed for %s while reading raw block", pos.ToString());
     }

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -580,9 +580,9 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, CXFieldHistoryMa
 {
     block.SetNull();
 
-    // Read raw block bytes (handles header + checksum internally)
+    // Read raw block bytes (handles header validation internally)
     std::vector<uint8_t> block_data;
-    if (!ReadRawBlockFromDisk(block_data, pos)) {
+    if (!ReadRawBlockFromDisk(block_data, pos, FederationParams().MessageStart())) {
         return false;
     }
 

--- a/src/file_io.h
+++ b/src/file_io.h
@@ -48,7 +48,7 @@ FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
 CDiskBlockPos SaveBlockToDisk(const CBlock& block, int nHeight, const CDiskBlockPos* dbp);
 
-/** Size of header written by WriteBlockToDisk (network magic + block size) */
-static constexpr size_t BLOCK_SERIALIZATION_HEADER_SIZE = CMessageHeader::MESSAGE_START_SIZE + sizeof(unsigned int);
+/** Size of header written before serialized block/undo data on disk (4 magic bytes + 4 length bytes) */
+static constexpr uint32_t STORAGE_HEADER_BYTES{CMessageHeader::MESSAGE_START_SIZE + sizeof(unsigned int)};
 
 #endif // BITCOIN_FILE_IO_H

--- a/src/streams.h
+++ b/src/streams.h
@@ -816,7 +816,15 @@ public:
     explicit BufferedWriter(S& stream, size_t buf_size = 1 << 16)
         : m_dst{stream}, m_buf(buf_size) {}
 
-    ~BufferedWriter() { flush(); }
+    // noexcept(false): flush() can throw (e.g. disk full via CAutoFile::write).
+    // m_buf_pos is cleared before write_buffer is called so that a throw inside
+    // flush() leaves m_buf_pos == 0; the destructor's flush() then becomes a
+    // no-op and the exception propagates cleanly without a second throw.
+    // If operator<< threw with data still buffered, the destructor may still
+    // re-enter flush() with m_buf_pos > 0 and produce a second throw during
+    // stack unwinding, which calls std::terminate. Prevent this by calling
+    // flush() explicitly before the BufferedWriter scope closes.
+    ~BufferedWriter() noexcept(false) { flush(); }
 
     int GetType() const { return m_dst.GetType(); }
     int GetVersion() const { return m_dst.GetVersion(); }
@@ -824,8 +832,9 @@ public:
     void flush()
     {
         if (m_buf_pos) {
-            m_dst.write_buffer(m_buf.data(), m_buf_pos);
+            size_t to_write = m_buf_pos;
             m_buf_pos = 0;
+            m_dst.write_buffer(m_buf.data(), to_write);
         }
     }
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -533,6 +533,20 @@ public:
             throw std::ios_base::failure("CAutoFile::write: write failed");
     }
 
+    /** Read up to nSize bytes, returning the actual count (non-throwing, for use by BufferedReader). */
+    size_t detail_fread(char* pch, size_t nSize)
+    {
+        if (!file)
+            throw std::ios_base::failure("CAutoFile::detail_fread: file handle is nullptr");
+        return fread(pch, 1, nSize, file);
+    }
+
+    /** Write nSize bytes; for use by BufferedWriter. */
+    void write_buffer(const char* pch, size_t nSize)
+    {
+        write(pch, nSize);
+    }
+
     template<typename T>
     CAutoFile& operator<<(const T& obj)
     {
@@ -702,6 +716,136 @@ public:
                 break;
             nReadPos++;
         }
+    }
+};
+
+/** Buffer type used by BufferedReader and BufferedWriter. */
+using DataBuffer = std::vector<char>;
+
+/**
+ * Minimal stream that deserializes from a byte vector.
+ * Stores nType and nVersion for Tapyrus serialization compatibility.
+ */
+class SpanReader
+{
+    const int nType;
+    const int nVersion;
+    const std::vector<uint8_t>& m_data;
+    size_t m_pos{0};
+
+public:
+    SpanReader(int nTypeIn, int nVersionIn, const std::vector<uint8_t>& data)
+        : nType(nTypeIn), nVersion(nVersionIn), m_data(data) {}
+
+    int GetType() const { return nType; }
+    int GetVersion() const { return nVersion; }
+
+    void read(char* pch, size_t nSize)
+    {
+        if (nSize > m_data.size() - m_pos)
+            throw std::ios_base::failure("SpanReader::read: end of data");
+        memcpy(pch, m_data.data() + m_pos, nSize);
+        m_pos += nSize;
+    }
+
+    template<typename T>
+    SpanReader& operator>>(T&& obj)
+    {
+        ::Unserialize(*this, obj);
+        return *this;
+    }
+};
+
+/**
+ * Wrapper that buffers reads from an underlying stream.
+ * Reduces the number of fread calls by reading ahead in larger batches.
+ * Requires the underlying stream to support read() and detail_fread().
+ */
+template <typename S>
+class BufferedReader
+{
+    S& m_src;
+    DataBuffer m_buf;
+    size_t m_buf_pos{0};
+    size_t m_buf_valid{0};
+
+public:
+    explicit BufferedReader(S& stream, size_t buf_size = 1 << 16)
+        : m_src{stream}, m_buf(buf_size) {}
+
+    int GetType() const { return m_src.GetType(); }
+    int GetVersion() const { return m_src.GetVersion(); }
+
+    void read(char* pch, size_t nSize)
+    {
+        if (const auto available = std::min(nSize, m_buf_valid - m_buf_pos)) {
+            memcpy(pch, m_buf.data() + m_buf_pos, available);
+            m_buf_pos += available;
+            pch += available;
+            nSize -= available;
+        }
+        if (nSize > 0) {
+            assert(m_buf_pos == m_buf_valid);
+            m_src.read(pch, nSize);
+            m_buf_pos = 0;
+            m_buf_valid = m_src.detail_fread(m_buf.data(), m_buf.size());
+        }
+    }
+
+    template<typename T>
+    BufferedReader& operator>>(T&& obj)
+    {
+        ::Unserialize(*this, obj);
+        return *this;
+    }
+};
+
+/**
+ * Wrapper that buffers writes to an underlying stream.
+ * Reduces the number of fwrite calls by collecting writes in a buffer.
+ * Requires the underlying stream to support write_buffer().
+ */
+template <typename S>
+class BufferedWriter
+{
+    S& m_dst;
+    DataBuffer m_buf;
+    size_t m_buf_pos{0};
+
+public:
+    explicit BufferedWriter(S& stream, size_t buf_size = 1 << 16)
+        : m_dst{stream}, m_buf(buf_size) {}
+
+    ~BufferedWriter() { flush(); }
+
+    int GetType() const { return m_dst.GetType(); }
+    int GetVersion() const { return m_dst.GetVersion(); }
+
+    void flush()
+    {
+        if (m_buf_pos) {
+            m_dst.write_buffer(m_buf.data(), m_buf_pos);
+            m_buf_pos = 0;
+        }
+    }
+
+    void write(const char* pch, size_t nSize)
+    {
+        while (nSize > 0) {
+            const size_t available = std::min(nSize, m_buf.size() - m_buf_pos);
+            memcpy(m_buf.data() + m_buf_pos, pch, available);
+            m_buf_pos += available;
+            if (m_buf_pos == m_buf.size()) flush();
+            pch += available;
+            nSize -= available;
+        }
+    }
+
+    template<typename T>
+    BufferedWriter& operator<<(const T& obj)
+    {
+        ::Serialize(*this, obj);
+        return *this;
     }
 };
 

--- a/src/test/file_io_tests.cpp
+++ b/src/test/file_io_tests.cpp
@@ -32,14 +32,14 @@ BOOST_AUTO_TEST_CASE(file_io_find_block_pos)
     // When a genesis block is added normally, it should be written at offset 8
     // (after the 8-byte serialization header)
     CDiskBlockPos pos1 = SaveBlockToDisk(genesisBlock, 0, nullptr);
-    BOOST_CHECK_EQUAL(pos1.nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
+    BOOST_CHECK_EQUAL(pos1.nPos, STORAGE_HEADER_BYTES);
 
     // Scenario 2: Simulate what happens during reindex
     // During reindex, blocks are found at known positions in the blk file.
     // The genesis block is found at offset 8 (after its serialization header).
-    CDiskBlockPos knownPos(0, BLOCK_SERIALIZATION_HEADER_SIZE);
+    CDiskBlockPos knownPos(0, STORAGE_HEADER_BYTES);
     CDiskBlockPos pos2 = SaveBlockToDisk(genesisBlock, 0, &knownPos);
-    BOOST_CHECK_EQUAL(pos2.nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
+    BOOST_CHECK_EQUAL(pos2.nPos, STORAGE_HEADER_BYTES);
 
     // Scenario 3: After reindex, when a new block is processed
     // This is the critical test that verifies the fix.
@@ -48,9 +48,9 @@ BOOST_AUTO_TEST_CASE(file_io_find_block_pos)
     // + size of genesis block
     // + 8 bytes (serialization header for the new block)
     CDiskBlockPos pos3 = SaveBlockToDisk(genesisBlock, 1, nullptr);
-    unsigned int expectedPos = BLOCK_SERIALIZATION_HEADER_SIZE +
+    unsigned int expectedPos = STORAGE_HEADER_BYTES +
                                ::GetSerializeSize(genesisBlock, SER_DISK, CLIENT_VERSION) +
-                               BLOCK_SERIALIZATION_HEADER_SIZE;
+                               STORAGE_HEADER_BYTES;
     BOOST_CHECK_EQUAL(pos3.nPos, expectedPos);
 
     // This assertion ensures that the bug described in issue #21379 does not recur:

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -148,9 +148,118 @@ BOOST_AUTO_TEST_CASE(buffered_writer_reader_round_trip)
         BOOST_CHECK_EQUAL(r1, v1);
         BOOST_CHECK_EQUAL(r2, v2);
         BOOST_CHECK_EQUAL(r3, v3);
+
+        // Reading past end-of-file must throw
+        DataBuffer extra(1);
+        BOOST_CHECK_THROW(reader.read(extra.data(), 1), std::ios_base::failure);
     }
 
     fs::remove(test_file);
+}
+
+BOOST_AUTO_TEST_CASE(buffered_reader_matches_autofile_random_content)
+{
+    // Use a random file size and buffer size to cover all buffer boundary cases
+    const size_t file_size = 1 + InsecureRandRange(1 << 17);
+    const size_t buf_size  = 1 + InsecureRandRange(file_size);
+    const fs::path test_file = GetDataDir() / "test_buffered_reader_random.bin";
+
+    // Write random content directly via CAutoFile
+    {
+        auto random_data = insecure_rand_ctx.randbytes(file_size);
+        CAutoFile file(fsbridge::fopen(test_file, "wb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!file.IsNull());
+        file.write(reinterpret_cast<const char*>(random_data.data()), file_size);
+    }
+
+    // Open the same file twice: once direct, once via BufferedReader
+    {
+        CAutoFile direct_file(fsbridge::fopen(test_file, "rb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!direct_file.IsNull());
+
+        CAutoFile buffered_file(fsbridge::fopen(test_file, "rb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!buffered_file.IsNull());
+        BufferedReader<CAutoFile> buffered_reader(buffered_file, buf_size);
+
+        // Read in random chunk sizes and compare byte-by-byte
+        for (size_t total_read = 0; total_read < file_size; ) {
+            size_t max_chunk = InsecureRandBool() ? buf_size : 2 * buf_size;
+            size_t read_size = 1 + InsecureRandRange(std::min(max_chunk, file_size - total_read));
+
+            DataBuffer direct_buf(read_size), buffered_buf(read_size);
+            direct_file.read(direct_buf.data(), read_size);
+            buffered_reader.read(buffered_buf.data(), read_size);
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(
+                direct_buf.begin(), direct_buf.end(),
+                buffered_buf.begin(), buffered_buf.end());
+
+            total_read += read_size;
+        }
+
+        // Both must throw at EOF
+        DataBuffer excess(1);
+        BOOST_CHECK_THROW(direct_file.read(excess.data(), 1), std::ios_base::failure);
+        BOOST_CHECK_THROW(buffered_reader.read(excess.data(), 1), std::ios_base::failure);
+    }
+
+    fs::remove(test_file);
+}
+
+BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
+{
+    const size_t file_size = 1 + InsecureRandRange(1 << 17);
+    const size_t buf_size  = 1 + InsecureRandRange(file_size);
+    const fs::path file_direct   = GetDataDir() / "test_bw_direct.bin";
+    const fs::path file_buffered = GetDataDir() / "test_bw_buffered.bin";
+
+    // Generate random test data once
+    auto test_data = insecure_rand_ctx.randbytes(file_size);
+
+    // Write the same data to two files using direct CAutoFile vs BufferedWriter
+    {
+        CAutoFile direct(fsbridge::fopen(file_direct, "wb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!direct.IsNull());
+
+        CAutoFile buffered_file(fsbridge::fopen(file_buffered, "wb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!buffered_file.IsNull());
+        BufferedWriter<CAutoFile> buffered(buffered_file, buf_size);
+
+        for (size_t total_written = 0; total_written < file_size; ) {
+            size_t max_chunk = InsecureRandBool() ? buf_size : 2 * buf_size;
+            size_t write_size = 1 + InsecureRandRange(std::min(max_chunk, file_size - total_written));
+
+            const char* chunk = reinterpret_cast<const char*>(test_data.data()) + total_written;
+            direct.write(chunk, write_size);
+            buffered.write(chunk, write_size);
+            total_written += write_size;
+        }
+        // BufferedWriter flushes in its destructor
+    }
+
+    // Read back both files and compare
+    DataBuffer direct_result(file_size), buffered_result(file_size);
+    {
+        CAutoFile f(fsbridge::fopen(file_direct, "rb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!f.IsNull());
+        f.read(direct_result.data(), file_size);
+        DataBuffer excess(1);
+        BOOST_CHECK_THROW(f.read(excess.data(), 1), std::ios_base::failure);
+    }
+    {
+        CAutoFile f(fsbridge::fopen(file_buffered, "rb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!f.IsNull());
+        f.read(buffered_result.data(), file_size);
+        DataBuffer excess(1);
+        BOOST_CHECK_THROW(f.read(excess.data(), 1), std::ios_base::failure);
+    }
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        direct_result.begin(), direct_result.end(),
+        buffered_result.begin(), buffered_result.end());
+
+    fs::remove(file_direct);
+    fs::remove(file_buffered);
 }
 
 BOOST_AUTO_TEST_CASE(span_reader_round_trip)

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) 2012-2018 The Bitcoin Core developers
-// Copyright (c) 2019 Chaintope Inc.
+// Copyright (c) 2019-2025 Chaintope Inc.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <fs.h>
 #include <streams.h>
 #include <support/allocators/zeroafterfree.h>
 #include <test/test_tapyrus.h>
@@ -122,6 +123,55 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     BOOST_CHECK_EQUAL(
             std::string(expected_xor.begin(), expected_xor.end()),
             std::string(ds.begin(), ds.end()));
+}
+
+BOOST_AUTO_TEST_CASE(buffered_writer_reader_round_trip)
+{
+    const uint32_t v1 = 0x12345678, v2 = 0xDEADBEEF, v3 = 0xCAFEBABE;
+    const fs::path test_file = GetDataDir() / "test_buffered_write_read.bin";
+
+    // Write via BufferedWriter with a 2-value-sized buffer to exercise flushing
+    {
+        CAutoFile file(fsbridge::fopen(test_file, "w+b"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!file.IsNull());
+        BufferedWriter<CAutoFile> writer(file, sizeof(v1) + sizeof(v2));
+        writer << v1 << v2 << v3;
+    }
+
+    // Read back using BufferedReader with same buffer size
+    {
+        uint32_t r1 = 0, r2 = 0, r3 = 0;
+        CAutoFile file(fsbridge::fopen(test_file, "rb"), SER_DISK, CLIENT_VERSION);
+        BOOST_REQUIRE(!file.IsNull());
+        BufferedReader<CAutoFile> reader(file, sizeof(v1) + sizeof(v2));
+        reader >> r1 >> r2 >> r3;
+        BOOST_CHECK_EQUAL(r1, v1);
+        BOOST_CHECK_EQUAL(r2, v2);
+        BOOST_CHECK_EQUAL(r3, v3);
+    }
+
+    fs::remove(test_file);
+}
+
+BOOST_AUTO_TEST_CASE(span_reader_round_trip)
+{
+    const uint32_t v1 = 0x12345678, v2 = 0xABCDEF01;
+
+    // Build a raw byte vector manually
+    std::vector<uint8_t> data(sizeof(v1) + sizeof(v2));
+    memcpy(data.data(), &v1, sizeof(v1));
+    memcpy(data.data() + sizeof(v1), &v2, sizeof(v2));
+
+    // Read back via SpanReader
+    uint32_t r1 = 0, r2 = 0;
+    SpanReader reader(SER_DISK, CLIENT_VERSION, data);
+    reader >> r1 >> r2;
+    BOOST_CHECK_EQUAL(r1, v1);
+    BOOST_CHECK_EQUAL(r2, v2);
+
+    // Reading past the end must throw
+    uint32_t extra = 0;
+    BOOST_CHECK_THROW(reader >> extra, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
  - Ports Bitcoin Core PR#31551: adds `SpanReader`, `BufferedReader`, and `BufferedWriter` to `streams.h`, then uses them for bulk serialization in block and undo file I/O
  - **`SpanReader`**: a read-only stream over a `Span<const std::byte>` — zero-copy deserialization from an already-loaded buffer
  - **`BufferedReader`**: wraps any stream and reads ahead in configurable chunks, reducing `fread` syscall count during block deserialization
  - **`BufferedWriter`**: wraps any stream and accumulates writes in a buffer, reducing `fwrite` syscall count during block/undo serialization; flushes on destruction
  - Block reads (`ReadBlockFromDisk`): now delegates to `ReadRawBlockFromDisk` (single `fread` into a buffer), then deserializes from a `SpanReader` — one syscall per block instead of many
  - Undo reads (`UndoReadFromDisk`): wraps `CAutoFile` in `BufferedReader` before passing to `CHashVerifier`
  - Block/undo writes (`WriteBlockToDisk`, `UndoWriteToDisk`): writes the 8-byte storage header unbuffered (to capture correct `pos.nPos`), then wraps subsequent data in `BufferedWriter`; replaces `ftell` with `pos.nPos +=
  STORAGE_HEADER_BYTES`
  - Refactors block I/O error handling into `try` blocks with unified error messages; renames `BLOCK_SERIALIZATION_HEADER_SIZE` → `STORAGE_HEADER_BYTES` for clarity

  Expected speedups (Bitcoin Core measurements on equivalent change): ~30% read, ~168% write on macOS/Clang; ~19% read, ~24% write on Linux/GCC.
  