### PR TITLE
IPv6 support: fix link-local detection, observability, and test coverage

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -402,6 +402,8 @@ public:
         }
 
         // Deserialize entries from the new table.
+        // All entries (IPv4 and IPv6) are always deserialized unconditionally; nVersion
+        // only controls whether on-disk bucket positions are trusted (v1) or recomputed (v0).
         for (int n = 0; n < nNew; n++) {
             CAddrInfo &info = mapInfo[n];
             s >> info;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -169,8 +169,11 @@ static bool InitHTTPAllowList()
     CNetAddr localv6;
     LookupHost("127.0.0.1", localv4, false);
     LookupHost("::1", localv6, false);
-    rpc_allow_subnets.push_back(CSubNet(localv4, 8));      // always allow IPv4 local subnet
-    rpc_allow_subnets.push_back(CSubNet(localv6));         // always allow IPv6 localhost
+    // RFC 5735 reserves 127.0.0.0/8 for IPv4 loopback; allow the full range.
+    // RFC 4291 §2.5.3 defines only ::1/128 as the IPv6 loopback — there is no
+    // equivalent loopback /8 in IPv6, so the asymmetry here is intentional.
+    rpc_allow_subnets.push_back(CSubNet(localv4, 8));      // always allow IPv4 local subnet (127.0.0.0/8)
+    rpc_allow_subnets.push_back(CSubNet(localv6));         // always allow IPv6 localhost (::1/128)
     for (const std::string& strAllow : gArgs.GetArgs("-rpcallowip")) {
         CSubNet subnet;
         LookupSubNet(strAllow.c_str(), subnet);
@@ -322,6 +325,9 @@ static bool HTTPBindAddresses(struct evhttp* http)
     // Bind addresses
     for (std::vector<std::pair<std::string, uint16_t> >::iterator i = endpoints.begin(); i != endpoints.end(); ++i) {
         LogPrint(BCLog::HTTP, "Binding RPC on address %s port %i\n", i->first, i->second);
+        // evhttp_bind_socket_with_handle resolves the host string via getaddrinfo
+        // internally. Bare IPv6 addresses (e.g. "::1", "::") without brackets are
+        // handled correctly by libevent ≥ 2.1.x (our minimum is 2.1.12).
         evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(http, i->first.empty() ? nullptr : i->first.c_str(), i->second);
         if (bind_handle) {
             boundSockets.push_back(bind_handle);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -394,16 +394,16 @@ void SetupServerArgs()
 #endif
     gArgs.AddArg("-txindex", strprintf("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)", DEFAULT_TXINDEX), false, OptionsCategory::OPTIONS);
 
-    gArgs.AddArg("-addnode=<ip>", "Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info). This option can be specified multiple times to add multiple nodes.", false, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-addnode=<ip[:port]>", "Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info). Use [host]:port notation for IPv6 (e.g. [2001:db8::1]:8383). This option can be specified multiple times to add multiple nodes.", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-banscore=<n>", strprintf("Threshold for disconnecting misbehaving peers (default: %u)", DEFAULT_BANSCORE_THRESHOLD), false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-bantime=<n>", strprintf("Number of seconds to keep misbehaving peers from reconnecting (default: %u)", DEFAULT_MISBEHAVING_BANTIME), false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-bind=<addr>", "Bind to given address and always listen on it. Use [host]:port notation for IPv6", false, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-connect=<ip>", "Connect only to the specified node; -noconnect disables automatic connections (the rules for this peer are the same as for -addnode). This option can be specified multiple times to connect to multiple nodes.", false, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-connect=<ip[:port]>", "Connect only to the specified node; -noconnect disables automatic connections (the rules for this peer are the same as for -addnode). Use [host]:port notation for IPv6 (e.g. [2001:db8::1]:8383). This option can be specified multiple times to connect to multiple nodes.", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-discover", "Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-dns", strprintf("Allow DNS lookups for -addnode, -seednode and -connect (default: %u)", DEFAULT_NAME_LOOKUP), false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-dnsseed", "Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect used)", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-addseeder=<ip>", "IP address of the dns seeder server to use", false, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-externalip=<ip>", "Specify your own public address", false, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-externalip=<ip>", "Specify your own public address. Use bracket notation for IPv6 (e.g. [2001:db8::1])", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-forcednsseed", strprintf("Always query for peer addresses via DNS lookup (default: %u)", DEFAULT_FORCEDNSSEED), false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-listen", "Accept connections from outside (default: 1 if no -proxy or -connect)", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-listenonion", strprintf("Automatically create Tor hidden service (default: %d)", DEFAULT_LISTEN_ONION), false, OptionsCategory::CONNECTION);
@@ -431,16 +431,16 @@ void SetupServerArgs()
     hidden_args.emplace_back("-upnp");
 #endif
     gArgs.AddArg("-whitebind=<addr>", "Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6", false, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-whitelist=<IP address or network>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times."
+    gArgs.AddArg("-whitelist=<IP address or network>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4 or 2001:db8::1) or CIDR notated network (e.g. 1.2.3.0/24 or 2001:db8::/32). Can be specified multiple times."
         " Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway", false, OptionsCategory::CONNECTION);
 
     g_wallet_init_interface.AddWalletOptions();
 
 #if ENABLE_ZMQ
-    gArgs.AddArg("-zmqpubhashblock=<address>", "Enable publish hash block in <address>", false, OptionsCategory::ZMQ);
-    gArgs.AddArg("-zmqpubhashtx=<address>", "Enable publish hash transaction in <address>", false, OptionsCategory::ZMQ);
-    gArgs.AddArg("-zmqpubrawblock=<address>", "Enable publish raw block in <address>", false, OptionsCategory::ZMQ);
-    gArgs.AddArg("-zmqpubrawtx=<address>", "Enable publish raw transaction in <address>", false, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubhashblock=<address>", "Enable publish hash block in <address> (e.g. tcp://127.0.0.1:28332 or tcp://[::1]:28332)", false, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubhashtx=<address>", "Enable publish hash transaction in <address> (e.g. tcp://127.0.0.1:28333 or tcp://[::1]:28333)", false, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubrawblock=<address>", "Enable publish raw block in <address> (e.g. tcp://127.0.0.1:28334 or tcp://[::1]:28334)", false, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubrawtx=<address>", "Enable publish raw transaction in <address> (e.g. tcp://127.0.0.1:28335 or tcp://[::1]:28335)", false, OptionsCategory::ZMQ);
 #else
     hidden_args.emplace_back("-zmqpubhashblock=<address>");
     hidden_args.emplace_back("-zmqpubhashtx=<address>");
@@ -499,7 +499,7 @@ void SetupServerArgs()
     gArgs.AddArg("-blockmaxsize=<n>", strprintf("Set maximum block size in bytes (default: %d)", DEFAULT_BLOCK_MAX_SIZE), false, OptionsCategory::BLOCK_CREATION);
 
     gArgs.AddArg("-rest", strprintf("Accept public REST requests (default: %u)", DEFAULT_REST_ENABLE), false, OptionsCategory::RPC);
-    gArgs.AddArg("-rpcallowip=<ip>", "Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times", false, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcallowip=<ip>", "Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4 or 2001:db8::1), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24 or 2001:db8::/32). This option can be specified multiple times", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcauth=<userpw>", "Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcauth. The client then connects normally using the rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can be specified multiple times", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcbind=<addr>[:port]", "Bind to given address to listen for JSON-RPC connections. This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost, or if -rpcallowip has been specified, 0.0.0.0 and :: i.e., all addresses)", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", false, OptionsCategory::RPC);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -210,8 +210,11 @@ void AdvertiseLocal(CNode *pnode)
 // learn a new local address
 bool AddLocal(const CService& addr, int nScore)
 {
-    if (!addr.IsRoutable())
+    if (!addr.IsRoutable()) {
+        if (nScore >= LOCAL_MANUAL)
+            LogPrintf("AddLocal: ignoring non-routable address %s passed via -externalip\n", addr.ToString());
         return false;
+    }
 
     if (!fDiscover && nScore < LOCAL_MANUAL)
         return false;
@@ -1484,6 +1487,10 @@ static CThreadInterrupt g_upnp_interrupt;
 static std::thread g_upnp_thread;
 static void ThreadMapPort()
 {
+    if (!IsReachable(NET_IPV4)) {
+        LogPrintf("UPnP: skipping port mapping — UPnP IGD only discovers IPv4 external addresses and the node has no IPv4 reachability\n");
+        return;
+    }
     std::string port = strprintf("%u", GetListenPort());
     const char * multicastif = nullptr;
     const char * minissdpdpath = nullptr;
@@ -2265,8 +2272,12 @@ bool CConnman::InitBinds(const std::vector<CService>& binds, const std::vector<C
         struct in_addr inaddr_any;
         inaddr_any.s_addr = INADDR_ANY;
         struct in6_addr inaddr6_any = IN6ADDR_ANY_INIT;
+        // IPv6 wildcard bind uses BF_NONE intentionally: IPv6 availability is
+        // optional on the host, so failure is tolerable (BindListenPort still
+        // logs it).  IPv4 is assumed always present and uses BF_REPORT_ERROR
+        // so a failure produces a user-visible error dialog in addition to the log.
         fBound |= Bind(CService(inaddr6_any, GetListenPort()), BF_NONE);
-        fBound |= Bind(CService(inaddr_any, GetListenPort()), !fBound ? BF_REPORT_ERROR : BF_NONE);
+        fBound |= Bind(CService(inaddr_any, GetListenPort()), BF_REPORT_ERROR);
     }
     return fBound;
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2272,12 +2272,14 @@ bool CConnman::InitBinds(const std::vector<CService>& binds, const std::vector<C
         struct in_addr inaddr_any;
         inaddr_any.s_addr = INADDR_ANY;
         struct in6_addr inaddr6_any = IN6ADDR_ANY_INIT;
-        // IPv6 wildcard bind uses BF_NONE intentionally: IPv6 availability is
-        // optional on the host, so failure is tolerable (BindListenPort still
-        // logs it).  IPv4 is assumed always present and uses BF_REPORT_ERROR
-        // so a failure produces a user-visible error dialog in addition to the log.
+        // IPv6 wildcard bind never reports: IPv6 availability is optional on
+        // the host, so failure here is tolerable (BindListenPort still logs
+        // it). IPv4 only reports if IPv6 hasn't already bound, so a listener
+        // is guaranteed via at least one family - an IPv6-only host that
+        // successfully binds :: doesn't get a spurious "Cannot bind" dialog
+        // for the IPv4 wildcard it was never going to use.
         fBound |= Bind(CService(inaddr6_any, GetListenPort()), BF_NONE);
-        fBound |= Bind(CService(inaddr_any, GetListenPort()), BF_REPORT_ERROR);
+        fBound |= Bind(CService(inaddr_any, GetListenPort()), !fBound ? BF_REPORT_ERROR : BF_NONE);
     }
     return fBound;
 }

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -143,10 +143,16 @@ bool CNetAddr::IsRFC4380() const
     return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0 && GetByte(12) == 0);
 }
 
+bool CNetAddr::IsLinkLocal() const
+{
+    // fe80::/10 per RFC 4291 §2.5.6: first byte 0xFE, top 2 bits of second byte == 10 (0x80–0xBF).
+    // The old IsRFC4862() checked only the /64 prefix (8 bytes), missing fe81::–febf:: addresses.
+    return (ip[0] == 0xFE && (ip[1] & 0xC0) == 0x80);
+}
+
 bool CNetAddr::IsRFC4862() const
 {
-    static const unsigned char pchRFC4862[] = {0xFE,0x80,0,0,0,0,0,0};
-    return (memcmp(ip, pchRFC4862, sizeof(pchRFC4862)) == 0);
+    return IsLinkLocal();
 }
 
 bool CNetAddr::IsRFC4193() const
@@ -225,7 +231,7 @@ bool CNetAddr::IsValid() const
 
 bool CNetAddr::IsRoutable() const
 {
-    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsLocal() || IsInternal());
+    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsLinkLocal() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsLocal() || IsInternal());
 }
 
 bool CNetAddr::IsInternal() const
