### PR TITLE
Remove dead wallet version-gating code (#405)

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2482,7 +2482,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.pushKV("keypoololdest", pwallet->GetOldestKeyPoolTime());
     obj.pushKV("keypoolsize", (int64_t)kpExternalSize);
     CKeyID seed_id = pwallet->GetHDChain().seed_id;
-    if (!seed_id.IsNull() && pwallet->CanSupportFeature(FEATURE_HD_SPLIT)) {
+    if (!seed_id.IsNull()) {
         obj.pushKV("keypoolsize_hd_internal",   (int64_t)(pwallet->GetKeyPoolSize() - kpExternalSize));
     }
     if (pwallet->IsCrypted()) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -177,7 +177,6 @@ CPubKey CWallet::GenerateNewKey(WalletBatch &batch, bool internal)
 {
     assert(!IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
     AssertLockHeld(cs_wallet); // mapKeyMetadata
-    bool fCompressed = CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
 
     CKey secret;
 
@@ -187,14 +186,9 @@ CPubKey CWallet::GenerateNewKey(WalletBatch &batch, bool internal)
 
     // use HD key derivation if HD was enabled during wallet creation
     if (IsHDEnabled()) {
-        DeriveNewChildKey(batch, metadata, secret, (CanSupportFeature(FEATURE_HD_SPLIT) ? internal : false));
+        DeriveNewChildKey(batch, metadata, secret, internal);
     } else {
-        secret.MakeNewKey(fCompressed);
-    }
-
-    // Compressed public keys were introduced in version 0.6.0
-    if (fCompressed) {
-        SetMinVersion(FEATURE_COMPRPUBKEY);
+        secret.MakeNewKey(true);
     }
 
     CPubKey pubkey = secret.GetPubKey();
@@ -229,7 +223,6 @@ void CWallet::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey
     masterKey.Derive(accountKey, BIP32_HARDENED_KEY_LIMIT);
 
     // derive m/0'/0' (external chain) OR m/0'/1' (internal chain)
-    assert(internal ? CanSupportFeature(FEATURE_HD_SPLIT) : true);
     accountKey.Derive(chainChildKey, BIP32_HARDENED_KEY_LIMIT+(internal ? 1 : 0));
 
     // derive child key at next index, skip keys already known to the wallet
@@ -478,39 +471,18 @@ void CWallet::ChainStateFlushed(const CBlockLocator& loc)
     batch.WriteBestBlock(loc);
 }
 
-void CWallet::SetMinVersion(enum WalletFeature nVersion, WalletBatch* batch_in, bool fExplicit)
+void CWallet::SetMinVersion(int nVersion, WalletBatch* batch_in)
 {
     LOCK(cs_wallet); // nWalletVersion
     if (nWalletVersion >= nVersion)
         return;
 
-    // when doing an explicit upgrade, if we pass the max version permitted, upgrade all the way
-    if (fExplicit && nVersion > nWalletMaxVersion)
-            nVersion = FEATURE_LATEST;
-
     nWalletVersion = nVersion;
 
-    if (nVersion > nWalletMaxVersion)
-        nWalletMaxVersion = nVersion;
-
-    {
-        WalletBatch* batch = batch_in ? batch_in : new WalletBatch(*database);
-        batch->WriteMinVersion(nWalletVersion);
-        if (!batch_in)
-            delete batch;
-    }
-}
-
-bool CWallet::SetMaxVersion(int nVersion)
-{
-    LOCK(cs_wallet); // nWalletVersion, nWalletMaxVersion
-    // cannot downgrade below current version
-    if (nWalletVersion > nVersion)
-        return false;
-
-    nWalletMaxVersion = nVersion;
-
-    return true;
+    WalletBatch* batch = batch_in ? batch_in : new WalletBatch(*database);
+    batch->WriteMinVersion(nWalletVersion);
+    if (!batch_in)
+        delete batch;
 }
 
 std::set<uint256> CWallet::GetConflicts(const uint256& txid) const
@@ -689,8 +661,8 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
             assert(false);
         }
 
-        // Encryption was introduced in version 0.4.0
-        SetMinVersion(FEATURE_WALLETCRYPT, encrypted_batch, true);
+        // Bring a wallet loaded from an older wallet.dat up to FEATURE_BASE.
+        SetMinVersion(FEATURE_BASE, encrypted_batch);
 
         if (!encrypted_batch->TxnCommit()) {
             delete encrypted_batch;
@@ -1491,7 +1463,7 @@ void CWallet::SetHDSeed(const CPubKey& seed)
     // the child index counter in the database
     // as a hdchain object
     CHDChain newHdChain;
-    newHdChain.nVersion = CanSupportFeature(FEATURE_HD_SPLIT) ? CHDChain::VERSION_HD_CHAIN_SPLIT : CHDChain::VERSION_HD_BASE;
+    newHdChain.nVersion = CHDChain::VERSION_HD_CHAIN_SPLIT;
     newHdChain.seed_id = seed.GetID();
     SetHDChain(newHdChain, false);
 }
@@ -3439,7 +3411,7 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
         int64_t missingExternal = std::max(std::max((int64_t) nTargetSize, (int64_t) 1) - (int64_t)setExternalKeyPool.size(), (int64_t) 0);
         int64_t missingInternal = std::max(std::max((int64_t) nTargetSize, (int64_t) 1) - (int64_t)setInternalKeyPool.size(), (int64_t) 0);
 
-        if (!IsHDEnabled() || !CanSupportFeature(FEATURE_HD_SPLIT))
+        if (!IsHDEnabled())
         {
             // don't create extra internal keys
             missingInternal = 0;
@@ -3484,7 +3456,7 @@ bool CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fRe
         if (!IsLocked())
             TopUpKeyPool();
 
-        bool fReturningInternal = IsHDEnabled() && CanSupportFeature(FEATURE_HD_SPLIT) && fRequestedInternal;
+        bool fReturningInternal = IsHDEnabled() && fRequestedInternal;
         bool use_split_keypool = set_pre_split_keypool.empty();
         std::set<int64_t>& setKeyPool = use_split_keypool ? (fReturningInternal ? setInternalKeyPool : setExternalKeyPool) : set_pre_split_keypool;
 
@@ -3587,7 +3559,7 @@ int64_t CWallet::GetOldestKeyPoolTime()
 
     // load oldest key from keypool, get time and return
     int64_t oldestKey = GetOldestKeyTimeInPool(setExternalKeyPool, batch);
-    if (IsHDEnabled() && CanSupportFeature(FEATURE_HD_SPLIT)) {
+    if (IsHDEnabled()) {
         oldestKey = std::max(GetOldestKeyTimeInPool(setInternalKeyPool, batch), oldestKey);
         if (!set_pre_split_keypool.empty()) {
             oldestKey = std::max(GetOldestKeyTimeInPool(set_pre_split_keypool, batch), oldestKey);
@@ -4171,7 +4143,6 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
             InitError(_("Cannot downgrade wallet"));
             return nullptr;
         }
-        walletInstance->SetMaxVersion(nMaxVersion);
     }
 
     // Upgrade to HD if explicit upgrade
@@ -4180,9 +4151,9 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
 
         bool hd_upgrade = false;
         bool split_upgrade = false;
-        if (walletInstance->CanSupportFeature(FEATURE_HD) && !walletInstance->IsHDEnabled()) {
+        if (!walletInstance->IsHDEnabled()) {
             walletInstance->WalletLogPrintf("Upgrading wallet to HD\n");
-            walletInstance->SetMinVersion(FEATURE_HD);
+            walletInstance->SetMinVersion(FEATURE_BASE);
 
             // generate a new master key
             CPubKey masterPubKey = walletInstance->GenerateNewSeed();
@@ -4190,10 +4161,10 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
             hd_upgrade = true;
         }
         // Upgrade to HD chain split if necessary
-        if (walletInstance->CanSupportFeature(FEATURE_HD_SPLIT)) {
+        {
             walletInstance->WalletLogPrintf("Upgrading wallet to use HD chain split\n");
-            walletInstance->SetMinVersion(FEATURE_PRE_SPLIT_KEYPOOL);
-            split_upgrade = FEATURE_HD_SPLIT > prev_version;
+            walletInstance->SetMinVersion(FEATURE_BASE);
+            split_upgrade = FEATURE_BASE > prev_version;
         }
         // Mark all keys currently in the keypool as pre-split
         if (split_upgrade) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -79,18 +79,7 @@ enum class FeeEstimateMode;
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {
-    FEATURE_BASE = 10500, // the earliest version new wallets supports (only useful for getwalletinfo's clientversion output)
-
-    FEATURE_WALLETCRYPT = FEATURE_BASE, // wallet encryption
-    FEATURE_COMPRPUBKEY = FEATURE_BASE, // compressed public keys
-
-    FEATURE_HD = FEATURE_BASE, // Hierarchical key derivation after BIP32 (HD Wallet)
-
-    FEATURE_HD_SPLIT = FEATURE_BASE, // Wallet with HD chain split (change outputs will use m/0'/1'/k)
-
-    FEATURE_NO_DEFAULT_KEY = FEATURE_BASE, // Wallet without a default key written
-
-    FEATURE_PRE_SPLIT_KEYPOOL = FEATURE_BASE, // Upgraded to HD SPLIT and can have a pre-split keypool
+    FEATURE_BASE = 10500, // the only wallet version Tapyrus supports (only useful for getwalletinfo's clientversion output)
 
     FEATURE_LATEST = FEATURE_BASE
 };
@@ -674,9 +663,6 @@ private:
     //! the current wallet version: clients below this version are not able to load the wallet
     int nWalletVersion = FEATURE_BASE;
 
-    //! the maximum wallet format version: memory-only variable that specifies to what version this wallet may be upgraded
-    int nWalletMaxVersion = FEATURE_BASE;
-
     int64_t nNextResend = 0;
     int64_t nLastResend = 0;
     bool fBroadcastTransactions = false;
@@ -834,9 +820,6 @@ public:
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 
-    //! check whether we are allowed to upgrade (or already support) to the named feature
-    bool CanSupportFeature(enum WalletFeature wf) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
-
     /**
      * populate vCoins with vector of available COutputs.
      */
@@ -891,7 +874,7 @@ public:
     void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void LoadScriptMetadata(const CScriptID& script_id, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
+    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; return true; }
     void UpdateTimeFirstKey(int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds an encrypted key to the store, and saves it to disk.
@@ -1080,11 +1063,8 @@ public:
         return setInternalKeyPool.size() + setExternalKeyPool.size();
     }
 
-    //! signify that a particular wallet feature is now used. this may change nWalletVersion and nWalletMaxVersion if those are lower
-    void SetMinVersion(enum WalletFeature, WalletBatch* batch_in = nullptr, bool fExplicit = false);
-
-    //! change which version we're allowed to upgrade to (note that this does not immediately imply upgrading to that format)
-    bool SetMaxVersion(int nVersion);
+    //! write nVersion to the DB if it advances the wallet's current version
+    void SetMinVersion(int nVersion, WalletBatch* batch_in = nullptr);
 
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }


### PR DESCRIPTION
Every WalletFeature constant was collapsed to FEATURE_BASE = 10500, making CanSupportFeature() always true, SetMinVersion() a permanent no-op, and every version-conditional branch's else-arm unreachable.

- Collapse the WalletFeature enum to FEATURE_BASE/FEATURE_LATEST only; delete the six intermediate constants inherited from Bitcoin Core that were never meaningful in Tapyrus.
- Remove CanSupportFeature(), SetMaxVersion(), and nWalletMaxVersion; simplify SetMinVersion() to just write the version when it advances.
- Drop the dead uncompressed-key branch in GenerateNewKey() and a tautological assert in DeriveNewChildKey() (Tapyrus always uses compressed keys and HD chain split).
- Collapse the now-always-true CanSupportFeature(FEATURE_HD_SPLIT) conjuncts in SetHDSeed/TopUpKeyPool/ReserveKeyFromKeyPool/ GetOldestKeyPoolTime/getwalletinfo down to their genuinely conditional IsHDEnabled() checks.
- Keep the SetMinVersion(FEATURE_BASE, ...) calls in EncryptWallet and the -upgradewallet HD-upgrade path: these aren't dead for a wallet loaded from an older/foreign wallet.dat with a stored version below FEATURE_BASE.

Introducing a new wallet-format version tied to coloured-coin GUI support (steps 2/3/8 of the #405 recommendation) is not needed as no such on-disk format change exists.