### PR TITLE
Fix macos build failure in depends Qt build

### DIFF
--- a/depends/packages/native_qt.mk
+++ b/depends/packages/native_qt.mk
@@ -8,6 +8,7 @@ $(package)_patches_path := $(qt_details_patches_path)
 $(package)_patches := qtbase-moc-ignore-gcc-macro.patch
 $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += skip_xcode_version_check.patch
+$(package)_patches += fix_qyieldcpu_arm_acle.patch
 
 $(package)_qttranslations_file_name=$(qt_details_qttranslations_file_name)
 $(package)_qttranslations_sha256_hash=$(qt_details_qttranslations_sha256_hash)
@@ -129,7 +130,8 @@ endef
 define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \
   patch -p1 -i $($(package)_patch_dir)/rcc_hardcode_timestamp.patch && \
-  patch -p1 -i $($(package)_patch_dir)/skip_xcode_version_check.patch
+  patch -p1 -i $($(package)_patch_dir)/skip_xcode_version_check.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_qyieldcpu_arm_acle.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -16,6 +16,7 @@ $(package)_patches += qttools_skip_dependencies.patch
 $(package)_patches += fix_qnetconmonitor_cross_compile.patch
 ifeq ($(host_os),darwin)
 $(package)_patches += fix_cgdisplay_macos15.patch
+$(package)_patches += fix_qyieldcpu_arm_acle.patch
 endif
 
 $(package)_qttranslations_file_name=$(qt_details_qttranslations_file_name)
@@ -271,6 +272,7 @@ ifeq ($(host),$(build))
 endif
 ifeq ($(host_os),darwin)
   $(package)_preprocess_cmds += && patch -p1 -i $($(package)_patch_dir)/fix_cgdisplay_macos15.patch
+  $(package)_preprocess_cmds += && patch -p1 -i $($(package)_patch_dir)/fix_qyieldcpu_arm_acle.patch
 endif
 
 define $(package)_config_cmds

--- a/depends/patches/qt/fix_qyieldcpu_arm_acle.patch
+++ b/depends/patches/qt/fix_qyieldcpu_arm_acle.patch
@@ -1,0 +1,15 @@
+diff --git a/qtbase/src/corelib/thread/qyieldcpu.h b/qtbase/src/corelib/thread/qyieldcpu.h
+--- a/qtbase/src/corelib/thread/qyieldcpu.h
++++ b/qtbase/src/corelib/thread/qyieldcpu.h
+@@ -19,6 +19,10 @@
+ #  endif
+ void _mm_pause(void);       // the compiler recognizes as intrinsic
+ #endif
+
++#if __has_builtin(__yield) && __has_include(<arm_acle.h>)
++#include <arm_acle.h>
++#endif
++
+ QT_BEGIN_NAMESPACE
+
+ Q_ALWAYS_INLINE


### PR DESCRIPTION
Fix macos depends build failure: add fix_qyieldcpu_arm_acle.patch to include arm_acle.h to declare __yield