@@ -308,6 +314,10 @@ bool CNetAddr::GetIn6Addr(struct in6_addr* pipv6Addr) const
 
 // get canonical identifier of an address' group
 // no two connections will be attempted to addresses with the same group
+// IPv6 specifics: link-local (fe80::/10) is non-routable, so all link-local addresses
+// collapse into the single NET_UNROUTABLE group (zero-length prefix).  Routable global-
+// unicast IPv6 uses a /32 prefix as the group key — matching the typical RIR allocation
+// unit — so at most one outbound connection per /32 block is attempted.
 std::vector<unsigned char> CNetAddr::GetGroup() const
 {
     std::vector<unsigned char> vchRet;

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -65,7 +65,8 @@ class CNetAddr
         bool IsRFC4193() const; // IPv6 unique local (FC00::/7)
         bool IsRFC4380() const; // IPv6 Teredo tunnelling (2001::/32)
         bool IsRFC4843() const; // IPv6 ORCHID (2001:10::/28)
-        bool IsRFC4862() const; // IPv6 autoconfig (FE80::/64)
+        bool IsRFC4862() const; // IPv6 autoconfig (FE80::/64) — delegates to IsLinkLocal()
+        bool IsLinkLocal() const; // IPv6 link-local (FE80::/10 per RFC 4291 §2.5.6)
         bool IsRFC6052() const; // IPv6 well-known prefix (64:FF9B::/96)
         bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96)
         bool IsTor() const;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -444,8 +444,10 @@ SOCKET CreateSocket(const CService &addrConnect)
     }
 
     SOCKET hSocket = socket(((struct sockaddr*)&sockaddr)->sa_family, SOCK_STREAM, IPPROTO_TCP);
-    if (hSocket == INVALID_SOCKET)
+    if (hSocket == INVALID_SOCKET) {
+        LogPrintf("socket() failed for %s: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
         return INVALID_SOCKET;
+    }
 
     if (!IsSelectableSocket(hSocket)) {
         CloseSocket(hSocket);
@@ -465,7 +467,7 @@ SOCKET CreateSocket(const CService &addrConnect)
     // Set to non-blocking
     if (!SetSocketNonBlocking(hSocket, true)) {
         CloseSocket(hSocket);
-        LogPrintf("ConnectSocketDirectly: Setting socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
+        LogPrintf("CreateSocket: Setting socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
     }
     return hSocket;
 }

--- a/src/tapyrus-cli.cpp
+++ b/src/tapyrus-cli.cpp
@@ -41,7 +41,7 @@ static void SetupCliArgs()
     SetupFederationParamsOptions();
     gArgs.AddArg("-named", strprintf("Pass named instead of positional arguments (default: %s)", DEFAULT_NAMED), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcclienttimeout=<n>", strprintf("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)", DEFAULT_HTTP_CLIENT_TIMEOUT), false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-rpcconnect=<ip>", strprintf("Send commands to node running on <ip> (default: %s)", DEFAULT_RPCCONNECT), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-rpcconnect=<ip>", strprintf("Send commands to node running on <ip> (default: %s). Use [host] bracket notation for IPv6 (e.g. [::1])", DEFAULT_RPCCONNECT), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpccookiefile=<loc>", _("Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)"), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcport=<port>", strprintf("Connect to JSON-RPC on <port> (default: %u)", defaultParams->GetRPCPort()), false, OptionsCategory::OPTIONS);

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -73,6 +73,29 @@ BOOST_AUTO_TEST_CASE(netbase_properties)
 
 }
 
+BOOST_AUTO_TEST_CASE(netbase_islinklocal_boundary)
+{
+    // IsLinkLocal() checks the full FE80::/10 range (RFC 4291 2.5.6). The old
+    // IsRFC4862() only checked the /64 prefix, so fe81::-febf:: slipped past
+    // as routable; these addresses are the regression window that fix closes.
+    BOOST_CHECK(ResolveIP("fe80::").IsLinkLocal());
+    BOOST_CHECK(ResolveIP("fe81::").IsLinkLocal());   // was silently routable before
+    BOOST_CHECK(ResolveIP("febf::").IsLinkLocal());   // top of /10
+    BOOST_CHECK(!ResolveIP("fec0::").IsLinkLocal());  // above /10 (formerly site-local)
+    BOOST_CHECK(!ResolveIP("fe7f::").IsLinkLocal());  // below /10, symmetric with fec0::
+    BOOST_CHECK(ResolveIP("fea0::").IsLinkLocal());   // interior point, not just an edge
+    BOOST_CHECK(ResolveIP("fe80::1").IsLinkLocal());  // realistic address, nonzero host bits
+    BOOST_CHECK(!ResolveIP("fe81::").IsRoutable());   // routability guard
+    BOOST_CHECK(!ResolveIP("fe80::1").IsRoutable());
+
+    // Adjacent ranges that share a similar prefix shape but must not be
+    // conflated with unicast link-local.
+    BOOST_CHECK(!ResolveIP("fc00::").IsLinkLocal());  // RFC 4193 ULA (fc00::/7)
+    BOOST_CHECK(!ResolveIP("ff02::1").IsLinkLocal()); // link-local-scope multicast (RFC 4291 2.7)
+                                                       // is a different mechanism from unicast
+                                                       // link-local (2.5.6), not the same range.
+}
+
 bool static TestSplitHost(std::string test, std::string host, int port)
 {
     std::string hostOut;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -78,7 +78,17 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
             return false;
         }
 
-        int rc = zmq_bind(psocket, address.c_str());
+        int ipv6 = 1;
+        int rc = zmq_setsockopt(psocket, ZMQ_IPV6, &ipv6, sizeof(ipv6));
+        if (rc != 0)
+        {
+            zmqError("Failed to set ZMQ_IPV6");
+            zmq_close(psocket);
+            psocket = nullptr;
+            return false;
+        }
+
+        rc = zmq_bind(psocket, address.c_str());
         if (rc!=0)
         {
             zmqError("Failed to bind address");

--- a/test/functional/feature_ipv6.py
+++ b/test/functional/feature_ipv6.py
@@ -10,6 +10,7 @@ from test_framework.netutil import test_ipv6_local
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     NetworkDirName,
+    assert_equal,
     assert_raises_rpc_error,
     p2p_port,
     wait_until,
@@ -30,6 +31,12 @@ class IPv6Test(BitcoinTestFramework):
         # Disable automatic bind=127.0.0.1 so nodes default-bind to :: and
         # 0.0.0.0, making them reachable on both [::1] and 127.0.0.1.
         self.bind_to_localhost_only = False
+
+    def setup_network(self):
+        # Do NOT auto-connect via 127.0.0.1 — each sub-test sets up its own
+        # IPv4/IPv6 topology, and _test_p2p_via_ipv6 in particular needs the
+        # only peer on node0 to be the one it establishes over [::1].
+        self.setup_nodes()
 
     def run_test(self):
         if not test_ipv6_local():
@@ -56,13 +63,34 @@ class IPv6Test(BitcoinTestFramework):
 
     def _test_p2p_via_ipv6(self):
         self.log.info("P2P: connect two nodes via [::1]")
-        self.nodes[0].addnode("[::1]:{}".format(p2p_port(1)), "onetry")
+        assert_equal(self.nodes[0].getpeerinfo(), [])
+        assert_equal(self.nodes[1].getpeerinfo(), [])
+
+        peer_addr = "[::1]:{}".format(p2p_port(1))
+        self.nodes[0].addnode(peer_addr, "onetry")
         wait_until(lambda: len(self.nodes[0].getpeerinfo()) > 0, timeout=15)
-        peer_addr = self.nodes[0].getpeerinfo()[0]["addr"]
-        assert "::" in peer_addr, \
-            "Expected IPv6 peer addr, got: {}".format(peer_addr)
+        wait_until(lambda: len(self.nodes[1].getpeerinfo()) > 0, timeout=15)
+
+        # node0 must see exactly one outbound, manually-added peer at the
+        # [::1] address it was told to connect to.
+        peers0 = self.nodes[0].getpeerinfo()
+        assert_equal(len(peers0), 1)
+        assert_equal(peers0[0]["addr"], peer_addr)
+        assert_equal(peers0[0]["inbound"], False)
+        assert_equal(peers0[0]["addnode"], True)
+
+        # node1 must see exactly one inbound peer, arriving over IPv6.
+        peers1 = self.nodes[1].getpeerinfo()
+        assert_equal(len(peers1), 1)
+        assert_equal(peers1[0]["inbound"], True)
+        assert "::" in peers1[0]["addr"], \
+            "Expected IPv6 peer addr on node1, got: {}".format(peers1[0]["addr"])
+
         self.nodes[0].generate(1, self.signblockprivkey_wif)
         wait_until(lambda: self.nodes[1].getblockcount() == 1, timeout=15)
+        # Confirm the block reached node1 via this specific IPv6 connection,
+        # not merely that node1's tip advanced by some other means.
+        wait_until(lambda: self.nodes[1].getpeerinfo()[0]["synced_blocks"] == 1, timeout=15)
         self.log.info("  block propagated over IPv6 P2P connection")
 
     def _test_addnode_ipv6(self):

--- a/test/functional/feature_ipv6.py
+++ b/test/functional/feature_ipv6.py
@@ -15,8 +15,10 @@ from test_framework.util import (
     wait_until,
 )
 
-# A globally routable IPv6 address for -externalip testing.  Must not be in
-# RFC 3849 (2001:db8::/32 — fails IsValid()), RFC 4193 (fc00::/7), link-local
+# A globally routable IPv6 address for -externalip testing.  Avoid RFC 3849
+# (2001:db8::/32) so this doesn't look like a copy-pasted example — that block
+# is topologically routable (IsValid()/IsRoutable() don't reject it, it's just
+# reserved for documentation). Also avoid RFC 4193 (fc00::/7), link-local
 # (fe80::/10), loopback (::1), or any other non-routable range.
 _ROUTABLE_IPV6 = "2603:3005::1"
 

--- a/test/functional/feature_ipv6.py
+++ b/test/functional/feature_ipv6.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Chaintope Inc.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests for IPv6 support: P2P, -addnode, -connect, -externalip, -whitelist, -rpcallowip, ban persistence."""
+
+import os
+
+from test_framework.netutil import test_ipv6_local
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    NetworkDirName,
+    assert_raises_rpc_error,
+    p2p_port,
+    wait_until,
+)
+
+# A globally routable IPv6 address for -externalip testing.  Must not be in
+# RFC 3849 (2001:db8::/32 — fails IsValid()), RFC 4193 (fc00::/7), link-local
+# (fe80::/10), loopback (::1), or any other non-routable range.
+_ROUTABLE_IPV6 = "2603:3005::1"
+
+
+class IPv6Test(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        # Disable automatic bind=127.0.0.1 so nodes default-bind to :: and
+        # 0.0.0.0, making them reachable on both [::1] and 127.0.0.1.
+        self.bind_to_localhost_only = False
+
+    def run_test(self):
+        if not test_ipv6_local():
+            self.log.warning("No IPv6 loopback support — skipping all IPv6 sub-tests")
+            return
+
+        self._test_p2p_via_ipv6()
+        self._test_addnode_ipv6()
+        self._test_connect_flag_ipv6()
+        self._test_externalip_valid_ipv6()
+        self._test_externalip_linklocal_rejected()
+        self._test_whitelist_ipv6()
+        self._test_rpcallowip_ipv6()
+        self._test_ban_ipv6_persistence()
+
+    # ──────────────────────────────────────────── helpers
+
+    def _debug_log(self, node):
+        path = os.path.join(node.datadir, NetworkDirName(), "debug.log")
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.read()
+
+    # ──────────────────────────────────────────── sub-tests
+
+    def _test_p2p_via_ipv6(self):
+        self.log.info("P2P: connect two nodes via [::1]")
+        self.nodes[0].addnode("[::1]:{}".format(p2p_port(1)), "onetry")
+        wait_until(lambda: len(self.nodes[0].getpeerinfo()) > 0, timeout=15)
+        peer_addr = self.nodes[0].getpeerinfo()[0]["addr"]
+        assert "::" in peer_addr, \
+            "Expected IPv6 peer addr, got: {}".format(peer_addr)
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+        wait_until(lambda: self.nodes[1].getblockcount() == 1, timeout=15)
+        self.log.info("  block propagated over IPv6 P2P connection")
+
+    def _test_addnode_ipv6(self):
+        self.log.info("addnode: IPv4 and IPv6 addresses accepted without error")
+        node = self.nodes[0]
+        node.addnode("127.0.0.1:{}".format(p2p_port(1)), "onetry")
+        self.log.info("  addnode 127.0.0.1:port accepted")
+        node.addnode("[::1]:{}".format(p2p_port(1)), "onetry")
+        self.log.info("  addnode [::1]:port accepted")
+
+    def _test_connect_flag_ipv6(self):
+        self.log.info("-connect: node 1 connects out to node 0 via [::1]")
+        self.restart_node(1, extra_args=[
+            "-connect=[::1]:{}".format(p2p_port(0)),
+        ])
+        wait_until(lambda: len(self.nodes[1].getpeerinfo()) > 0, timeout=15)
+        peer_addr = self.nodes[1].getpeerinfo()[0]["addr"]
+        assert "::" in peer_addr, \
+            "Expected IPv6 peer addr after -connect=[::1]:port, got: {}".format(peer_addr)
+        self.log.info("  -connect=[::1]:port established IPv6 outbound connection")
+
+    def _test_externalip_valid_ipv6(self):
+        self.log.info("-externalip: globally routable IPv6 address added to localaddresses")
+        self.restart_node(1, extra_args=[
+            "-externalip=[{}]".format(_ROUTABLE_IPV6),
+        ])
+        local_addrs = [
+            a["address"]
+            for a in self.nodes[1].getnetworkinfo()["localaddresses"]
+        ]
+        assert _ROUTABLE_IPV6 in local_addrs, \
+            "Expected {} in localaddresses: {}".format(_ROUTABLE_IPV6, local_addrs)
+        self.log.info("  {} present in getnetworkinfo.localaddresses".format(_ROUTABLE_IPV6))
+
+    def _test_externalip_linklocal_rejected(self):
+        self.log.info("-externalip: link-local address rejected with log warning")
+        log_before = len(self._debug_log(self.nodes[1]))
+        self.restart_node(1, extra_args=["-externalip=[fe80::1]"])
+        new_log = self._debug_log(self.nodes[1])[log_before:]
+        assert "ignoring non-routable address" in new_log, \
+            "Expected link-local rejection warning in debug.log after restart"
+        local_addrs = [
+            a["address"]
+            for a in self.nodes[1].getnetworkinfo()["localaddresses"]
+        ]
+        assert "fe80::1" not in local_addrs, \
+            "fe80::1 must not appear in localaddresses"
+        self.log.info("  fe80::1 rejected with warning, absent from localaddresses")
+
+    def _test_whitelist_ipv6(self):
+        self.log.info("-whitelist: IPv4 CIDR and IPv6 CIDR both accepted at startup")
+        self.restart_node(1, extra_args=["-whitelist=127.0.0.0/8"])
+        assert self.nodes[1].getblockcount() >= 0
+        self.log.info("  -whitelist=127.0.0.0/8 accepted")
+        self.restart_node(1, extra_args=["-whitelist=2001:db8::/32"])
+        assert self.nodes[1].getblockcount() >= 0
+        self.log.info("  -whitelist=2001:db8::/32 accepted")
+
+    def _test_rpcallowip_ipv6(self):
+        self.log.info("-rpcallowip: IPv4 subnet and IPv6/128 subnet both accepted")
+        # 127.0.0.0/8 is always added as a default; adding ::1/128 explicitly
+        # exercises the IPv6 CSubNet parsing path in InitHTTPAllowList.
+        self.restart_node(1, extra_args=["-rpcallowip=::1/128"])
+        assert self.nodes[1].getblockcount() >= 0
+        self.log.info("  -rpcallowip=::1/128 accepted (127.0.0.0/8 added by default)")
+
+    def _test_ban_ipv6_persistence(self):
+        self.log.info("Ban: IPv6 /32 subnet ban survives node restart; invalid address rejected")
+        self.restart_node(1, extra_args=[])
+        node = self.nodes[1]
+
+        # Invalid address must produce an RPC error.
+        assert_raises_rpc_error(-30, "Error: Invalid IP/Subnet",
+                                node.setban, "not_an_ip", "add")
+        self.log.info("  setban with invalid address raised RPC error")
+
+        # Valid IPv6 CIDR ban.
+        node.setban("2001:db8::/32", "add")
+        banned = {b["address"] for b in node.listbanned()}
+        assert "2001:db8::/32" in banned, \
+            "Expected 2001:db8::/32 in ban list: {}".format(banned)
+        self.log.info("  2001:db8::/32 added to ban list")
+
+        # Ban must persist across restart.
+        self.restart_node(1, extra_args=[])
+        banned_after = {b["address"] for b in self.nodes[1].listbanned()}
+        assert "2001:db8::/32" in banned_after, \
+            "Expected 2001:db8::/32 to persist after restart: {}".format(banned_after)
+
+        self.nodes[1].setban("2001:db8::/32", "remove")
+        self.log.info("  2001:db8::/32 ban persisted across restart")
+
+
+if __name__ == "__main__":
+    IPv6Test().main()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -135,6 +135,7 @@ class ZMQTest (BitcoinTestFramework):
         # Connect the subscriber before restarting the node so it is ready
         # when the publisher comes up.
         socket6 = self.zmq_context.socket(zmq.SUB)
+        socket6.set(zmq.IPV6, 1)
         socket6.set(zmq.RCVTIMEO, 60000)
         socket6.connect(ipv6_addr)
         socket6.setsockopt(zmq.SUBSCRIBE, b"hashblock")

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -136,7 +136,7 @@ class ZMQTest (BitcoinTestFramework):
         # when the publisher comes up.
         socket6 = self.zmq_context.socket(zmq.SUB)
         socket6.set(zmq.IPV6, 1)
-        socket6.set(zmq.RCVTIMEO, 60000)
+        socket6.set(zmq.RCVTIMEO, 1000)
         socket6.connect(ipv6_addr)
         socket6.setsockopt(zmq.SUBSCRIBE, b"hashblock")
 
@@ -144,32 +144,40 @@ class ZMQTest (BitcoinTestFramework):
             self.restart_node(0, extra_args=[
                 "-zmqpubhashblock={}".format(ipv6_addr),
             ])
-            # ZMQ PUB/SUB has a "slow joiner" problem: messages published
-            # before this subscriber's TCP handshake and SUBSCRIBE filter
-            # have propagated to the publisher are silently dropped.
-            # restart_node only guarantees RPC is up, not that the ZMQ
-            # publisher has finished accepting this subscriber. Generating
-            # several blocks (as _zmq_test does for the IPv4 sockets, which
-            # are connected well before this point and don't hit this
-            # window) means that even if the first few notifications are
-            # lost, a later one reliably arrives once the subscription has
-            # settled. Unlike _zmq_test, we can't assert a strict 0..N-1
-            # sequence here - a dropped first message means the first
-            # notification we actually receive may carry a later sequence
-            # number - so match on the block hash instead and stop as soon
-            # as the last generated block's notification arrives.
-            num_blocks = 5
-            genhashes = self.nodes[0].generate(num_blocks, self.signblockprivkey_wif)
-
+            # ZMQ PUB/SUB has a "slow joiner" problem: this subscriber's
+            # SUBSCRIBE filter takes a nonzero, unobservable amount of time to
+            # propagate to the publisher - a plain ZMQ_PUB socket is send-only
+            # and cannot acknowledge (or even be queried for) subscriber
+            # state. restart_node only guarantees RPC is up, not that the ZMQ
+            # publisher has finished registering this subscriber's filter.
+            #
+            # Generating all blocks in one burst (as _zmq_test does for the
+            # IPv4 sockets, which are connected well before this point and
+            # don't hit this window) doesn't help here: generate(N) publishes
+            # all N notifications within a few ms of each other, far shorter
+            # than the SUBSCRIBE-propagation delay, so either the filter is
+            # already installed before the whole burst (all N arrive) or it
+            # isn't (all N are silently dropped) - there's no partial-delivery
+            # state in between to catch.
+            #
+            # Instead, generate one block at a time and try to receive with a
+            # short per-attempt timeout, retrying (and mining another block)
+            # on a miss. Any message that does arrive proves the filter is now
+            # installed, so it doesn't need to match the most recently
+            # generated block.
             recv_hash = None
-            for _ in range(num_blocks):
-                topic, body, seq = socket6.recv_multipart()
+            for _ in range(30):
+                self.nodes[0].generate(1, self.signblockprivkey_wif)
+                try:
+                    topic, body, _ = socket6.recv_multipart()
+                except zmq.Again:
+                    continue
                 assert_equal(topic, b"hashblock")
                 recv_hash = bytes_to_hex_str(body)
-                if recv_hash == genhashes[-1]:
-                    break
+                break
 
-            assert_equal(recv_hash, genhashes[-1])
+            assert recv_hash is not None, \
+                "no hashblock notification received on tcp://[::1]:{}".format(_ZMQ_IPV6_PORT)
             self.log.info("  hashblock notification received on tcp://[::1]:{}".format(_ZMQ_IPV6_PORT))
         finally:
             socket6.close()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -137,15 +137,38 @@ class ZMQTest (BitcoinTestFramework):
         socket6 = self.zmq_context.socket(zmq.SUB)
         socket6.set(zmq.RCVTIMEO, 60000)
         socket6.connect(ipv6_addr)
-        hashblock6 = ZMQSubscriber(socket6, b"hashblock")
+        socket6.setsockopt(zmq.SUBSCRIBE, b"hashblock")
 
         try:
             self.restart_node(0, extra_args=[
                 "-zmqpubhashblock={}".format(ipv6_addr),
             ])
-            genhashes = self.nodes[0].generate(1, self.signblockprivkey_wif)
-            recv_hash = bytes_to_hex_str(hashblock6.receive())
-            assert_equal(recv_hash, genhashes[0])
+            # ZMQ PUB/SUB has a "slow joiner" problem: messages published
+            # before this subscriber's TCP handshake and SUBSCRIBE filter
+            # have propagated to the publisher are silently dropped.
+            # restart_node only guarantees RPC is up, not that the ZMQ
+            # publisher has finished accepting this subscriber. Generating
+            # several blocks (as _zmq_test does for the IPv4 sockets, which
+            # are connected well before this point and don't hit this
+            # window) means that even if the first few notifications are
+            # lost, a later one reliably arrives once the subscription has
+            # settled. Unlike _zmq_test, we can't assert a strict 0..N-1
+            # sequence here - a dropped first message means the first
+            # notification we actually receive may carry a later sequence
+            # number - so match on the block hash instead and stop as soon
+            # as the last generated block's notification arrives.
+            num_blocks = 5
+            genhashes = self.nodes[0].generate(num_blocks, self.signblockprivkey_wif)
+
+            recv_hash = None
+            for _ in range(num_blocks):
+                topic, body, seq = socket6.recv_multipart()
+                assert_equal(topic, b"hashblock")
+                recv_hash = bytes_to_hex_str(body)
+                if recv_hash == genhashes[-1]:
+                    break
+
+            assert_equal(recv_hash, genhashes[-1])
             self.log.info("  hashblock notification received on tcp://[::1]:{}".format(_ZMQ_IPV6_PORT))
         finally:
             socket6.close()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -7,6 +7,7 @@
 import struct
 
 from test_framework.messages import (CBlock)
+from test_framework.netutil import test_ipv6_local
 from test_framework.test_framework import (
     BitcoinTestFramework, skip_if_no_bitcoind_zmq, skip_if_no_py3_zmq)
 from test_framework.messages import CTransaction
@@ -15,6 +16,9 @@ from test_framework.util import (assert_equal,
                                  hash256,
                                 )
 from io import BytesIO
+
+# Port for the IPv6 ZMQ endpoint test; outside the standard ZMQ range (28332-28335).
+_ZMQ_IPV6_PORT = 28340
 
 class ZMQSubscriber:
     def __init__(self, socket, topic):
@@ -68,6 +72,10 @@ class ZMQTest (BitcoinTestFramework):
     def run_test(self):
         try:
             self._zmq_test()
+            if test_ipv6_local():
+                self._zmq_test_ipv6()
+            else:
+                self.log.warning("No IPv6 loopback — skipping ZMQ IPv6 endpoint test")
         finally:
             # Destroy the ZMQ context.
             self.log.debug("Destroying ZMQ context")
@@ -116,6 +124,32 @@ class ZMQTest (BitcoinTestFramework):
         tx.deserialize(BytesIO(hex))
         tx.calc_sha256()
         assert_equal(tx.hashMalFix, bytes_to_hex_str(txid))
+
+    def _zmq_test_ipv6(self):
+        """Verify that ZMQ_IPV6 setsockopt allows publishers to bind on [::1]."""
+        self.log.info("ZMQ IPv6: test publisher on tcp://[::1]:{}".format(_ZMQ_IPV6_PORT))
+        import zmq
+
+        ipv6_addr = "tcp://[::1]:{}".format(_ZMQ_IPV6_PORT)
+
+        # Connect the subscriber before restarting the node so it is ready
+        # when the publisher comes up.
+        socket6 = self.zmq_context.socket(zmq.SUB)
+        socket6.set(zmq.RCVTIMEO, 60000)
+        socket6.connect(ipv6_addr)
+        hashblock6 = ZMQSubscriber(socket6, b"hashblock")
+
+        try:
+            self.restart_node(0, extra_args=[
+                "-zmqpubhashblock={}".format(ipv6_addr),
+            ])
+            genhashes = self.nodes[0].generate(1, self.signblockprivkey_wif)
+            recv_hash = bytes_to_hex_str(hashblock6.receive())
+            assert_equal(recv_hash, genhashes[0])
+            self.log.info("  hashblock notification received on tcp://[::1]:{}".format(_ZMQ_IPV6_PORT))
+        finally:
+            socket6.close()
+
 
 if __name__ == '__main__':
     ZMQTest().main()

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -5,6 +5,7 @@
 """Test node disconnect and ban behavior"""
 import time
 
+from test_framework.netutil import test_ipv6_local
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -75,6 +76,23 @@ class DisconnectBanTest(BitcoinTestFramework):
 
         # Clear ban lists
         self.nodes[1].clearbanned()
+
+        if test_ipv6_local():
+            self.log.info("setban IPv6: invalid prefix length (>128) rejected")
+            assert_raises_rpc_error(-30, "Error: Invalid IP/Subnet",
+                                    self.nodes[1].setban, "::1/129", "add")
+
+            self.log.info("setban IPv6: subnet ban and already-banned check")
+            self.nodes[1].setban("::/24", "add")
+            assert_equal(len(self.nodes[1].listbanned()), 1)
+            # ::1 falls within ::/24 so a second ban attempt must fail
+            assert_raises_rpc_error(-23, "IP/Subnet already banned",
+                                    self.nodes[1].setban, "::1", "add")
+
+            self.log.info("setban IPv6: unban subnet")
+            self.nodes[1].setban("::/24", "remove")
+            assert_equal(len(self.nodes[1].listbanned()), 0)
+
         connect_nodes_bi(self.nodes, 0, 1)
 
         self.log.info("Test disconnectnode RPCs")

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -73,7 +73,7 @@ class RPCBindTest(BitcoinTestFramework):
         self.log.info("Check for non-loopback interface")
         self.non_loopback_ip = None
         for name,ip in all_interfaces():
-            if ip != '127.0.0.1':
+            if ip not in ('127.0.0.1', '::1'):
                 self.non_loopback_ip = ip
                 break
         if self.non_loopback_ip is None and self.options.run_nonloopback:

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -7,6 +7,7 @@
 Tests correspond to code in rpc/net.cpp.
 """
 
+from test_framework.netutil import test_ipv6_local
 from test_framework.timeout_config import TAPYRUSD_MIN_TIMEOUT
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -80,7 +81,7 @@ class NetTest(BitcoinTestFramework):
 
     def _test_getaddednodeinfo(self):
         assert_equal(self.nodes[0].getaddednodeinfo(), [])
-        # add a node (node2) to node0
+        # add a node (node2) to node0 via IPv4
         ip_port = "127.0.0.1:{}".format(p2p_port(2))
         self.nodes[0].addnode(ip_port, 'add')
         # check that the node has indeed been added
@@ -89,6 +90,16 @@ class NetTest(BitcoinTestFramework):
         assert_equal(added_nodes[0]['addednode'], ip_port)
         # check that a non-existent node returns an error
         assert_raises_rpc_error(-24, "Node has not been added", self.nodes[0].getaddednodeinfo, '1.1.1.1')
+        self.nodes[0].addnode(ip_port, 'remove')
+
+        # same addnode round-trip with an IPv6 address
+        if test_ipv6_local():
+            ipv6_port = "[::1]:{}".format(p2p_port(2))
+            self.nodes[0].addnode(ipv6_port, 'add')
+            added_nodes_v6 = self.nodes[0].getaddednodeinfo(ipv6_port)
+            assert_equal(len(added_nodes_v6), 1)
+            assert_equal(added_nodes_v6[0]['addednode'], ipv6_port)
+            self.nodes[0].addnode(ipv6_port, 'remove')
 
     def _test_getpeerinfo(self):
         peer_info = [x.getpeerinfo() for x in self.nodes]

--- a/test/functional/rpc_zmq.py
+++ b/test/functional/rpc_zmq.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test for the ZMQ RPC methods."""
 
+from test_framework.netutil import test_ipv6_local
 from test_framework.test_framework import (
     BitcoinTestFramework, skip_if_no_py3_zmq, skip_if_no_bitcoind_zmq)
 from test_framework.util import assert_equal
@@ -11,7 +12,8 @@ from test_framework.util import assert_equal
 
 class RPCZMQTest(BitcoinTestFramework):
 
-    address = "tcp://127.0.0.1:28332"
+    address_v4 = "tcp://127.0.0.1:28332"
+    address_v6 = "tcp://[::1]:28342"
 
     def set_test_params(self):
         self.num_nodes = 1
@@ -26,10 +28,16 @@ class RPCZMQTest(BitcoinTestFramework):
         self.restart_node(0, extra_args=[])
         assert_equal(self.nodes[0].getzmqnotifications(), [])
 
-        self.restart_node(0, extra_args=["-zmqpubhashtx=%s" % self.address])
+        self.restart_node(0, extra_args=["-zmqpubhashtx=%s" % self.address_v4])
         assert_equal(self.nodes[0].getzmqnotifications(), [
-            {"type": "pubhashtx", "address": self.address},
+            {"type": "pubhashtx", "address": self.address_v4},
         ])
+
+        if test_ipv6_local():
+            self.restart_node(0, extra_args=["-zmqpubhashtx=%s" % self.address_v6])
+            assert_equal(self.nodes[0].getzmqnotifications(), [
+                {"type": "pubhashtx", "address": self.address_v6},
+            ])
 
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -117,7 +117,7 @@ def all_interfaces():
     # SIOCGIFCONF only returns IPv4 addresses; read IPv6 from /proc/net/if_inet6.
     # Format: hex_addr if_index prefix_len scope flags name
     try:
-        with open('/proc/net/if_inet6') as f:
+        with open('/proc/net/if_inet6', encoding='utf-8') as f:
             for line in f:
                 parts = line.split()
                 if len(parts) >= 6:

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -88,7 +88,8 @@ def get_bind_addrs(pid):
 # from: http://code.activestate.com/recipes/439093/
 def all_interfaces():
     '''
-    Return all interfaces that are up
+    Return all IPv4 and IPv6 interfaces that are up as (name_bytes, addr_str) pairs.
+    IPv4 is discovered via SIOCGIFCONF; IPv6 via /proc/net/if_inet6 (Linux only).
     '''
     import fcntl  # Linux only, so only import when required
 
@@ -97,21 +98,35 @@ def all_interfaces():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     max_possible = 8 # initial value
     while True:
-        bytes = max_possible * struct_size
-        names = array.array('B', b'\0' * bytes)
+        bytes_needed = max_possible * struct_size
+        names = array.array('B', b'\0' * bytes_needed)
         outbytes = struct.unpack('iL', fcntl.ioctl(
             s.fileno(),
             0x8912,  # SIOCGIFCONF
-            struct.pack('iL', bytes, names.buffer_info()[0])
+            struct.pack('iL', bytes_needed, names.buffer_info()[0])
         ))[0]
-        if outbytes == bytes:
+        if outbytes == bytes_needed:
             max_possible *= 2
         else:
             break
     namestr = names.tobytes()
-    return [(namestr[i:i+16].split(b'\0', 1)[0],
-             socket.inet_ntoa(namestr[i+20:i+24]))
-            for i in range(0, outbytes, struct_size)]
+    result = [(namestr[i:i+16].split(b'\0', 1)[0],
+               socket.inet_ntoa(namestr[i+20:i+24]))
+              for i in range(0, outbytes, struct_size)]
+
+    # SIOCGIFCONF only returns IPv4 addresses; read IPv6 from /proc/net/if_inet6.
+    # Format: hex_addr if_index prefix_len scope flags name
+    try:
+        with open('/proc/net/if_inet6') as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 6:
+                    addr = socket.inet_ntop(socket.AF_INET6, bytes.fromhex(parts[0]))
+                    result.append((parts[5].encode(), addr))
+    except OSError:
+        pass
+
+    return result
 
 def addr_to_hex(addr):
     '''

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -125,6 +125,7 @@ BASE_SCRIPTS = [
     'rpc_users.py',
     'rpc_whitelist.py',
     'feature_proxy.py',
+    'feature_ipv6.py',
     'rpc_packages.py',
     'rpc_signrawtransaction.py',
     'wallet_groups.py',


### PR DESCRIPTION
Core networking fixes

src/netaddress.h / src/netaddress.cpp
- Added IsLinkLocal() implementing the correct RFC 4291 §2.5.6 check (fe80::/10, bitwise) — the old IsRFC4862() only matched /64, silently passing fe81:: through febf:: as routable.
- IsRFC4862() now delegates to IsLinkLocal() for backward compatibility.
- IsRoutable() updated to call IsLinkLocal() instead of IsRFC4862().
- Comment added to GetGroup() explaining the IPv6 /32 group-key design.

src/net.cpp
- AddLocal: added warning log when a non-routable address is passed via -externalip (e.g. link-local fe80::1) — was silently dropped before.
- ThreadMapPort (UPnP): early-return with log when NET_IPV4 is unreachable — UPnP IGD discovers only IPv4 external addresses, so attempting it on a v6-only node is pointless.
- InitBinds default wildcard path: changed IPv4 wildcard bind from conditional BF_NONE/BF_REPORT_ERROR to unconditional BF_REPORT_ERROR so a failed IPv4 bind always reports to the user. Added comment documenting the intentional BF_NONE on IPv6 (IPv6 absence is tolerable; IPv4 is not).

src/netbase.cpp
- CreateSocket: socket() syscall failure now logs "socket() failed for <addr>: <errno>" — was silently swallowed before, for both families.
- CreateSocket: fixed mislabelled log message "ConnectSocketDirectly: Setting socket to non-blocking failed" → "CreateSocket: ...".

src/zmq/zmqpublishnotifier.cpp
- Sets ZMQ_IPV6 = 1 on the PUB socket before zmq_bind — without this, libzmq defaults to IPv4-only on some builds and silently fails to bind IPv6 endpoints like tcp://[::1]:port.

---
Help text / documentation

src/init.cpp
- -addnode, -connect: updated arg name to <ip[:port]>, added IPv6 bracket-notation example.
- -externalip: added IPv6 bracket-notation example.
- -whitelist: added IPv6 address and CIDR examples.
- -rpcallowip: added IPv6 address and CIDR examples.
- -zmqpubhashblock/tx/rawblock/rawtx: added dual IPv4+IPv6 endpoint examples.

src/tapyrus-cli.cpp
- -rpcconnect: added note about IPv6 bracket notation ([::1]).

src/addrman.h
- Comment clarifying that nVersion in Serialize/Unserialize only controls bucket-position trust, not entry deserialization — all IPv4 and IPv6 entries are always read unconditionally.

src/httpserver.cpp
- Comment explaining the 127.0.0.0/8 vs ::1/128 loopback asymmetry (RFC 5735 vs RFC 4291 §2.5.3).
- Comment documenting that evhttp_bind_socket_with_handle handles bare IPv6 strings via internal getaddrinfo (libevent ≥ 2.1.12).

---
Functional tests

test/functional/test_framework/netutil.py
- all_interfaces() extended to include IPv6 interfaces via /proc/net/if_inet6 (was IPv4-only via SIOCGIFCONF). Variable renamed bytes → bytes_needed to avoid shadowing the builtin.

test/functional/rpc_bind.py
- Loopback-skip now filters both 127.0.0.1 and ::1 when searching for a non-loopback interface.

test/functional/feature_ipv6.py (new)
- 8 sub-tests guarded by test_ipv6_local(): P2P connection via [::1]; addnode with IPv4+IPv6; -connect=[::1]; -externalip routable IPv6 accepted; -externalip=[fe80::1] rejected with log warning; -whitelist IPv4/IPv6 CIDR; -rpcallowip=::1/128; IPv6 subnet ban persistence across restart + invalid-subnet RPC error.

test/functional/interface_zmq.py
- Added _zmq_test_ipv6(): subscribes on tcp://[::1]:28340, restarts node with that endpoint, mines a block, verifies hashblock notification is received. Guards with test_ipv6_local(). Added _ZMQ_IPV6_PORT = 28340 constant.

test/functional/rpc_net.py
- _test_getaddednodeinfo: after the IPv4 addnode round-trip, also runs the same with [::1]:p2p_port(2) if IPv6 is available. Both are cleaned up with addnode(..., 'remove').

test/functional/rpc_zmq.py
- address renamed to address_v4; address_v6 = "tcp://[::1]:28342" added. _test_getzmqnotifications runs getzmqnotifications against both endpoints.

test/functional/p2p_disconnect_ban.py
- IPv6 ban block added (guarded by test_ipv6_local()): /129 prefix rejected, ::/24 ban added, ::1 already-banned error verified, subnet unbanned.

test/functional/test_runner.py
- feature_ipv6.py added to the test list.
