### PR TITLE
Add PSTT (TIP-174) Phase 1: core data structures and Signer

### DIFF
--- a/doc/tapyrus/pstt.md
+++ b/doc/tapyrus/pstt.md
@@ -1,0 +1,231 @@
+Partially Signed Tapyrus Transaction (PSTT)
+============================================
+
+PSTT is Tapyrus's own partially-signed-transaction format, defined by
+[TIP-174](https://github.com/chaintope/tips/blob/master/tip-0174.md) and
+implemented in `src/pstt.h`/`src/pstt.cpp`. It replaces the Bitcoin-shaped
+PSBT (BIP-174 "v0") that tapyrus-core previously inherited unmodified: PSBT
+has no counterpart for Tapyrus's malleability-fixed txid, no notion of
+Colored Coins, and hardcodes ECDSA-only signing.
+
+PSTT is built on BIP-370's constructable (per-input/output) data model
+instead of BIP-174's single embedded unsigned transaction: there is no
+global unsigned tx record. Each input carries its own previous-txid/output-index
+pair directly, which is what lets a PSTT be built up incrementally across
+multiple round trips between parties (see [Fee Provider workflow](#fee-provider-workflow)
+below) rather than requiring one party to fix the whole set of inputs and
+outputs up front.
+
+Key differences from BIP-174 PSBT:
+* No global unsigned transaction; per-input outpoint fields instead.
+* No witness fields (Tapyrus has no segwit) and no Taproot fields.
+* Colored Coin aware: `PSTT_OUT_SCRIPT` may carry the `<color id> OP_COLOR`
+  prefix, and CP2SH redeem-script verification accounts for it.
+* Signer supports both ECDSA and Schnorr, and rejects mixing the two
+  schemes within one input's signature set.
+
+---
+
+Wire format
+-----------
+
+A PSTT is `PSTT_MAGIC_BYTES` followed by a global key-value map, then one
+key-value map per input, then one per output. Every map is terminated by an
+empty key (a single `0x00` length byte) — a map with no terminator is a
+parse error, not an implicit end-of-data.
+
+```
+magic bytes: 0x70 0x73 0x74 0x74 0xFF  ("pstt" + 0xFF)
+```
+
+Each record in a map is `<key><value>`, where both `<key>` and `<value>`
+are themselves length-prefixed byte strings (a CompactSize byte count
+followed by that many bytes) — this holds even for fixed-width values like
+a `uint32_t` or a `uint256`; those still get wrapped in the same
+length-prefix envelope as every other value. `<key>`'s first byte is the
+record's type; any remaining key bytes are that type's keydata (e.g. a
+pubkey for `PSTT_IN_PARTIAL_SIG`).
+
+### Global types
+
+| Name | Value | Keydata | Value | Notes |
+|---|---|---|---|---|
+| `PSTT_GLOBAL_XPUB` | `0x01` | `<xpub>` — the 78-byte BIP32 extended public key (4-byte version prefix + `CExtPubKey`'s 74-byte encoding) | `<fingerprint><32-bit uint>*` — master fingerprint + derivation path | Prefix must equal exactly `Params().Base58Prefix(EXT_PUBLIC_KEY)` for the running node's own network; any other prefix, including the other Tapyrus network's, is rejected at parse time |
+| `PSTT_GLOBAL_TX_FEATURES` | `0x02` | none | `int32_t` | **Required.** Any value is accepted and round-tripped verbatim into `CMutableTransaction::nFeatures` on extraction — no validation is imposed here beyond what the transaction layer itself imposes |
+| `PSTT_GLOBAL_FALLBACK_LOCKTIME` | `0x03` | none | `uint32_t` | Default 0 if absent |
+| `PSTT_GLOBAL_INPUT_COUNT` | `0x04` | none | `<compact size uint>` | **Required.** Not stored separately from `inputs.size()`; only meaningful on the wire, to tell the parser how many input maps follow |
+| `PSTT_GLOBAL_OUTPUT_COUNT` | `0x05` | none | `<compact size uint>` | **Required.** Same as above, for output maps |
+| `PSTT_GLOBAL_TX_MODIFIABLE` | `0x06` | none | `uint8_t` bitfield | Absent means not modifiable. Bit 0: inputs modifiable. Bit 1: outputs modifiable. Bit 2: has a `SIGHASH_SINGLE` signature (input/output correspondence must be preserved). Bits 3-7 reserved, must be 0 |
+| `PSTT_GLOBAL_VERSION` | `0xFB` | none | `uint32_t` | Default 0; a value greater than 0 is rejected at parse time |
+| `PSTT_GLOBAL_PROPRIETARY` | `0xFC` | proprietary identifier | proprietary | Passed through unchanged |
+
+Type value `0x00` is reserved (it was BIP-174's global unsigned transaction,
+which has no counterpart here) and must be actively rejected, not folded
+into the unknown-field bucket.
+
+### Input types
+
+| Name | Value | Keydata | Value | Notes |
+|---|---|---|---|---|
+| `PSTT_IN_UTXO` | `0x00` | none | the full previous transaction | Required before signing. No witness-UTXO shortcut exists in Tapyrus |
+| `PSTT_IN_PARTIAL_SIG` | `0x02` | 33- or 65-byte public key | signature + 1-byte sighash type | Valuedata is either a DER-encoded ECDSA signature (~71-73 bytes total including the trailing sighash byte) or exactly 65 bytes (64-byte Schnorr signature + sighash byte) — no other length is legal |
+| `PSTT_IN_SIGHASH_TYPE` | `0x03` | none | `int32_t` | |
+| `PSTT_IN_REDEEM_SCRIPT` | `0x04` | none | script | For CP2SH, this is the redeem script alone — it excludes the `<color id> OP_COLOR` prefix that lives in the outer scriptPubKey |
+| `PSTT_IN_BIP32_DERIVATION` | `0x06` | public key | `<fingerprint><32-bit uint>*` | |
+| `PSTT_IN_FINAL_SCRIPTSIG` | `0x07` | none | script | Once present, an input is finalized; its other signing-only fields are stripped |
+| `PSTT_IN_RIPEMD160` | `0x0a` | 20-byte hash | preimage | |
+| `PSTT_IN_SHA256` | `0x0b` | 32-byte hash | preimage | |
+| `PSTT_IN_HASH160` | `0x0c` | 20-byte hash | preimage | |
+| `PSTT_IN_HASH256` | `0x0d` | 32-byte hash | preimage | |
+| `PSTT_IN_PREVIOUS_TXID` | `0x0e` | none | `uint256` (`hashMalFix` of the previous tx) | **Required.** There is no global unsigned tx, so this and the next field are the only source of truth for what this input spends |
+| `PSTT_IN_OUTPUT_INDEX` | `0x0f` | none | `uint32_t` | **Required** |
+| `PSTT_IN_SEQUENCE` | `0x10` | none | `uint32_t` | Default `0xFFFFFFFF` if absent |
+| `PSTT_IN_REQUIRED_TIME_LOCKTIME` | `0x11` | none | `uint32_t` | Must be `>= 500000000`; out-of-range values are rejected at parse time, not deferred |
+| `PSTT_IN_REQUIRED_HEIGHT_LOCKTIME` | `0x12` | none | `uint32_t` | Must be `> 0` and `< 500000000`; same parse-time bounds check |
+| `PSTT_IN_PROPRIETARY` | `0xFC` | proprietary identifier | proprietary | |
+
+Reserved and must be rejected, not silently treated as unknown: `0x01`
+(witness UTXO), `0x05` (witness script), `0x08` (finalized scriptWitness),
+`0x09` (proof-of-reserves commitment), and the Taproot-related type values
+from BIP-371 (`0x13`-`0x18`) — none have a Tapyrus counterpart.
+
+### Output types
+
+| Name | Value | Keydata | Value | Notes |
+|---|---|---|---|---|
+| `PSTT_OUT_REDEEM_SCRIPT` | `0x00` | none | script | |
+| `PSTT_OUT_BIP32_DERIVATION` | `0x02` | public key | `<fingerprint><32-bit uint>*` | |
+| `PSTT_OUT_AMOUNT` | `0x03` | none | `int64_t` | **Required** |
+| `PSTT_OUT_SCRIPT` | `0x04` | none | script | **Required.** Includes the `<color id> OP_COLOR` prefix when the output is colored |
+| `PSTT_OUT_PROPRIETARY` | `0xFC` | proprietary identifier | proprietary | |
+
+Reserved and must be rejected: `0x01` (witness script) and the
+Taproot-related type values from BIP-371 (`0x05`-`0x07`).
+
+---
+
+Determining the locktime
+-------------------------
+
+A PSTT has no single stored locktime field; it is computed from the
+constituent inputs whenever one is needed (identification, signing,
+extraction):
+
+1. If no input sets `PSTT_IN_REQUIRED_TIME_LOCKTIME` or
+   `PSTT_IN_REQUIRED_HEIGHT_LOCKTIME`, the locktime is
+   `PSTT_GLOBAL_FALLBACK_LOCKTIME` (default 0).
+2. Otherwise, each input that sets at least one of the two fields
+   constrains the locktime to a kind: `{height}` if only height is set,
+   `{time}` if only time is set, `{height, time}` if both are set (an
+   input setting neither imposes no constraint). Intersect the constraint
+   sets across every input that specifies at least one kind. An empty
+   intersection means no locktime works for every input — the PSTT is
+   locktime-invalid, and no role primitive should sign or extract it.
+   When both kinds remain acceptable, height is preferred.
+3. The locktime is the maximum of the chosen kind's field across the
+   inputs that specify it.
+
+---
+
+Unique identification
+----------------------
+
+A PSTT's identifier is the `hashMalFix` of the transaction it would
+materialize with every input's sequence number forced to zero (this,
+rather than the actual sequence numbers, is what keeps the identifier
+stable as inputs get filled in with real sequence numbers over the course
+of construction and signing). Two PSTTs are combinable only if they share
+an identifier.
+
+---
+
+Roles
+-----
+
+Every role below is an independently invokable operation — nothing in
+tapyrus-core hardcodes a fixed pipeline ordering them, since the same
+transaction can flow through the same role more than once (the Constructor
+role in particular is designed for multi-round-trip incremental
+construction across separate parties, not a single call).
+
+* **Creator** — builds a bare PSTT from a caller-supplied set of inputs and
+  outputs (either of which may be empty).
+* **Constructor** — appends inputs/outputs to an existing PSTT. Only ever
+  appends; never removes or reorders what is already present. Refuses to
+  add an input whose required locktime would make the PSTT's already-signed
+  content locktime-invalid.
+* **Updater** — attaches externally known data (UTXOs, redeem scripts,
+  BIP32 derivation paths) without altering which inputs/outputs exist. Must
+  not change an input's sequence number once that input carries a
+  signature, or once any other input carries a `SIGHASH_ALL`-without-
+  `SIGHASH_ANYONECANPAY` signature (either case would silently invalidate
+  a commitment already made).
+* **Signer** — produces a partial signature for one input. Refuses to sign
+  an input with no `PSTT_IN_UTXO`, or whose UTXO's txid does not match
+  `PSTT_IN_PREVIOUS_TXID`, or whose redeem script does not hash to the
+  value committed in the scriptPubKey (accounting for the CP2SH color-id
+  prefix), or that would use `SIGHASH_SINGLE` on an input whose index has
+  no corresponding output, or that would add a signature whose scheme
+  (ECDSA/Schnorr) conflicts with a signature already present on that
+  input.
+* **Combiner** — merges two or more PSTTs that share an identifier.
+  Per-field conflict policy on a mismatch: `PSTT_IN_PARTIAL_SIG`,
+  `PSTT_IN_FINAL_SCRIPTSIG`, and `PSTT_IN_UTXO` refuse (signature/UTXO
+  disagreements are exactly the disagreements that must not be silently
+  dropped); `PSTT_IN_REDEEM_SCRIPT` and any `*_BIP32_DERIVATION` record
+  must match exactly (both parties should have derived the identical
+  value, so a mismatch signals a real problem); every other field,
+  including unrecognized/proprietary records, is harmless to duplicate and
+  the first-seen value wins.
+* **Input Finalizer** — for each input whose signature requirements are
+  satisfied, synthesizes `PSTT_IN_FINAL_SCRIPTSIG` and strips the
+  now-redundant signing-only fields (partial sigs, sighash type, redeem
+  script, BIP32 derivation, preimages), keeping the outpoint fields, UTXO,
+  sequence, required locktime, and any unrecognized records. Refuses while
+  either modifiable flag is still set.
+* **Transaction Extractor** — once every input is finalized, assembles and
+  returns the network-serialized transaction.
+
+---
+
+Fee Provider workflow
+----------------------
+
+TIP-174 exists in part to support a wallet that holds only Colored Coins:
+since fees are always paid in TPC, such a wallet cannot complete a
+transaction alone. The Fee Provider pattern lets a second party — one that
+does hold TPC — complete the transaction, using only the Constructor,
+Updater, Signer, and Combiner primitives above; tapyrus-core does not
+hardcode the two-party protocol itself, only the primitives that make it
+possible.
+
+Both variants share the same starting point: the token-only party
+constructs a PSTT covering their own inputs/outputs with the Inputs
+Modifiable flag left set (so a TPC input can be added later) and signs
+with `SIGHASH_ALL | SIGHASH_ANYONECANPAY` (so more inputs can be added
+without invalidating their signature). The two variants differ in how the
+fee provider then supplies its input:
+
+* **Non-interactive** — the fee provider supplies one already-known TPC
+  outpoint directly. Its color must be verified (derived from the
+  referenced output's scriptPubKey, never assumed from the caller's
+  intent) before it is added — a colored-coin outpoint must be rejected,
+  not silently accepted as if it were TPC.
+* **Interactive** — the fee provider runs its own coin selection and adds
+  both a TPC input and a TPC change output.
+
+Either way, the fee provider signs its own new input with `SIGHASH_ALL`,
+and either party finalizes and extracts once both signatures are present.
+
+---
+
+Colored Coin balance verification
+-----------------------------------
+
+Any code path that needs to reason about "how much of which color moves
+through this PSTT" (a fee provider deciding whether to add its input, a
+wallet double-checking a PSTT before signing) should compute one balance
+map keyed by color identifier, where TPC is simply the entry keyed by the
+default/`NONE`-type color identifier — never a structurally separate
+field. Color is always derived from a scriptPubKey via
+`GetColorIdFromScript()`, never assumed from an RPC parameter's name.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(tapyrus_common STATIC EXCLUDE_FROM_ALL
   netbase.cpp
   policy/feerate.cpp
   protocol.cpp
+  pstt.cpp
   scheduler.cpp
   script/descriptor.cpp
   script/ismine.cpp

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -216,14 +216,23 @@ class CTransaction
 {
 public:
     // Default transaction features.
-    static const int32_t CURRENT_FEATURES=1;
+    //
+    // constexpr (not plain "static const"): a plain in-class-initialized
+    // static const member has no out-of-line definition anywhere in this
+    // codebase, so any use that binds a reference to it (e.g. assigning
+    // into a boost::optional<int32_t>, or passing it to
+    // boost::optional::value_or()) is an ODR-use requiring a linker symbol
+    // that doesn't exist. GCC/Linux enforces this strictly and fails to
+    // link; Apple's clang/ld64 happens to tolerate it. constexpr is
+    // implicitly inline in C++17/20, which resolves this on every platform.
+    static constexpr int32_t CURRENT_FEATURES=1;
 
     // Changing the default transaction version requires a two step process: first
     // adapting relay policy by bumping MAX_STANDARD_FEATURES, and then later date
     // bumping the default CURRENT_FEATURES at which point both CURRENT_FEATURES
     // and MAX_STANDARD_FEATURES will be equal.
     // Tapyrus: renaming MAX_STANDARD_VERSION to MAX_STANDARD_FEATURES.
-    static const int32_t MAX_STANDARD_FEATURES=1;
+    static constexpr int32_t MAX_STANDARD_FEATURES=1;
 
     // The local variables are made const to prevent unintended modification
     // without updating the cached hash value. However, CTransaction is not

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -70,21 +70,21 @@ public:
 
     /* Setting nSequence to this value for every input in a transaction
      * disables nLockTime. */
-    static const uint32_t SEQUENCE_FINAL = 0xffffffff;
+    static constexpr uint32_t SEQUENCE_FINAL = 0xffffffff;
 
     /* Below flags apply in the context of BIP 68*/
     /* If this flag set, CTxIn::nSequence is NOT interpreted as a
      * relative lock-time. */
-    static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 << 31);
+    static constexpr uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 << 31);
 
     /* If CTxIn::nSequence encodes a relative lock-time and this flag
      * is set, the relative lock-time has units of 512 seconds,
      * otherwise it specifies blocks with a granularity of 1. */
-    static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = (1 << 22);
+    static constexpr uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = (1 << 22);
 
     /* If CTxIn::nSequence encodes a relative lock-time, this mask is
      * applied to extract that lock-time from the sequence field. */
-    static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+    static constexpr uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
 
     /* In order to use the same number of bits to encode roughly the
      * same wall-clock duration, and because blocks are naturally
@@ -93,7 +93,7 @@ public:
      * Converting from CTxIn::nSequence to seconds is performed by
      * multiplying by 512 = 2^9, or equivalently shifting up by
      * 9 bits. */
-    static const int SEQUENCE_LOCKTIME_GRANULARITY = 9;
+    static constexpr int SEQUENCE_LOCKTIME_GRANULARITY = 9;
 
     CTxIn()
     {

--- a/src/pstt.cpp
+++ b/src/pstt.cpp
@@ -159,7 +159,7 @@ void PSTTInput::Merge(const PSTTInput& input)
     }
 
     // Everything else: pick-first, no throw.
-    if (sighash_type == 0 && input.sighash_type > 0) sighash_type = input.sighash_type;
+    if (!sighash_type && input.sighash_type) sighash_type = input.sighash_type;
     if (!sequence && input.sequence) sequence = input.sequence;
     if (!required_time_locktime && input.required_time_locktime) required_time_locktime = input.required_time_locktime;
     if (!required_height_locktime && input.required_height_locktime) required_height_locktime = input.required_height_locktime;
@@ -213,9 +213,9 @@ void PSTTInput::Serialize(Stream& s) const
             s << sig_pair.second.second;
         }
 
-        if (sighash_type > 0) {
+        if (sighash_type) {
             SerializeToVector(s, PSTT_IN_SIGHASH_TYPE);
-            SerializeToVector(s, sighash_type);
+            SerializeToVector(s, *sighash_type);
         }
 
         if (!redeem_script.empty()) {
@@ -272,7 +272,6 @@ void PSTTInput::Serialize(Stream& s) const
 template <typename Stream>
 void PSTTInput::Unserialize(Stream& s)
 {
-    bool has_sighash_type = false;
     while (true) {
         if (s.empty()) throw std::ios_base::failure("PSTT input map is missing its terminating separator");
         std::vector<unsigned char> key;
@@ -311,10 +310,13 @@ void PSTTInput::Unserialize(Stream& s)
                 break;
             }
             case PSTT_IN_SIGHASH_TYPE:
-                if (has_sighash_type) throw std::ios_base::failure("Duplicate Key, PSTT_IN_SIGHASH_TYPE already provided");
+                if (sighash_type) throw std::ios_base::failure("Duplicate Key, PSTT_IN_SIGHASH_TYPE already provided");
                 if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_SIGHASH_TYPE key is more than one byte type");
-                UnserializeFromVector(s, sighash_type);
-                has_sighash_type = true;
+                {
+                    int32_t v;
+                    UnserializeFromVector(s, v);
+                    sighash_type = v;
+                }
                 break;
             case PSTT_IN_REDEEM_SCRIPT:
                 if (!redeem_script.empty()) throw std::ios_base::failure("Duplicate Key, PSTT_IN_REDEEM_SCRIPT already provided");
@@ -572,6 +574,10 @@ static std::vector<unsigned char> XpubEntryCanonicalBytes(const std::pair<CExtPu
 
 void PartiallySignedTapyrusTransaction::Merge(const PartiallySignedTapyrusTransaction& other)
 {
+    if (inputs.size() != other.inputs.size() || outputs.size() != other.outputs.size()) {
+        throw std::invalid_argument("PSTT Merge() with mismatched input/output counts");
+    }
+
     for (unsigned int i = 0; i < inputs.size(); ++i) {
         inputs[i].Merge(other.inputs[i]);
     }
@@ -599,6 +605,13 @@ bool PartiallySignedTapyrusTransaction::IsSane() const
         if (input.utxo && input.prev_out_index_set && input.prev_out_index >= input.utxo->vout.size()) {
             return false;
         }
+        // Deliberately NOT checked here: input.utxo->GetHashMalFix() ==
+        // input.previous_txid. Per TIP-174's own fixtures (see
+        // test/functional/data/tip174_invalid.json, "utxo-txid-mismatch"),
+        // a PSTT_IN_UTXO/PSTT_IN_PREVIOUS_TXID mismatch is a Signer-role
+        // rule violation, not a structural/parse failure -- it must still
+        // decode successfully, and only SignPSTTInput() is required to
+        // reject it. See SignPSTTInput() for the actual enforcement.
     }
     for (const PSTTOutput& output : outputs) {
         if (!output.IsSane()) return false;
@@ -886,10 +899,7 @@ CMutableTransaction MaterializeTransaction(const PartiallySignedTapyrusTransacti
         if (force_zero_sequence) {
             txin.nSequence = 0;
         } else {
-            // Literal 0xFFFFFFFF, not CTxIn::SEQUENCE_FINAL: that's an in-class-initialized
-            // static const with no out-of-line definition, and boost::optional::value_or()
-            // binds its argument by reference, which ODR-uses it and fails to link.
-            txin.nSequence = input.sequence.value_or(0xFFFFFFFFu);
+            txin.nSequence = input.sequence.value_or(CTxIn::SEQUENCE_FINAL);
         }
         if (use_final_scriptsig) {
             txin.scriptSig = input.final_script_sig;
@@ -925,6 +935,7 @@ std::string PSTTSignResultToString(PSTTSignResult result)
         case PSTTSignResult::OK: return "OK";
         case PSTTSignResult::MISSING_UTXO: return "input has no PSTT_IN_UTXO";
         case PSTTSignResult::UTXO_TXID_MISMATCH: return "PSTT_IN_UTXO txid does not match PSTT_IN_PREVIOUS_TXID";
+        case PSTTSignResult::PREV_OUT_INDEX_OOB: return "PSTT_IN_OUTPUT_INDEX is out of range for PSTT_IN_UTXO";
         case PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH: return "redeem script does not hash to the committed value";
         case PSTTSignResult::SIGHASH_CONFLICT: return "requested sighash type conflicts with PSTT_IN_SIGHASH_TYPE";
         case PSTTSignResult::SCHEME_CONFLICT: return "signature scheme conflicts with an existing signature on this input";
@@ -965,15 +976,17 @@ PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySig
     if (!input.utxo) {
         return PSTTSignResult::MISSING_UTXO;
     }
-    // Must verify the UTXO's txid matches PSTT_IN_PREVIOUS_TXID. This is defense-in-depth:
-    // it's also enforced at Unserialize() time on the whole PSTT, but a Merge()'d PSTT could
-    // combine a PSTT_IN_UTXO from one party with a PSTT_IN_PREVIOUS_TXID from another that
-    // don't match, bypassing the parse-time check.
+    // Must verify the UTXO's txid matches PSTT_IN_PREVIOUS_TXID. Deliberately
+    // NOT checked at Unserialize()/IsSane() time -- per TIP-174's own fixtures
+    // (test/functional/data/tip174_invalid.json, "utxo-txid-mismatch"), this
+    // is a Signer-role rule violation, not a structural one: a PSTT carrying
+    // a mismatch must still decode successfully, and only signing it must
+    // fail. This is the sole point of enforcement.
     if (input.utxo->GetHashMalFix() != input.previous_txid) {
         return PSTTSignResult::UTXO_TXID_MISMATCH;
     }
     if (input.prev_out_index >= input.utxo->vout.size()) {
-        return PSTTSignResult::UTXO_TXID_MISMATCH;
+        return PSTTSignResult::PREV_OUT_INDEX_OOB;
     }
 
     const CTxOut& utxo_out = input.utxo->vout[input.prev_out_index];
@@ -991,7 +1004,7 @@ PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySig
     }
 
     // Must use the sighash type in PSTT_IN_SIGHASH_TYPE if present.
-    if (input.sighash_type > 0 && input.sighash_type != sighash) {
+    if (input.sighash_type && *input.sighash_type != sighash) {
         return PSTTSignResult::SIGHASH_CONFLICT;
     }
 

--- a/src/pstt.cpp
+++ b/src/pstt.cpp
@@ -1,0 +1,1034 @@
+// Copyright (c) 2026 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <pstt.h>
+
+#include <chainparams.h>
+#include <coloridentifier.h>
+#include <hash.h>
+#include <key.h>
+#include <script/interpreter.h>
+#include <script/standard.h>
+#include <streams.h>
+#include <utilstrencodings.h>
+
+#include <algorithm>
+#include <set>
+
+// =======================================================================
+// PSTT_GLOBAL_XPUB keydata helpers
+// =======================================================================
+
+std::vector<unsigned char> SerializeXpubKeyData(const CExtPubKey& xpub)
+{
+    const std::vector<unsigned char>& prefix = Params().Base58Prefix(CChainParams::EXT_PUBLIC_KEY);
+    std::vector<unsigned char> out(prefix.begin(), prefix.end());
+    unsigned char code[BIP32_EXTKEY_SIZE];
+    xpub.Encode(code);
+    out.insert(out.end(), code, code + BIP32_EXTKEY_SIZE);
+    return out;
+}
+
+CExtPubKey ParseXpubKeyData(const std::vector<unsigned char>& keydata)
+{
+    if (keydata.size() != PSTT_XPUB_KEYDATA_SIZE) {
+        throw std::ios_base::failure("PSTT_GLOBAL_XPUB keydata is not 78 bytes");
+    }
+    const std::vector<unsigned char>& expected_prefix = Params().Base58Prefix(CChainParams::EXT_PUBLIC_KEY);
+    std::vector<unsigned char> actual_prefix(keydata.begin(), keydata.begin() + 4);
+    if (actual_prefix != expected_prefix) {
+        throw std::ios_base::failure(
+            "expected xpub prefix " + HexStr(expected_prefix) + ", got " + HexStr(actual_prefix));
+    }
+    CExtPubKey xpub;
+    unsigned char code[BIP32_EXTKEY_SIZE];
+    std::copy(keydata.begin() + 4, keydata.end(), code);
+    xpub.Decode(code);
+    return xpub;
+}
+
+// =======================================================================
+// PSTTInput
+// =======================================================================
+
+bool PSTTInput::IsNull() const
+{
+    return !previous_txid_set && !prev_out_index_set && !utxo && partial_sigs.empty() &&
+           unknown.empty() && hd_keypaths.empty() && redeem_script.empty() && final_script_sig.empty();
+}
+
+void PSTTInput::FillSignatureData(SignatureData& sigdata) const
+{
+    if (!final_script_sig.empty()) {
+        sigdata.scriptSig = final_script_sig;
+        sigdata.complete = true;
+    }
+    if (sigdata.complete) {
+        return;
+    }
+
+    sigdata.signatures.insert(partial_sigs.begin(), partial_sigs.end());
+    if (!redeem_script.empty()) {
+        sigdata.redeem_script = redeem_script;
+    }
+    for (const auto& key_pair : hd_keypaths) {
+        sigdata.misc_pubkeys.emplace(key_pair.first.GetID(), key_pair.first);
+    }
+}
+
+void PSTTInput::FromSignatureData(const SignatureData& sigdata)
+{
+    if (sigdata.complete) {
+        partial_sigs.clear();
+        hd_keypaths.clear();
+        redeem_script.clear();
+
+        if (!sigdata.scriptSig.empty()) {
+            final_script_sig = sigdata.scriptSig;
+        }
+        return;
+    }
+
+    partial_sigs.insert(sigdata.signatures.begin(), sigdata.signatures.end());
+    if (redeem_script.empty() && !sigdata.redeem_script.empty()) {
+        redeem_script = sigdata.redeem_script;
+    }
+}
+
+// Per-field-class Combiner conflict policy:
+//  - PARTIAL_SIG / FINAL_SCRIPTSIG / UTXO           -> refuse (throw) on conflict
+//  - REDEEM_SCRIPT / any BIP32_DERIVATION            -> must-match (throw on mismatch)
+//  - everything else (incl. unknown/proprietary)      -> pick-first, no throw
+void PSTTInput::Merge(const PSTTInput& input)
+{
+    // previous_txid / prev_out_index are required-and-identical by construction
+    // (both sides must already agree, or they wouldn't share a PSTT identifier --
+    // HasSameIdentifierAs() is checked by the Combiner before Merge() is ever
+    // called). Nothing to merge for these two fields.
+
+    // UTXO: refuse tier.
+    if (utxo && input.utxo) {
+        if (utxo->GetHashMalFix() != input.utxo->GetHashMalFix()) {
+            throw std::invalid_argument("PSTT_IN_UTXO conflict on Merge()");
+        }
+    } else if (!utxo && input.utxo) {
+        utxo = input.utxo;
+    }
+
+    // FINAL_SCRIPTSIG: refuse tier.
+    if (!final_script_sig.empty() && !input.final_script_sig.empty()) {
+        if (final_script_sig != input.final_script_sig) {
+            throw std::invalid_argument("PSTT_IN_FINAL_SCRIPTSIG conflict on Merge()");
+        }
+    } else if (final_script_sig.empty() && !input.final_script_sig.empty()) {
+        final_script_sig = input.final_script_sig;
+    }
+
+    // PARTIAL_SIG: refuse tier, per-pubkey.
+    for (const auto& kv : input.partial_sigs) {
+        auto it = partial_sigs.find(kv.first);
+        if (it != partial_sigs.end()) {
+            if (it->second.second != kv.second.second) {
+                throw std::invalid_argument("PSTT_IN_PARTIAL_SIG conflict on Merge()");
+            }
+        } else {
+            partial_sigs.insert(kv);
+        }
+    }
+
+    // REDEEM_SCRIPT: must-match tier.
+    if (!redeem_script.empty() && !input.redeem_script.empty()) {
+        if (redeem_script != input.redeem_script) {
+            throw std::invalid_argument("PSTT_IN_REDEEM_SCRIPT mismatch on Merge()");
+        }
+    } else if (redeem_script.empty() && !input.redeem_script.empty()) {
+        redeem_script = input.redeem_script;
+    }
+
+    // BIP32_DERIVATION: must-match tier, per-pubkey.
+    for (const auto& kv : input.hd_keypaths) {
+        auto it = hd_keypaths.find(kv.first);
+        if (it != hd_keypaths.end()) {
+            if (it->second != kv.second) {
+                throw std::invalid_argument("PSTT_IN_BIP32_DERIVATION mismatch on Merge()");
+            }
+        } else {
+            hd_keypaths.insert(kv);
+        }
+    }
+
+    // Everything else: pick-first, no throw.
+    if (sighash_type == 0 && input.sighash_type > 0) sighash_type = input.sighash_type;
+    if (!sequence && input.sequence) sequence = input.sequence;
+    if (!required_time_locktime && input.required_time_locktime) required_time_locktime = input.required_time_locktime;
+    if (!required_height_locktime && input.required_height_locktime) required_height_locktime = input.required_height_locktime;
+    for (const auto& kv : input.ripemd160_preimages) ripemd160_preimages.insert(kv);
+    for (const auto& kv : input.sha256_preimages) sha256_preimages.insert(kv);
+    for (const auto& kv : input.hash160_preimages) hash160_preimages.insert(kv);
+    for (const auto& kv : input.hash256_preimages) hash256_preimages.insert(kv);
+    for (const auto& kv : input.unknown) unknown.insert(kv);
+}
+
+bool PSTTInput::IsSane() const
+{
+    // previous_txid / output_index are required.
+    if (!previous_txid_set || !prev_out_index_set) return false;
+
+    // No mixed ECDSA/Schnorr signatures on one input. Mirrors interpreter.cpp's
+    // SCRIPT_ERR_MIXED_SCHEME_MULTISIG classification rule exactly: a 65-byte
+    // signature (including its trailing sighash byte) is Schnorr, anything else
+    // is ECDSA.
+    boost::optional<SignatureScheme> scheme_seen;
+    for (const auto& kv : partial_sigs) {
+        const std::vector<unsigned char>& sig = kv.second.second;
+        SignatureScheme this_scheme = (sig.size() == CPubKey::COMPACT_SIGNATURE_SIZE)
+            ? SignatureScheme::SCHNORR : SignatureScheme::ECDSA;
+        if (scheme_seen && *scheme_seen != this_scheme) return false;
+        scheme_seen = this_scheme;
+    }
+
+    return true;
+}
+
+template <typename Stream>
+void PSTTInput::Serialize(Stream& s) const
+{
+    if (previous_txid_set) {
+        SerializeToVector(s, PSTT_IN_PREVIOUS_TXID);
+        SerializeToVector(s, previous_txid);
+    }
+    if (prev_out_index_set) {
+        SerializeToVector(s, PSTT_IN_OUTPUT_INDEX);
+        SerializeToVector(s, prev_out_index);
+    }
+    if (utxo) {
+        SerializeToVector(s, PSTT_IN_UTXO);
+        SerializeToVector(s, utxo);
+    }
+
+    if (final_script_sig.empty()) {
+        for (const auto& sig_pair : partial_sigs) {
+            SerializeToVector(s, PSTT_IN_PARTIAL_SIG, MakeSpan(sig_pair.second.first));
+            s << sig_pair.second.second;
+        }
+
+        if (sighash_type > 0) {
+            SerializeToVector(s, PSTT_IN_SIGHASH_TYPE);
+            SerializeToVector(s, sighash_type);
+        }
+
+        if (!redeem_script.empty()) {
+            SerializeToVector(s, PSTT_IN_REDEEM_SCRIPT);
+            s << redeem_script;
+        }
+
+        SerializeHDKeypaths(s, hd_keypaths, PSTT_IN_BIP32_DERIVATION);
+
+        for (const auto& kv : ripemd160_preimages) {
+            SerializeToVector(s, PSTT_IN_RIPEMD160, MakeSpan(kv.first));
+            s << kv.second;
+        }
+        for (const auto& kv : sha256_preimages) {
+            SerializeToVector(s, PSTT_IN_SHA256, MakeSpan(kv.first));
+            s << kv.second;
+        }
+        for (const auto& kv : hash160_preimages) {
+            SerializeToVector(s, PSTT_IN_HASH160, MakeSpan(kv.first));
+            s << kv.second;
+        }
+        for (const auto& kv : hash256_preimages) {
+            SerializeToVector(s, PSTT_IN_HASH256, MakeSpan(kv.first));
+            s << kv.second;
+        }
+    }
+
+    if (!final_script_sig.empty()) {
+        SerializeToVector(s, PSTT_IN_FINAL_SCRIPTSIG);
+        s << final_script_sig;
+    }
+
+    if (sequence) {
+        SerializeToVector(s, PSTT_IN_SEQUENCE);
+        SerializeToVector(s, *sequence);
+    }
+    if (required_time_locktime) {
+        SerializeToVector(s, PSTT_IN_REQUIRED_TIME_LOCKTIME);
+        SerializeToVector(s, *required_time_locktime);
+    }
+    if (required_height_locktime) {
+        SerializeToVector(s, PSTT_IN_REQUIRED_HEIGHT_LOCKTIME);
+        SerializeToVector(s, *required_height_locktime);
+    }
+
+    for (const auto& entry : unknown) {
+        s << entry.first;
+        s << entry.second;
+    }
+
+    s << PSTT_SEPARATOR;
+}
+
+template <typename Stream>
+void PSTTInput::Unserialize(Stream& s)
+{
+    bool has_sighash_type = false;
+    while (true) {
+        if (s.empty()) throw std::ios_base::failure("PSTT input map is missing its terminating separator");
+        std::vector<unsigned char> key;
+        s >> key;
+        if (key.empty()) return; // separator found
+
+        unsigned char type = key[0];
+        switch (type) {
+            case PSTT_IN_UTXO:
+            {
+                if (utxo) throw std::ios_base::failure("Duplicate Key, PSTT_IN_UTXO already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_UTXO key is more than one byte type");
+                UnserializeFromVector(s, utxo);
+                break;
+            }
+            case PSTT_IN_PARTIAL_SIG:
+            {
+                if (key.size() != CPubKey::COMPRESSED_PUBLIC_KEY_SIZE + 1 && key.size() != CPubKey::PUBLIC_KEY_SIZE + 1) {
+                    throw std::ios_base::failure("PSTT_IN_PARTIAL_SIG keydata must be a 33- or 65-byte public key");
+                }
+                CPubKey pubkey(key.begin() + 1, key.end());
+                if (!pubkey.IsFullyValid()) throw std::ios_base::failure("Invalid pubkey");
+                if (partial_sigs.count(pubkey.GetID()) > 0) {
+                    throw std::ios_base::failure("Duplicate Key, PSTT_IN_PARTIAL_SIG for pubkey already provided");
+                }
+                std::vector<unsigned char> sig;
+                s >> sig;
+                // valuedata: DER signature + 1 hashtype byte (variable, ~71-73 total incl. that
+                // byte), or exactly a 65-byte Schnorr sig + 1 hashtype byte (64+1). No third
+                // length is legal.
+                if (sig.size() != CPubKey::COMPACT_SIGNATURE_SIZE &&
+                    (sig.size() < 9 || sig.size() > CPubKey::SIGNATURE_SIZE + 1)) {
+                    throw std::ios_base::failure("PSTT_IN_PARTIAL_SIG valuedata has an invalid length");
+                }
+                partial_sigs.emplace(pubkey.GetID(), SigPair(pubkey, std::move(sig)));
+                break;
+            }
+            case PSTT_IN_SIGHASH_TYPE:
+                if (has_sighash_type) throw std::ios_base::failure("Duplicate Key, PSTT_IN_SIGHASH_TYPE already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_SIGHASH_TYPE key is more than one byte type");
+                UnserializeFromVector(s, sighash_type);
+                has_sighash_type = true;
+                break;
+            case PSTT_IN_REDEEM_SCRIPT:
+                if (!redeem_script.empty()) throw std::ios_base::failure("Duplicate Key, PSTT_IN_REDEEM_SCRIPT already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_REDEEM_SCRIPT key is more than one byte type");
+                s >> redeem_script;
+                break;
+            case PSTT_IN_BIP32_DERIVATION:
+                DeserializeHDKeypaths(s, key, hd_keypaths);
+                break;
+            case PSTT_IN_FINAL_SCRIPTSIG:
+                if (!final_script_sig.empty()) throw std::ios_base::failure("Duplicate Key, PSTT_IN_FINAL_SCRIPTSIG already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_FINAL_SCRIPTSIG key is more than one byte type");
+                s >> final_script_sig;
+                break;
+            case PSTT_IN_RIPEMD160:
+            case PSTT_IN_HASH160:
+            {
+                auto& map_ref = (type == PSTT_IN_RIPEMD160) ? ripemd160_preimages : hash160_preimages;
+                if (key.size() != 20 + 1) throw std::ios_base::failure("Preimage keydata must be 20 bytes");
+                std::vector<unsigned char> hash_key(key.begin() + 1, key.end());
+                if (map_ref.count(hash_key) > 0) throw std::ios_base::failure("Duplicate Key, preimage already provided");
+                std::vector<unsigned char> preimage;
+                s >> preimage;
+                map_ref.emplace(std::move(hash_key), std::move(preimage));
+                break;
+            }
+            case PSTT_IN_SHA256:
+            case PSTT_IN_HASH256:
+            {
+                auto& map_ref = (type == PSTT_IN_SHA256) ? sha256_preimages : hash256_preimages;
+                if (key.size() != 32 + 1) throw std::ios_base::failure("Preimage keydata must be 32 bytes");
+                std::vector<unsigned char> hash_key(key.begin() + 1, key.end());
+                if (map_ref.count(hash_key) > 0) throw std::ios_base::failure("Duplicate Key, preimage already provided");
+                std::vector<unsigned char> preimage;
+                s >> preimage;
+                map_ref.emplace(std::move(hash_key), std::move(preimage));
+                break;
+            }
+            case PSTT_IN_PREVIOUS_TXID:
+                if (previous_txid_set) throw std::ios_base::failure("Duplicate Key, PSTT_IN_PREVIOUS_TXID already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_PREVIOUS_TXID key is more than one byte type");
+                UnserializeFromVector(s, previous_txid);
+                previous_txid_set = true;
+                break;
+            case PSTT_IN_OUTPUT_INDEX:
+                if (prev_out_index_set) throw std::ios_base::failure("Duplicate Key, PSTT_IN_OUTPUT_INDEX already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_OUTPUT_INDEX key is more than one byte type");
+                UnserializeFromVector(s, prev_out_index);
+                prev_out_index_set = true;
+                break;
+            case PSTT_IN_SEQUENCE:
+                if (sequence) throw std::ios_base::failure("Duplicate Key, PSTT_IN_SEQUENCE already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_SEQUENCE key is more than one byte type");
+                {
+                    uint32_t v;
+                    UnserializeFromVector(s, v);
+                    sequence = v;
+                }
+                break;
+            case PSTT_IN_REQUIRED_TIME_LOCKTIME:
+            {
+                if (required_time_locktime) throw std::ios_base::failure("Duplicate Key, PSTT_IN_REQUIRED_TIME_LOCKTIME already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_REQUIRED_TIME_LOCKTIME key is more than one byte type");
+                uint32_t v;
+                UnserializeFromVector(s, v);
+                if (v < 500000000) throw std::ios_base::failure("PSTT_IN_REQUIRED_TIME_LOCKTIME must be greater than or equal to 500000000");
+                required_time_locktime = v;
+                break;
+            }
+            case PSTT_IN_REQUIRED_HEIGHT_LOCKTIME:
+            {
+                if (required_height_locktime) throw std::ios_base::failure("Duplicate Key, PSTT_IN_REQUIRED_HEIGHT_LOCKTIME already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_REQUIRED_HEIGHT_LOCKTIME key is more than one byte type");
+                uint32_t v;
+                UnserializeFromVector(s, v);
+                if (v == 0) throw std::ios_base::failure("PSTT_IN_REQUIRED_HEIGHT_LOCKTIME must be greater than 0");
+                if (v >= 500000000) throw std::ios_base::failure("PSTT_IN_REQUIRED_HEIGHT_LOCKTIME must be less than 500000000");
+                required_height_locktime = v;
+                break;
+            }
+            // Reserved and must be rejected, not silently treated as unknown:
+            // 0x01 witness UTXO, 0x05 witness script, 0x08 finalized scriptWitness,
+            // 0x09 proof-of-reserves commitment, 0x13-0x18 Taproot fields (BIP-371).
+            // See doc/tapyrus/pstt.md.
+            case 0x01: case 0x05: case 0x08: case 0x09:
+            case 0x13: case 0x14: case 0x15: case 0x16: case 0x17: case 0x18:
+                throw std::ios_base::failure("Reserved input key type used");
+            case PSTT_IN_PROPRIETARY:
+            default:
+                if (unknown.count(key) > 0) throw std::ios_base::failure("Duplicate Key, key for unknown value already provided");
+                std::vector<unsigned char> val_bytes;
+                s >> val_bytes;
+                unknown.emplace(std::move(key), std::move(val_bytes));
+                break;
+        }
+    }
+}
+
+// =======================================================================
+// PSTTOutput
+// =======================================================================
+
+bool PSTTOutput::IsNull() const
+{
+    return !amount && script.empty() && redeem_script.empty() && hd_keypaths.empty() && unknown.empty();
+}
+
+void PSTTOutput::FillSignatureData(SignatureData& sigdata) const
+{
+    if (!redeem_script.empty()) {
+        sigdata.redeem_script = redeem_script;
+    }
+    for (const auto& key_pair : hd_keypaths) {
+        sigdata.misc_pubkeys.emplace(key_pair.first.GetID(), key_pair.first);
+    }
+}
+
+void PSTTOutput::FromSignatureData(const SignatureData& sigdata)
+{
+    if (redeem_script.empty() && !sigdata.redeem_script.empty()) {
+        redeem_script = sigdata.redeem_script;
+    }
+}
+
+void PSTTOutput::Merge(const PSTTOutput& output)
+{
+    // REDEEM_SCRIPT: must-match tier.
+    if (!redeem_script.empty() && !output.redeem_script.empty()) {
+        if (redeem_script != output.redeem_script) {
+            throw std::invalid_argument("PSTT_OUT_REDEEM_SCRIPT mismatch on Merge()");
+        }
+    } else if (redeem_script.empty() && !output.redeem_script.empty()) {
+        redeem_script = output.redeem_script;
+    }
+
+    // BIP32_DERIVATION: must-match tier.
+    for (const auto& kv : output.hd_keypaths) {
+        auto it = hd_keypaths.find(kv.first);
+        if (it != hd_keypaths.end()) {
+            if (it->second != kv.second) {
+                throw std::invalid_argument("PSTT_OUT_BIP32_DERIVATION mismatch on Merge()");
+            }
+        } else {
+            hd_keypaths.insert(kv);
+        }
+    }
+
+    for (const auto& kv : output.unknown) unknown.insert(kv);
+}
+
+bool PSTTOutput::IsSane() const
+{
+    return amount.is_initialized() && !script.empty();
+}
+
+template <typename Stream>
+void PSTTOutput::Serialize(Stream& s) const
+{
+    if (amount) {
+        SerializeToVector(s, PSTT_OUT_AMOUNT);
+        SerializeToVector(s, *amount);
+    }
+    if (!script.empty()) {
+        SerializeToVector(s, PSTT_OUT_SCRIPT);
+        s << script;
+    }
+    if (!redeem_script.empty()) {
+        SerializeToVector(s, PSTT_OUT_REDEEM_SCRIPT);
+        s << redeem_script;
+    }
+
+    SerializeHDKeypaths(s, hd_keypaths, PSTT_OUT_BIP32_DERIVATION);
+
+    for (const auto& entry : unknown) {
+        s << entry.first;
+        s << entry.second;
+    }
+
+    s << PSTT_SEPARATOR;
+}
+
+template <typename Stream>
+void PSTTOutput::Unserialize(Stream& s)
+{
+    while (true) {
+        if (s.empty()) throw std::ios_base::failure("PSTT output map is missing its terminating separator");
+        std::vector<unsigned char> key;
+        s >> key;
+        if (key.empty()) return; // separator found
+
+        unsigned char type = key[0];
+        switch (type) {
+            case PSTT_OUT_REDEEM_SCRIPT:
+                if (!redeem_script.empty()) throw std::ios_base::failure("Duplicate Key, PSTT_OUT_REDEEM_SCRIPT already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_OUT_REDEEM_SCRIPT key is more than one byte type");
+                s >> redeem_script;
+                break;
+            case PSTT_OUT_BIP32_DERIVATION:
+                DeserializeHDKeypaths(s, key, hd_keypaths);
+                break;
+            case PSTT_OUT_AMOUNT:
+                if (amount) throw std::ios_base::failure("Duplicate Key, PSTT_OUT_AMOUNT already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_OUT_AMOUNT key is more than one byte type");
+                {
+                    CAmount v;
+                    UnserializeFromVector(s, v);
+                    amount = v;
+                }
+                break;
+            case PSTT_OUT_SCRIPT:
+                if (!script.empty()) throw std::ios_base::failure("Duplicate Key, PSTT_OUT_SCRIPT already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_OUT_SCRIPT key is more than one byte type");
+                s >> script;
+                break;
+            // Reserved and must be rejected: 0x01 witness script, 0x05-0x07
+            // Taproot fields (BIP-371). See doc/tapyrus/pstt.md.
+            case 0x01:
+            case 0x05: case 0x06: case 0x07:
+                throw std::ios_base::failure("Reserved output key type used");
+            case PSTT_OUT_PROPRIETARY:
+            default:
+                if (unknown.count(key) > 0) throw std::ios_base::failure("Duplicate Key, key for unknown value already provided");
+                std::vector<unsigned char> val_bytes;
+                s >> val_bytes;
+                unknown.emplace(std::move(key), std::move(val_bytes));
+                break;
+        }
+    }
+}
+
+// =======================================================================
+// PartiallySignedTapyrusTransaction
+// =======================================================================
+
+bool PartiallySignedTapyrusTransaction::IsNull() const
+{
+    return !tx_features && inputs.empty() && outputs.empty() && unknown.empty() && xpubs.empty();
+}
+
+// xpubs dedup: a temporary set-like lookup keyed on the entry's canonical
+// byte form (78-byte xpub + derivation path), built just for the duration
+// of this call, so appending stays close to linear rather than O(n^2) for
+// large xpub counts.
+static std::vector<unsigned char> XpubEntryCanonicalBytes(const std::pair<CExtPubKey, std::vector<uint32_t>>& entry)
+{
+    std::vector<unsigned char> out = SerializeXpubKeyData(entry.first);
+    for (uint32_t v : entry.second) {
+        out.push_back(static_cast<unsigned char>(v & 0xff));
+        out.push_back(static_cast<unsigned char>((v >> 8) & 0xff));
+        out.push_back(static_cast<unsigned char>((v >> 16) & 0xff));
+        out.push_back(static_cast<unsigned char>((v >> 24) & 0xff));
+    }
+    return out;
+}
+
+void PartiallySignedTapyrusTransaction::Merge(const PartiallySignedTapyrusTransaction& other)
+{
+    for (unsigned int i = 0; i < inputs.size(); ++i) {
+        inputs[i].Merge(other.inputs[i]);
+    }
+    for (unsigned int i = 0; i < outputs.size(); ++i) {
+        outputs[i].Merge(other.outputs[i]);
+    }
+
+    std::set<std::vector<unsigned char>> seen;
+    for (const auto& entry : xpubs) seen.insert(XpubEntryCanonicalBytes(entry));
+    for (const auto& entry : other.xpubs) {
+        std::vector<unsigned char> canon = XpubEntryCanonicalBytes(entry);
+        if (seen.insert(canon).second) {
+            xpubs.push_back(entry);
+        }
+    }
+
+    // Global unknown/proprietary fields: pick-first tier.
+    for (const auto& kv : other.unknown) unknown.insert(kv);
+}
+
+bool PartiallySignedTapyrusTransaction::IsSane() const
+{
+    for (const PSTTInput& input : inputs) {
+        if (!input.IsSane()) return false;
+        if (input.utxo && input.prev_out_index_set && input.prev_out_index >= input.utxo->vout.size()) {
+            return false;
+        }
+    }
+    for (const PSTTOutput& output : outputs) {
+        if (!output.IsSane()) return false;
+    }
+    if (tx_modifiable && (*tx_modifiable & PSTT_TXMOD_RESERVED_MASK) != 0) {
+        return false; // reserved PSTT_GLOBAL_TX_MODIFIABLE bits must be 0
+    }
+    return true;
+}
+
+// PSTT_GLOBAL_INPUT_COUNT/OUTPUT_COUNT's value is itself "<compact size uint>",
+// which -- like every other value in this KV-map format -- also needs the
+// uniform outer value-length prefix. Streaming a plain byte vector
+// already produces exactly that envelope (length-prefix + raw bytes), so
+// build the inner compact-size encoding into one first rather than writing
+// the count directly (which would omit the outer length prefix entirely).
+template <typename Stream>
+static void SerializeCompactSizeValue(Stream& s, uint64_t v)
+{
+    CDataStream inner(SER_NETWORK, PROTOCOL_VERSION);
+    WriteCompactSize(inner, v);
+    std::vector<unsigned char> bytes(inner.begin(), inner.end());
+    s << bytes;
+}
+
+template <typename Stream>
+static uint64_t UnserializeCompactSizeValue(Stream& s)
+{
+    std::vector<unsigned char> bytes;
+    s >> bytes;
+    CDataStream inner(bytes, SER_NETWORK, PROTOCOL_VERSION);
+    uint64_t v = ReadCompactSize(inner);
+    if (!inner.empty()) {
+        throw std::ios_base::failure("Compact-size value has trailing bytes");
+    }
+    return v;
+}
+
+template <typename Stream>
+void PartiallySignedTapyrusTransaction::Serialize(Stream& s) const
+{
+    s << PSTT_MAGIC_BYTES;
+
+    for (const auto& entry : xpubs) {
+        std::vector<unsigned char> keydata = SerializeXpubKeyData(entry.first);
+        SerializeToVector(s, PSTT_GLOBAL_XPUB, MakeSpan(keydata));
+        WriteCompactSize(s, entry.second.size() * sizeof(uint32_t));
+        for (uint32_t v : entry.second) s << v;
+    }
+
+    if (tx_features) {
+        SerializeToVector(s, PSTT_GLOBAL_TX_FEATURES);
+        SerializeToVector(s, *tx_features);
+    }
+    if (fallback_locktime) {
+        SerializeToVector(s, PSTT_GLOBAL_FALLBACK_LOCKTIME);
+        SerializeToVector(s, *fallback_locktime);
+    }
+    SerializeToVector(s, PSTT_GLOBAL_INPUT_COUNT);
+    SerializeCompactSizeValue(s, inputs.size());
+    SerializeToVector(s, PSTT_GLOBAL_OUTPUT_COUNT);
+    SerializeCompactSizeValue(s, outputs.size());
+    if (tx_modifiable) {
+        SerializeToVector(s, PSTT_GLOBAL_TX_MODIFIABLE);
+        SerializeToVector(s, *tx_modifiable);
+    }
+    if (version) {
+        SerializeToVector(s, PSTT_GLOBAL_VERSION);
+        SerializeToVector(s, *version);
+    }
+
+    for (const auto& entry : unknown) {
+        s << entry.first;
+        s << entry.second;
+    }
+
+    s << PSTT_SEPARATOR;
+
+    for (const PSTTInput& input : inputs) s << input;
+    for (const PSTTOutput& output : outputs) s << output;
+}
+
+template <typename Stream>
+void PartiallySignedTapyrusTransaction::Unserialize(Stream& s)
+{
+    uint8_t magic[5];
+    s >> magic;
+    if (!std::equal(magic, magic + 5, PSTT_MAGIC_BYTES)) {
+        throw std::ios_base::failure("Invalid PSTT magic bytes");
+    }
+
+    boost::optional<uint64_t> input_count;
+    boost::optional<uint64_t> output_count;
+    std::set<std::vector<unsigned char>> seen_xpubs;
+
+    while (true) {
+        if (s.empty()) throw std::ios_base::failure("PSTT global map is missing its terminating separator");
+        std::vector<unsigned char> key;
+        s >> key;
+        if (key.empty()) break; // separator found
+
+        unsigned char type = key[0];
+        switch (type) {
+            case 0x00:
+                throw std::ios_base::failure("Global type value 0x00 is reserved and must not be used");
+            case PSTT_GLOBAL_XPUB:
+            {
+                if (key.size() != 1 + PSTT_XPUB_KEYDATA_SIZE) {
+                    throw std::ios_base::failure("PSTT_GLOBAL_XPUB keydata is not 78 bytes");
+                }
+                std::vector<unsigned char> xpub_keydata(key.begin() + 1, key.end());
+                if (seen_xpubs.count(xpub_keydata) > 0) {
+                    throw std::ios_base::failure("Duplicate Key, PSTT_GLOBAL_XPUB already provided");
+                }
+                seen_xpubs.insert(xpub_keydata);
+                CExtPubKey xpub = ParseXpubKeyData(xpub_keydata);
+
+                uint64_t value_len = ReadCompactSize(s);
+                if (value_len < sizeof(uint32_t)) throw std::ios_base::failure("XPUB value must contain at least a 4-byte fingerprint");
+                if (value_len % sizeof(uint32_t) != 0) throw std::ios_base::failure("XPUB value length is not a multiple of 4");
+                std::vector<uint32_t> path;
+                for (unsigned int i = 0; i < value_len; i += sizeof(uint32_t)) {
+                    uint32_t v;
+                    s >> v;
+                    path.push_back(v);
+                }
+                xpubs.emplace_back(xpub, std::move(path));
+                break;
+            }
+            case PSTT_GLOBAL_TX_FEATURES:
+                if (tx_features) throw std::ios_base::failure("Duplicate Key, PSTT_GLOBAL_TX_FEATURES already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_GLOBAL_TX_FEATURES key is more than one byte type");
+                {
+                    int32_t v;
+                    UnserializeFromVector(s, v);
+                    tx_features = v; // any value accepted, see doc/tapyrus/pstt.md
+                }
+                break;
+            case PSTT_GLOBAL_FALLBACK_LOCKTIME:
+                if (fallback_locktime) throw std::ios_base::failure("Duplicate Key, PSTT_GLOBAL_FALLBACK_LOCKTIME already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_GLOBAL_FALLBACK_LOCKTIME key is more than one byte type");
+                {
+                    uint32_t v;
+                    UnserializeFromVector(s, v);
+                    fallback_locktime = v;
+                }
+                break;
+            case PSTT_GLOBAL_INPUT_COUNT:
+                if (input_count) throw std::ios_base::failure("Duplicate Key, PSTT_GLOBAL_INPUT_COUNT already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_GLOBAL_INPUT_COUNT key is more than one byte type");
+                input_count = UnserializeCompactSizeValue(s);
+                break;
+            case PSTT_GLOBAL_OUTPUT_COUNT:
+                if (output_count) throw std::ios_base::failure("Duplicate Key, PSTT_GLOBAL_OUTPUT_COUNT already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_GLOBAL_OUTPUT_COUNT key is more than one byte type");
+                output_count = UnserializeCompactSizeValue(s);
+                break;
+            case PSTT_GLOBAL_TX_MODIFIABLE:
+                if (tx_modifiable) throw std::ios_base::failure("Duplicate Key, PSTT_GLOBAL_TX_MODIFIABLE already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_GLOBAL_TX_MODIFIABLE key is more than one byte type");
+                {
+                    uint8_t v;
+                    UnserializeFromVector(s, v);
+                    tx_modifiable = v;
+                }
+                break;
+            case PSTT_GLOBAL_VERSION:
+                if (version) throw std::ios_base::failure("Duplicate Key, PSTT_GLOBAL_VERSION already provided");
+                if (key.size() != 1) throw std::ios_base::failure("PSTT_GLOBAL_VERSION key is more than one byte type");
+                {
+                    uint32_t v;
+                    UnserializeFromVector(s, v);
+                    if (v > 0) throw std::ios_base::failure("PSTT_GLOBAL_VERSION greater than 0 is not supported");
+                    version = v;
+                }
+                break;
+            case PSTT_GLOBAL_PROPRIETARY:
+            default:
+                if (unknown.count(key) > 0) throw std::ios_base::failure("Duplicate Key, key for unknown value already provided");
+                std::vector<unsigned char> val_bytes;
+                s >> val_bytes;
+                unknown.emplace(std::move(key), std::move(val_bytes));
+                break;
+        }
+    }
+
+    if (!tx_features) throw std::ios_base::failure("PSTT_GLOBAL_TX_FEATURES is required");
+    if (!input_count) throw std::ios_base::failure("PSTT_GLOBAL_INPUT_COUNT is required");
+    if (!output_count) throw std::ios_base::failure("PSTT_GLOBAL_OUTPUT_COUNT is required");
+
+    for (uint64_t i = 0; i < *input_count; ++i) {
+        if (s.empty()) throw std::ios_base::failure("Unexpected end of data while reading PSTT inputs");
+        PSTTInput input;
+        s >> input;
+        inputs.push_back(std::move(input));
+    }
+    for (uint64_t i = 0; i < *output_count; ++i) {
+        if (s.empty()) throw std::ios_base::failure("Unexpected end of data while reading PSTT outputs");
+        PSTTOutput output;
+        s >> output;
+        outputs.push_back(std::move(output));
+    }
+    if (!s.empty()) {
+        throw std::ios_base::failure("Unexpected data after the declared number of inputs/outputs");
+    }
+
+    if (!IsSane()) {
+        throw std::ios_base::failure("PSTT is not sane.");
+    }
+}
+
+// Explicit instantiation for the stream types this codebase actually uses --
+// needed because Serialize/Unserialize are defined out-of-line from the
+// class body (unlike the old PSBT code's inline-in-header templates).
+template void PSTTInput::Serialize(CDataStream&) const;
+template void PSTTInput::Unserialize(CDataStream&);
+template void PSTTOutput::Serialize(CDataStream&) const;
+template void PSTTOutput::Unserialize(CDataStream&);
+template void PartiallySignedTapyrusTransaction::Serialize(CDataStream&) const;
+template void PartiallySignedTapyrusTransaction::Unserialize(CDataStream&);
+
+// =======================================================================
+// Locktime, Identifier, and the shared tx-materialization helper.
+// See doc/tapyrus/pstt.md for the locktime and identifier algorithms.
+// =======================================================================
+
+bool ComputeLocktime(const PartiallySignedTapyrusTransaction& pstt, uint32_t& locktime_out)
+{
+    bool any_constrains = false;
+    for (const PSTTInput& input : pstt.inputs) {
+        if (input.required_time_locktime || input.required_height_locktime) {
+            any_constrains = true;
+            break;
+        }
+    }
+    if (!any_constrains) {
+        locktime_out = pstt.fallback_locktime.value_or(0);
+        return true;
+    }
+
+    bool height_possible = true;
+    bool time_possible = true;
+    for (const PSTTInput& input : pstt.inputs) {
+        bool has_height = input.required_height_locktime.is_initialized();
+        bool has_time = input.required_time_locktime.is_initialized();
+        if (!has_height && !has_time) continue; // no constraint from this input
+        if (!has_height) height_possible = false;
+        if (!has_time) time_possible = false;
+    }
+
+    if (!height_possible && !time_possible) return false;
+
+    bool use_height = height_possible; // both possible -> prefer height
+    uint32_t chosen = 0;
+    bool have_any = false;
+    for (const PSTTInput& input : pstt.inputs) {
+        const boost::optional<uint32_t>& field = use_height ? input.required_height_locktime : input.required_time_locktime;
+        if (field) {
+            chosen = have_any ? std::max(chosen, *field) : *field;
+            have_any = true;
+        }
+    }
+    if (!have_any) return false;
+    locktime_out = chosen;
+    return true;
+}
+
+namespace {
+
+// Not exposed in pstt.h. force_zero_sequence is true only for GetIdentifier()
+// (spec: identification zeroes all sequence numbers). use_final_scriptsig is
+// true only for extraction (uses PSTT_IN_FINAL_SCRIPTSIG; false leaves
+// scriptSig empty, used for signature-hash computation and IsSane()'s
+// locktime pre-check).
+CMutableTransaction MaterializeTransaction(const PartiallySignedTapyrusTransaction& pstt, uint32_t locktime,
+                                            bool force_zero_sequence, bool use_final_scriptsig)
+{
+    CMutableTransaction mtx;
+    mtx.nFeatures = pstt.tx_features.value_or(CTransaction::CURRENT_FEATURES);
+    mtx.nLockTime = locktime;
+
+    for (const PSTTInput& input : pstt.inputs) {
+        CTxIn txin;
+        txin.prevout = COutPoint(input.previous_txid, input.prev_out_index);
+        if (force_zero_sequence) {
+            txin.nSequence = 0;
+        } else {
+            // Literal 0xFFFFFFFF, not CTxIn::SEQUENCE_FINAL: that's an in-class-initialized
+            // static const with no out-of-line definition, and boost::optional::value_or()
+            // binds its argument by reference, which ODR-uses it and fails to link.
+            txin.nSequence = input.sequence.value_or(0xFFFFFFFFu);
+        }
+        if (use_final_scriptsig) {
+            txin.scriptSig = input.final_script_sig;
+        }
+        mtx.vin.push_back(std::move(txin));
+    }
+
+    for (const PSTTOutput& output : pstt.outputs) {
+        mtx.vout.emplace_back(output.amount.value_or(0), output.script);
+    }
+
+    return mtx;
+}
+
+} // namespace
+
+uint256 PartiallySignedTapyrusTransaction::GetIdentifier() const
+{
+    uint32_t locktime;
+    if (!ComputeLocktime(*this, locktime)) {
+        throw std::runtime_error("PSTT has no valid locktime; cannot compute identifier");
+    }
+    return MaterializeTransaction(*this, locktime, /*force_zero_sequence=*/true, /*use_final_scriptsig=*/false).GetHashMalFix();
+}
+
+// =======================================================================
+// Signer
+// =======================================================================
+
+std::string PSTTSignResultToString(PSTTSignResult result)
+{
+    switch (result) {
+        case PSTTSignResult::OK: return "OK";
+        case PSTTSignResult::MISSING_UTXO: return "input has no PSTT_IN_UTXO";
+        case PSTTSignResult::UTXO_TXID_MISMATCH: return "PSTT_IN_UTXO txid does not match PSTT_IN_PREVIOUS_TXID";
+        case PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH: return "redeem script does not hash to the committed value";
+        case PSTTSignResult::SIGHASH_CONFLICT: return "requested sighash type conflicts with PSTT_IN_SIGHASH_TYPE";
+        case PSTTSignResult::SCHEME_CONFLICT: return "signature scheme conflicts with an existing signature on this input";
+        case PSTTSignResult::LOCKTIME_INVALID: return "no locktime is acceptable to every constraining input";
+        case PSTTSignResult::SIGHASH_SINGLE_OOB: return "SIGHASH_SINGLE used on an input with no corresponding output";
+    }
+    return "unknown PSTTSignResult";
+}
+
+static bool ExtractRedeemScriptHash(const CScript& scriptPubKey, uint160& hash_out)
+{
+    if (scriptPubKey.IsPayToScriptHash()) {
+        // OP_HASH160 <20-byte hash> OP_EQUAL
+        hash_out = uint160(std::vector<unsigned char>(scriptPubKey.begin() + 2, scriptPubKey.begin() + 22));
+        return true;
+    }
+    if (scriptPubKey.IsColoredPayToScriptHash()) {
+        // <COLOR identifier> OP_COLOR OP_HASH160 <20-byte hash> OP_EQUAL -- skip the
+        // 33-byte color-id prefix (push opcode + 33 bytes payload = 34 bytes) before
+        // the OP_HASH160/hash/OP_EQUAL suffix that mirrors plain P2SH.
+        hash_out = uint160(std::vector<unsigned char>(scriptPubKey.begin() + 37, scriptPubKey.begin() + 57));
+        return true;
+    }
+    return false;
+}
+
+PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySignedTapyrusTransaction& pstt,
+                              unsigned int index, SignatureData& sigdata, int sighash, SignatureScheme sigScheme)
+{
+    const PSTTInput& input = pstt.inputs.at(index);
+
+    // Already finalized: nothing to do.
+    if (!input.final_script_sig.empty()) {
+        return PSTTSignResult::OK;
+    }
+
+    // Must not sign an input lacking a UTXO.
+    if (!input.utxo) {
+        return PSTTSignResult::MISSING_UTXO;
+    }
+    // Must verify the UTXO's txid matches PSTT_IN_PREVIOUS_TXID. This is defense-in-depth:
+    // it's also enforced at Unserialize() time on the whole PSTT, but a Merge()'d PSTT could
+    // combine a PSTT_IN_UTXO from one party with a PSTT_IN_PREVIOUS_TXID from another that
+    // don't match, bypassing the parse-time check.
+    if (input.utxo->GetHashMalFix() != input.previous_txid) {
+        return PSTTSignResult::UTXO_TXID_MISMATCH;
+    }
+    if (input.prev_out_index >= input.utxo->vout.size()) {
+        return PSTTSignResult::UTXO_TXID_MISMATCH;
+    }
+
+    const CTxOut& utxo_out = input.utxo->vout[input.prev_out_index];
+
+    // Must verify the redeem script hashes to the value committed in the
+    // scriptPubKey, accounting for CP2SH's color-id prefix.
+    if (!input.redeem_script.empty()) {
+        uint160 expected_hash;
+        if (!ExtractRedeemScriptHash(utxo_out.scriptPubKey, expected_hash)) {
+            return PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH;
+        }
+        if (CScriptID(input.redeem_script) != CScriptID(expected_hash)) {
+            return PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH;
+        }
+    }
+
+    // Must use the sighash type in PSTT_IN_SIGHASH_TYPE if present.
+    if (input.sighash_type > 0 && input.sighash_type != sighash) {
+        return PSTTSignResult::SIGHASH_CONFLICT;
+    }
+
+    // SIGHASH_SINGLE must not sign an index >= output count.
+    if ((sighash & 0x1f) == SIGHASH_SINGLE && index >= pstt.outputs.size()) {
+        return PSTTSignResult::SIGHASH_SINGLE_OOB;
+    }
+
+    // Must compute the locktime and refuse to sign if none is valid.
+    uint32_t locktime;
+    if (!ComputeLocktime(pstt, locktime)) {
+        return PSTTSignResult::LOCKTIME_INVALID;
+    }
+
+    // Must not add a signature whose scheme conflicts with a signature already
+    // present on this input -- proactive rejection; IsSane() is the reactive/
+    // structural backstop for the same rule.
+    SignatureScheme incoming_scheme = sigScheme;
+    for (const auto& kv : input.partial_sigs) {
+        const std::vector<unsigned char>& sig = kv.second.second;
+        SignatureScheme existing_scheme = (sig.size() == CPubKey::COMPACT_SIGNATURE_SIZE)
+            ? SignatureScheme::SCHNORR : SignatureScheme::ECDSA;
+        if (existing_scheme != incoming_scheme) {
+            return PSTTSignResult::SCHEME_CONFLICT;
+        }
+    }
+
+    input.FillSignatureData(sigdata);
+
+    CMutableTransaction mtx_view = MaterializeTransaction(pstt, locktime, /*force_zero_sequence=*/false, /*use_final_scriptsig=*/false);
+    MutableTransactionSignatureCreator creator(&mtx_view, index, utxo_out.nValue, sighash, sigScheme);
+    ProduceSignature(provider, creator, utxo_out.scriptPubKey, sigdata);
+
+    // pstt is taken by const reference (MaterializeTransaction needs the whole
+    // PSTT, not just this input, so the signature intentionally doesn't take a
+    // mutable single-input reference the way the old SignPSBTInput did) -- it's
+    // the caller's responsibility to apply input.FromSignatureData(sigdata) to
+    // its own mutable copy once this returns OK.
+    return PSTTSignResult::OK;
+}

--- a/src/pstt.h
+++ b/src/pstt.h
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// Partially Signed Tapyrus Transaction (PSTT), per TIP-174
+// (chaintope/tips, tip-0174.md). Tapyrus-native replacement for the
+// Bitcoin-shaped PSBT (BIP-174 "v0") format previously carried in
+// script/sign.h/.cpp -- no global unsigned tx, per-input outpoint fields
+// instead, Colored Coin aware, ECDSA/Schnorr aware.
+
+#ifndef TAPYRUS_PSTT_H
+#define TAPYRUS_PSTT_H
+
+#include <boost/optional.hpp>
+#include <primitives/transaction.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <script/sign.h>
+#include <uint256.h>
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+// ---------------------------------------------------------------------
+// Magic bytes
+// ---------------------------------------------------------------------
+
+static constexpr uint8_t PSTT_MAGIC_BYTES[5] = {'p', 's', 't', 't', 0xFF};
+
+// ---------------------------------------------------------------------
+// Global types
+// ---------------------------------------------------------------------
+
+static constexpr uint8_t PSTT_GLOBAL_XPUB              = 0x01;
+static constexpr uint8_t PSTT_GLOBAL_TX_FEATURES        = 0x02; // required
+static constexpr uint8_t PSTT_GLOBAL_FALLBACK_LOCKTIME  = 0x03;
+static constexpr uint8_t PSTT_GLOBAL_INPUT_COUNT        = 0x04; // required
+static constexpr uint8_t PSTT_GLOBAL_OUTPUT_COUNT       = 0x05; // required
+static constexpr uint8_t PSTT_GLOBAL_TX_MODIFIABLE      = 0x06;
+static constexpr uint8_t PSTT_GLOBAL_VERSION            = 0xFB;
+static constexpr uint8_t PSTT_GLOBAL_PROPRIETARY        = 0xFC;
+// 0x00 is reserved (BIP-174's global unsigned tx, no counterpart here) --
+// must be actively rejected, not silently folded into unknown.
+
+// ---------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------
+
+static constexpr uint8_t PSTT_IN_UTXO                     = 0x00; // required before signing
+static constexpr uint8_t PSTT_IN_PARTIAL_SIG               = 0x02;
+static constexpr uint8_t PSTT_IN_SIGHASH_TYPE              = 0x03;
+static constexpr uint8_t PSTT_IN_REDEEM_SCRIPT             = 0x04;
+static constexpr uint8_t PSTT_IN_BIP32_DERIVATION          = 0x06;
+static constexpr uint8_t PSTT_IN_FINAL_SCRIPTSIG           = 0x07;
+static constexpr uint8_t PSTT_IN_RIPEMD160                 = 0x0a;
+static constexpr uint8_t PSTT_IN_SHA256                    = 0x0b;
+static constexpr uint8_t PSTT_IN_HASH160                   = 0x0c;
+static constexpr uint8_t PSTT_IN_HASH256                   = 0x0d;
+static constexpr uint8_t PSTT_IN_PREVIOUS_TXID             = 0x0e; // required
+static constexpr uint8_t PSTT_IN_OUTPUT_INDEX              = 0x0f; // required
+static constexpr uint8_t PSTT_IN_SEQUENCE                  = 0x10;
+static constexpr uint8_t PSTT_IN_REQUIRED_TIME_LOCKTIME    = 0x11;
+static constexpr uint8_t PSTT_IN_REQUIRED_HEIGHT_LOCKTIME  = 0x12;
+static constexpr uint8_t PSTT_IN_PROPRIETARY               = 0xFC;
+// Reserved/must-reject on inputs: 0x01 (witness UTXO), 0x05 (witness script),
+// 0x08 (finalized scriptWitness), 0x09 (proof-of-reserves commitment), and
+// the Taproot-related type values from BIP-371 (PSBT_IN_TAP_KEY_SIG=0x13
+// through PSBT_IN_TAP_MERKLE_ROOT=0x18) -- none have a Tapyrus counterpart.
+
+// ---------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------
+
+static constexpr uint8_t PSTT_OUT_REDEEM_SCRIPT    = 0x00;
+static constexpr uint8_t PSTT_OUT_BIP32_DERIVATION  = 0x02;
+static constexpr uint8_t PSTT_OUT_AMOUNT             = 0x03; // required
+static constexpr uint8_t PSTT_OUT_SCRIPT              = 0x04; // required
+static constexpr uint8_t PSTT_OUT_PROPRIETARY          = 0xFC;
+// Reserved/must-reject on outputs: 0x01 (witness script), and the
+// Taproot-related type values from BIP-371 (PSBT_OUT_TAP_INTERNAL_KEY=0x05
+// through PSBT_OUT_TAP_BIP32_DERIVATION=0x07).
+
+static constexpr uint8_t PSTT_SEPARATOR = 0x00;
+
+// PSTT_GLOBAL_TX_MODIFIABLE bitfield
+static constexpr uint8_t PSTT_TXMOD_INPUTS_MODIFIABLE  = 1 << 0;
+static constexpr uint8_t PSTT_TXMOD_OUTPUTS_MODIFIABLE = 1 << 1;
+static constexpr uint8_t PSTT_TXMOD_HAS_SIGHASH_SINGLE = 1 << 2;
+// Bits 3-7 are reserved and must be 0.
+static constexpr uint8_t PSTT_TXMOD_RESERVED_MASK = ~static_cast<uint8_t>(
+    PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE | PSTT_TXMOD_HAS_SIGHASH_SINGLE);
+
+// ---------------------------------------------------------------------
+// PSTT_GLOBAL_XPUB keydata helpers (see pstt.cpp)
+//
+// The spec's 78-byte xpub keydata is BIP32's full serialization (4-byte
+// version prefix + CExtPubKey's 74-byte encoding). CExtPubKey::Encode()
+// only produces the 74 bytes; the version prefix must be affixed/checked
+// separately against Params().Base58Prefix(EXT_PUBLIC_KEY) -- exactly one
+// accepted prefix, not a {PROD, DEV} set (see pstt.cpp for the rationale).
+// Do not use EncodeExtPubKey/DecodeExtPubKey (key_io.h) here -- those
+// produce/consume a base58check *string*, the wrong shape for raw PSTT
+// keydata.
+// ---------------------------------------------------------------------
+
+static constexpr size_t PSTT_XPUB_KEYDATA_SIZE = 4 + BIP32_EXTKEY_SIZE; // 78
+
+std::vector<unsigned char> SerializeXpubKeyData(const CExtPubKey& xpub);
+/** Throws std::ios_base::failure (naming the concrete prefix mismatch) if
+ *  the 4-byte prefix isn't exactly Params().Base58Prefix(EXT_PUBLIC_KEY). */
+CExtPubKey ParseXpubKeyData(const std::vector<unsigned char>& keydata);
+
+// ---------------------------------------------------------------------
+// PSTTInput
+// ---------------------------------------------------------------------
+
+struct PSTTInput
+{
+    // Required -- these have no natural "empty" sentinel, hence explicit
+    // presence flags rather than e.g. treating an all-zero txid as absent.
+    uint256  previous_txid;
+    uint32_t prev_out_index = 0;
+    bool     previous_txid_set = false;
+    bool     prev_out_index_set = false;
+
+    // Optional, absence is the natural "empty"
+    CTransactionRef utxo;             // PSTT_IN_UTXO -- full previous tx only
+    CScript   redeem_script;          // PSTT_IN_REDEEM_SCRIPT (CP2SH: excludes color-id prefix)
+    CScript   final_script_sig;       // PSTT_IN_FINAL_SCRIPTSIG
+    std::map<CPubKey, std::vector<uint32_t>> hd_keypaths;   // PSTT_IN_BIP32_DERIVATION
+    std::map<CKeyID, SigPair> partial_sigs;                 // PSTT_IN_PARTIAL_SIG
+    int sighash_type = 0;             // PSTT_IN_SIGHASH_TYPE
+    boost::optional<uint32_t> sequence;               // PSTT_IN_SEQUENCE; default 0xFFFFFFFF if absent
+    boost::optional<uint32_t> required_time_locktime;    // >= 500000000
+    boost::optional<uint32_t> required_height_locktime;  // >0 and <500000000
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> ripemd160_preimages; // key len 20
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> sha256_preimages;    // key len 32
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> hash160_preimages;   // key len 20
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> hash256_preimages;   // key len 32
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> unknown; // PSTT_IN_PROPRIETARY + unrecognized
+
+    bool IsNull() const;
+    void FillSignatureData(SignatureData& sigdata) const;
+    void FromSignatureData(const SignatureData& sigdata);
+    void Merge(const PSTTInput& input);
+    bool IsSane() const;
+
+    template <typename Stream>
+    void Serialize(Stream& s) const;
+    template <typename Stream>
+    void Unserialize(Stream& s);
+};
+
+// ---------------------------------------------------------------------
+// PSTTOutput
+// ---------------------------------------------------------------------
+
+struct PSTTOutput
+{
+    boost::optional<CAmount> amount;  // PSTT_OUT_AMOUNT; required
+    CScript   script;                 // PSTT_OUT_SCRIPT; required -- includes <color id> OP_COLOR prefix if colored
+    CScript   redeem_script;          // PSTT_OUT_REDEEM_SCRIPT
+    std::map<CPubKey, std::vector<uint32_t>> hd_keypaths; // PSTT_OUT_BIP32_DERIVATION
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> unknown; // PSTT_OUT_PROPRIETARY + unrecognized
+
+    bool IsNull() const;
+    void FillSignatureData(SignatureData& sigdata) const;
+    void FromSignatureData(const SignatureData& sigdata);
+    void Merge(const PSTTOutput& output);
+    bool IsSane() const;   // amount present && script present
+
+    template <typename Stream>
+    void Serialize(Stream& s) const;
+    template <typename Stream>
+    void Unserialize(Stream& s);
+};
+
+// ---------------------------------------------------------------------
+// PartiallySignedTapyrusTransaction
+// ---------------------------------------------------------------------
+
+struct PartiallySignedTapyrusTransaction
+{
+    boost::optional<int32_t>  tx_features;       // PSTT_GLOBAL_TX_FEATURES; required, any value accepted
+    boost::optional<uint32_t> fallback_locktime; // PSTT_GLOBAL_FALLBACK_LOCKTIME; default 0
+    boost::optional<uint8_t>  tx_modifiable;     // PSTT_GLOBAL_TX_MODIFIABLE bitfield; absent = not modifiable
+    boost::optional<uint32_t> version;           // PSTT_GLOBAL_VERSION; default 0; must reject > 0 on parse
+    std::vector<std::pair<CExtPubKey, std::vector<uint32_t>>> xpubs; // PSTT_GLOBAL_XPUB
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> unknown; // PSTT_GLOBAL_PROPRIETARY + unrecognized
+
+    std::vector<PSTTInput>  inputs;
+    std::vector<PSTTOutput> outputs;
+    // PSTT_GLOBAL_INPUT_COUNT/OUTPUT_COUNT are NOT separate stored members --
+    // always == inputs.size()/outputs.size() in memory. On the wire they tell
+    // Unserialize how many input-map/output-map blocks follow; a mismatch
+    // between the declared count and the stream's actual content is a parse
+    // error.
+
+    bool IsNull() const;
+    void Merge(const PartiallySignedTapyrusTransaction& other);   // Combiner
+    bool IsSane() const;
+    uint256 GetIdentifier() const;
+    bool HasSameIdentifierAs(const PartiallySignedTapyrusTransaction& other) const
+    {
+        return GetIdentifier() == other.GetIdentifier();
+    }
+
+    template <typename Stream>
+    void Serialize(Stream& s) const;
+    template <typename Stream>
+    void Unserialize(Stream& s);
+};
+
+/** Determine the locktime a PartiallySignedTapyrusTransaction's materialized
+ *  transaction must carry, per TIP-174's "Determining the Locktime" algorithm
+ *  (see pstt.cpp). Returns false (leaving locktime_out unspecified) if no
+ *  locktime kind is acceptable to every input that constrains one. */
+bool ComputeLocktime(const PartiallySignedTapyrusTransaction& pstt, uint32_t& locktime_out);
+
+// ---------------------------------------------------------------------
+// Signer result taxonomy
+// ---------------------------------------------------------------------
+
+enum class PSTTSignResult
+{
+    OK,
+    MISSING_UTXO,
+    UTXO_TXID_MISMATCH,
+    REDEEM_SCRIPT_HASH_MISMATCH,
+    SIGHASH_CONFLICT,
+    SCHEME_CONFLICT,
+    LOCKTIME_INVALID,
+    SIGHASH_SINGLE_OOB,
+};
+
+// String forms returned by PSTTSignResultToString() are PSTT-internal and
+// may be renamed; RPC callers must not treat them as a stable API contract
+// beyond "this string is safe to surface in an error message."
+std::string PSTTSignResultToString(PSTTSignResult result);
+
+/** Sign one input of a PartiallySignedTapyrusTransaction, verifying that all
+ *  provided data (UTXO, redeem script, sighash type, locktime) matches what
+ *  is being signed, and that the added signature's scheme doesn't conflict
+ *  with any signature already present on that input. */
+PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySignedTapyrusTransaction& pstt,
+                              unsigned int index, SignatureData& sigdata, int sighash,
+                              SignatureScheme sigScheme = SignatureScheme::ECDSA);
+
+#endif // TAPYRUS_PSTT_H

--- a/src/pstt.h
+++ b/src/pstt.h
@@ -131,7 +131,7 @@ struct PSTTInput
     CScript   final_script_sig;       // PSTT_IN_FINAL_SCRIPTSIG
     std::map<CPubKey, std::vector<uint32_t>> hd_keypaths;   // PSTT_IN_BIP32_DERIVATION
     std::map<CKeyID, SigPair> partial_sigs;                 // PSTT_IN_PARTIAL_SIG
-    int sighash_type = 0;             // PSTT_IN_SIGHASH_TYPE
+    boost::optional<int32_t> sighash_type;            // PSTT_IN_SIGHASH_TYPE
     boost::optional<uint32_t> sequence;               // PSTT_IN_SEQUENCE; default 0xFFFFFFFF if absent
     boost::optional<uint32_t> required_time_locktime;    // >= 500000000
     boost::optional<uint32_t> required_height_locktime;  // >0 and <500000000
@@ -228,6 +228,7 @@ enum class PSTTSignResult
     OK,
     MISSING_UTXO,
     UTXO_TXID_MISMATCH,
+    PREV_OUT_INDEX_OOB,
     REDEEM_SCRIPT_HASH_MISMATCH,
     SIGHASH_CONFLICT,
     SCHEME_CONFLICT,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -87,6 +87,7 @@ add_executable(test_tapyrus
         pmt_tests.cpp
         policyestimator_tests.cpp
         prevector_tests.cpp
+        pstt_tests.cpp
         raii_event_tests.cpp
         random_tests.cpp
         reverselock_tests.cpp

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(pstt_roundtrip_full_fields)
     BOOST_CHECK_EQUAL(*parsed.tx_modifiable, *pstt.tx_modifiable);
     BOOST_CHECK_EQUAL(*parsed.version, 0U);
     const PSTTInput& pinput = parsed.inputs[0];
-    BOOST_CHECK_EQUAL(pinput.sighash_type, 1);
+    BOOST_CHECK_EQUAL(*pinput.sighash_type, 1);
     BOOST_CHECK_EQUAL(*pinput.sequence, 0xFFFFFFFEu);
     BOOST_CHECK_EQUAL(*pinput.required_height_locktime, 100U);
     BOOST_CHECK_EQUAL(pinput.partial_sigs.size(), 1U);
@@ -818,6 +818,269 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_token_without_fee, TestChainSetup)
     SignInputForTest(transferPstt, 0, coloredProvider);
 
     CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(transferPstt)), false, "bad-txns-token-without-fee");
+}
+
+// -----------------------------------------------------------------------
+// PSTTInput::Merge() / PSTTOutput::Merge() conflict and mismatch throw sites
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_merge_refuses_mismatched_input_output_counts)
+{
+    PartiallySignedTapyrusTransaction a = MakeBasicPstt();
+    PartiallySignedTapyrusTransaction b = a;
+    CTransactionRef utxo2 = MakeSimpleUtxoTx(RandomP2PKHScript(), 5000);
+    b.inputs.push_back(MakeBasicInput(utxo2->GetHashMalFix(), 0, utxo2));
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_input_merge_refuses_conflicting_utxo)
+{
+    CTransactionRef utxo1 = MakeSimpleUtxoTx(RandomP2PKHScript(), 1000);
+    CTransactionRef utxo2 = MakeSimpleUtxoTx(RandomP2PKHScript(), 2000);
+    PSTTInput a = MakeBasicInput(utxo1->GetHashMalFix(), 0, utxo1);
+    PSTTInput b = a;
+    b.utxo = utxo2; // different tx attached to the "same" input
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_input_merge_refuses_conflicting_final_scriptsig)
+{
+    CTransactionRef utxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 1000);
+    PSTTInput a = MakeBasicInput(utxo->GetHashMalFix(), 0, utxo);
+    PSTTInput b = a;
+    a.final_script_sig = CScript() << OP_TRUE;
+    b.final_script_sig = CScript() << OP_FALSE;
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_input_merge_refuses_conflicting_partial_sig)
+{
+    CTransactionRef utxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 1000);
+    PSTTInput a = MakeBasicInput(utxo->GetHashMalFix(), 0, utxo);
+    PSTTInput b = a;
+    CKey key;
+    key.MakeNewKey(true);
+    std::vector<unsigned char> sig1(71, 0x11);
+    sig1.push_back(1);
+    std::vector<unsigned char> sig2(71, 0x22);
+    sig2.push_back(1);
+    a.partial_sigs.emplace(key.GetPubKey().GetID(), SigPair(key.GetPubKey(), sig1));
+    b.partial_sigs.emplace(key.GetPubKey().GetID(), SigPair(key.GetPubKey(), sig2));
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_input_merge_refuses_mismatched_redeem_script)
+{
+    CTransactionRef utxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 1000);
+    PSTTInput a = MakeBasicInput(utxo->GetHashMalFix(), 0, utxo);
+    PSTTInput b = a;
+    a.redeem_script = CScript() << OP_TRUE;
+    b.redeem_script = CScript() << OP_FALSE;
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_input_merge_refuses_mismatched_bip32_derivation)
+{
+    CTransactionRef utxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 1000);
+    PSTTInput a = MakeBasicInput(utxo->GetHashMalFix(), 0, utxo);
+    PSTTInput b = a;
+    CKey key;
+    key.MakeNewKey(true);
+    a.hd_keypaths.emplace(key.GetPubKey(), std::vector<uint32_t>{1, 2, 3});
+    b.hd_keypaths.emplace(key.GetPubKey(), std::vector<uint32_t>{4, 5, 6});
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_output_merge_refuses_mismatched_redeem_script)
+{
+    PSTTOutput a;
+    a.amount = 1000;
+    a.script = RandomP2PKHScript();
+    PSTTOutput b = a;
+    a.redeem_script = CScript() << OP_TRUE;
+    b.redeem_script = CScript() << OP_FALSE;
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_output_merge_refuses_mismatched_bip32_derivation)
+{
+    PSTTOutput a;
+    a.amount = 1000;
+    a.script = RandomP2PKHScript();
+    PSTTOutput b = a;
+    CKey key;
+    key.MakeNewKey(true);
+    a.hd_keypaths.emplace(key.GetPubKey(), std::vector<uint32_t>{1});
+    b.hd_keypaths.emplace(key.GetPubKey(), std::vector<uint32_t>{2});
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+// -----------------------------------------------------------------------
+// Output-side reserved keytype rejection (analog to
+// pstt_rejects_reserved_input_keytype above, for PSTTOutput)
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_reserved_output_keytype)
+{
+    for (uint8_t reserved : {0x01, 0x05, 0x06, 0x07}) {
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        SerializeToVector(ss, reserved);
+        ss << std::vector<unsigned char>{0x00};
+        ss << PSTT_SEPARATOR;
+
+        std::vector<unsigned char> data(ss.begin(), ss.end());
+        BOOST_CHECK_THROW(UnserializeObj<PSTTOutput>(data), std::ios_base::failure);
+    }
+}
+
+// -----------------------------------------------------------------------
+// PSTT_IN_REQUIRED_*_LOCKTIME parse-time range validation
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_time_locktime_too_low)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    SerializeToVector(ss, PSTT_IN_REQUIRED_TIME_LOCKTIME);
+    SerializeToVector(ss, (uint32_t)499999999);
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PSTTInput>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_height_locktime_zero)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    SerializeToVector(ss, PSTT_IN_REQUIRED_HEIGHT_LOCKTIME);
+    SerializeToVector(ss, (uint32_t)0);
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PSTTInput>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_height_locktime_too_high)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    SerializeToVector(ss, PSTT_IN_REQUIRED_HEIGHT_LOCKTIME);
+    SerializeToVector(ss, (uint32_t)500000000);
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PSTTInput>(data), std::ios_base::failure);
+}
+
+// -----------------------------------------------------------------------
+// PSTT_GLOBAL_TX_MODIFIABLE reserved bits (3-7)
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_issane_rejects_reserved_txmod_bits)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.tx_modifiable = 1 << 3; // lowest reserved bit
+    BOOST_CHECK(!pstt.IsSane());
+}
+
+// -----------------------------------------------------------------------
+// SignPSTTInput() non-OK result coverage. These call SignPSTTInput()
+// directly on hand-built PSTTs rather than going through the mempool-level
+// pipeline above -- each case is set up to fail at one specific check, so
+// DUMMY_SIGNING_PROVIDER (no real keys) is sufficient; none of these reach
+// ProduceSignature().
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_sign_missing_utxo)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.inputs[0].utxo = nullptr;
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_ALL);
+    BOOST_CHECK(result == PSTTSignResult::MISSING_UTXO);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_sign_utxo_txid_mismatch)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    // Swap in an unrelated UTXO whose hash no longer matches previous_txid.
+    pstt.inputs[0].utxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 5000);
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_ALL);
+    BOOST_CHECK(result == PSTTSignResult::UTXO_TXID_MISMATCH);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_sign_prev_out_index_oob)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.inputs[0].prev_out_index = 5; // utxo only has a single output (index 0)
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_ALL);
+    BOOST_CHECK(result == PSTTSignResult::PREV_OUT_INDEX_OOB);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_sign_redeem_script_hash_mismatch)
+{
+    CScript actualRedeem = CScript() << OP_TRUE;
+    CScript scriptPubKey = CScript() << OP_HASH160 << ToByteVector(CScriptID(actualRedeem)) << OP_EQUAL;
+    CTransactionRef utxo = MakeSimpleUtxoTx(scriptPubKey, 100000);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    pstt.inputs.push_back(MakeBasicInput(utxo->GetHashMalFix(), 0, utxo));
+    PSTTOutput output;
+    output.amount = 90000;
+    output.script = RandomP2PKHScript();
+    pstt.outputs.push_back(output);
+
+    pstt.inputs[0].redeem_script = CScript() << OP_FALSE; // wrong script -- different hash
+
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_ALL);
+    BOOST_CHECK(result == PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_sign_sighash_conflict)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.inputs[0].sighash_type = SIGHASH_ALL;
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_NONE);
+    BOOST_CHECK(result == PSTTSignResult::SIGHASH_CONFLICT);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_sign_sighash_single_oob)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt(); // 1 input, 1 output
+    CTransactionRef utxo2 = MakeSimpleUtxoTx(RandomP2PKHScript(), 50000);
+    pstt.inputs.push_back(MakeBasicInput(utxo2->GetHashMalFix(), 0, utxo2)); // 2nd input, no matching 2nd output
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 1, sigdata, SIGHASH_SINGLE);
+    BOOST_CHECK(result == PSTTSignResult::SIGHASH_SINGLE_OOB);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_sign_locktime_invalid)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    CTransactionRef utxo2 = MakeSimpleUtxoTx(RandomP2PKHScript(), 50000);
+    pstt.inputs.push_back(MakeBasicInput(utxo2->GetHashMalFix(), 0, utxo2));
+    // Input 0 only accepts height, input 1 only accepts time -> empty intersection.
+    pstt.inputs[0].required_height_locktime = 800;
+    pstt.inputs[1].required_time_locktime = 700000000;
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_ALL);
+    BOOST_CHECK(result == PSTTSignResult::LOCKTIME_INVALID);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_sign_scheme_conflict)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    CKey key1;
+    key1.MakeNewKey(true);
+    std::vector<unsigned char> schnorr_sig(CPubKey::COMPACT_SIGNATURE_SIZE, 0x22); // already-present Schnorr sig
+    pstt.inputs[0].partial_sigs.emplace(key1.GetPubKey().GetID(), SigPair(key1.GetPubKey(), schnorr_sig));
+
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_ALL, SignatureScheme::ECDSA);
+    BOOST_CHECK(result == PSTTSignResult::SCHEME_CONFLICT);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -1,0 +1,823 @@
+// Copyright (c) 2026 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <pstt.h>
+
+#include <amount.h>
+#include <chainparams.h>
+#include <coloridentifier.h>
+#include <consensus/validation.h>
+#include <key.h>
+#include <policy/policy.h>
+#include <script/script.h>
+#include <streams.h>
+#include <test/test_tapyrus.h>
+#include <txmempool.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(pstt_tests, BasicTestingSetup)
+
+static CScript RandomP2PKHScript()
+{
+    CKey key;
+    key.MakeNewKey(true);
+    CKeyID id = key.GetPubKey().GetID();
+    CScript script;
+    script << OP_DUP << OP_HASH160 << ToByteVector(id) << OP_EQUALVERIFY << OP_CHECKSIG;
+    return script;
+}
+
+static CTransactionRef MakeSimpleUtxoTx(const CScript& scriptPubKey, CAmount amount)
+{
+    CMutableTransaction mtx;
+    mtx.nFeatures = CTransaction::CURRENT_FEATURES;
+    mtx.nLockTime = 0;
+    mtx.vout.emplace_back(amount, scriptPubKey);
+    return MakeTransactionRef(std::move(mtx));
+}
+
+static PSTTInput MakeBasicInput(const uint256& prev_txid, uint32_t vout, const CTransactionRef& utxo)
+{
+    PSTTInput input;
+    input.previous_txid = prev_txid;
+    input.prev_out_index = vout;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    input.utxo = utxo;
+    return input;
+}
+
+static PartiallySignedTapyrusTransaction MakeBasicPstt()
+{
+    CScript scriptPubKey = RandomP2PKHScript();
+    CTransactionRef utxo = MakeSimpleUtxoTx(scriptPubKey, 100000);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    pstt.inputs.push_back(MakeBasicInput(utxo->GetHashMalFix(), 0, utxo));
+
+    PSTTOutput output;
+    output.amount = 90000;
+    output.script = RandomP2PKHScript();
+    pstt.outputs.push_back(output);
+
+    return pstt;
+}
+
+template <typename T>
+static std::vector<unsigned char> SerializeObj(const T& obj)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << obj;
+    return std::vector<unsigned char>(ss.begin(), ss.end());
+}
+
+template <typename T>
+static T UnserializeObj(const std::vector<unsigned char>& data)
+{
+    CDataStream ss(data, SER_NETWORK, PROTOCOL_VERSION);
+    T obj;
+    ss >> obj;
+    return obj;
+}
+
+// -----------------------------------------------------------------------
+// Round-trip serialize/deserialize
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_roundtrip_basic)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    std::vector<unsigned char> data = SerializeObj(pstt);
+    PartiallySignedTapyrusTransaction parsed = UnserializeObj<PartiallySignedTapyrusTransaction>(data);
+
+    BOOST_CHECK_EQUAL(*parsed.tx_features, *pstt.tx_features);
+    BOOST_CHECK_EQUAL(parsed.inputs.size(), 1U);
+    BOOST_CHECK_EQUAL(parsed.outputs.size(), 1U);
+    BOOST_CHECK(parsed.inputs[0].previous_txid_set);
+    BOOST_CHECK(parsed.inputs[0].previous_txid == pstt.inputs[0].previous_txid);
+    BOOST_CHECK_EQUAL(parsed.inputs[0].prev_out_index, pstt.inputs[0].prev_out_index);
+    BOOST_CHECK(parsed.inputs[0].utxo->GetHashMalFix() == pstt.inputs[0].utxo->GetHashMalFix());
+    BOOST_CHECK_EQUAL(*parsed.outputs[0].amount, *pstt.outputs[0].amount);
+    BOOST_CHECK(parsed.outputs[0].script == pstt.outputs[0].script);
+    BOOST_CHECK(parsed.GetIdentifier() == pstt.GetIdentifier());
+}
+
+BOOST_AUTO_TEST_CASE(pstt_roundtrip_full_fields)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.fallback_locktime = 12345;
+    pstt.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE;
+    pstt.version = 0;
+
+    PSTTInput& input = pstt.inputs[0];
+    input.sighash_type = 1;
+    input.sequence = 0xFFFFFFFEu;
+    input.required_height_locktime = 100;
+    CKey key;
+    key.MakeNewKey(true);
+    std::vector<unsigned char> der_sig(71, 0x11);
+    der_sig.push_back(1); // sighash byte
+    input.partial_sigs.emplace(key.GetPubKey().GetID(), SigPair(key.GetPubKey(), der_sig));
+    input.hd_keypaths.emplace(key.GetPubKey(), std::vector<uint32_t>{0x01020304, 0, 1});
+    input.ripemd160_preimages.emplace(std::vector<unsigned char>(20, 0xAA), std::vector<unsigned char>{1, 2, 3});
+    input.sha256_preimages.emplace(std::vector<unsigned char>(32, 0xBB), std::vector<unsigned char>{4, 5, 6});
+    input.hash160_preimages.emplace(std::vector<unsigned char>(20, 0xCC), std::vector<unsigned char>{7, 8});
+    input.hash256_preimages.emplace(std::vector<unsigned char>(32, 0xDD), std::vector<unsigned char>{9});
+    input.unknown.emplace(std::vector<unsigned char>{(unsigned char)PSTT_IN_PROPRIETARY, 0x01}, std::vector<unsigned char>{0x42});
+
+    std::vector<unsigned char> data = SerializeObj(pstt);
+    PartiallySignedTapyrusTransaction parsed = UnserializeObj<PartiallySignedTapyrusTransaction>(data);
+
+    BOOST_CHECK_EQUAL(*parsed.fallback_locktime, 12345U);
+    BOOST_CHECK_EQUAL(*parsed.tx_modifiable, *pstt.tx_modifiable);
+    BOOST_CHECK_EQUAL(*parsed.version, 0U);
+    const PSTTInput& pinput = parsed.inputs[0];
+    BOOST_CHECK_EQUAL(pinput.sighash_type, 1);
+    BOOST_CHECK_EQUAL(*pinput.sequence, 0xFFFFFFFEu);
+    BOOST_CHECK_EQUAL(*pinput.required_height_locktime, 100U);
+    BOOST_CHECK_EQUAL(pinput.partial_sigs.size(), 1U);
+    BOOST_CHECK_EQUAL(pinput.hd_keypaths.size(), 1U);
+    BOOST_CHECK_EQUAL(pinput.ripemd160_preimages.size(), 1U);
+    BOOST_CHECK_EQUAL(pinput.sha256_preimages.size(), 1U);
+    BOOST_CHECK_EQUAL(pinput.hash160_preimages.size(), 1U);
+    BOOST_CHECK_EQUAL(pinput.hash256_preimages.size(), 1U);
+    BOOST_CHECK_EQUAL(pinput.unknown.size(), 1U);
+}
+
+// -----------------------------------------------------------------------
+// ComputeLocktime
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_computelocktime_fallback_only)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.fallback_locktime = 555;
+    uint32_t locktime;
+    BOOST_CHECK(ComputeLocktime(pstt, locktime));
+    BOOST_CHECK_EQUAL(locktime, 555U);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_computelocktime_fallback_default_zero)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    uint32_t locktime;
+    BOOST_CHECK(ComputeLocktime(pstt, locktime));
+    BOOST_CHECK_EQUAL(locktime, 0U);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_computelocktime_height_only)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.inputs[0].required_height_locktime = 700;
+    uint32_t locktime;
+    BOOST_CHECK(ComputeLocktime(pstt, locktime));
+    BOOST_CHECK_EQUAL(locktime, 700U);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_computelocktime_time_only)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.inputs[0].required_time_locktime = 600000000;
+    uint32_t locktime;
+    BOOST_CHECK(ComputeLocktime(pstt, locktime));
+    BOOST_CHECK_EQUAL(locktime, 600000000U);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_computelocktime_both_acceptable_prefers_height)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    // Second input with no constraint at all (imposes nothing).
+    CTransactionRef utxo2 = MakeSimpleUtxoTx(RandomP2PKHScript(), 50000);
+    pstt.inputs.push_back(MakeBasicInput(utxo2->GetHashMalFix(), 0, utxo2));
+    // First input accepts both kinds (both fields set) -> height preferred.
+    pstt.inputs[0].required_height_locktime = 800;
+    pstt.inputs[0].required_time_locktime = 700000000;
+    uint32_t locktime;
+    BOOST_CHECK(ComputeLocktime(pstt, locktime));
+    BOOST_CHECK_EQUAL(locktime, 800U);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_computelocktime_contradictory_kinds_fails)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    CTransactionRef utxo2 = MakeSimpleUtxoTx(RandomP2PKHScript(), 50000);
+    pstt.inputs.push_back(MakeBasicInput(utxo2->GetHashMalFix(), 0, utxo2));
+    // Input 0 only accepts height, input 1 only accepts time -> empty intersection.
+    pstt.inputs[0].required_height_locktime = 800;
+    pstt.inputs[1].required_time_locktime = 700000000;
+    uint32_t locktime;
+    BOOST_CHECK(!ComputeLocktime(pstt, locktime));
+}
+
+// -----------------------------------------------------------------------
+// IsSane() mixed-scheme rejection
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_issane_rejects_mixed_scheme)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    CKey key1, key2;
+    key1.MakeNewKey(true);
+    key2.MakeNewKey(true);
+
+    std::vector<unsigned char> der_sig(71, 0x11);
+    der_sig.push_back(1); // ECDSA-shaped: not COMPACT_SIGNATURE_SIZE (65)
+    std::vector<unsigned char> schnorr_sig(CPubKey::COMPACT_SIGNATURE_SIZE, 0x22); // 65 bytes incl. sighash byte
+
+    pstt.inputs[0].partial_sigs.emplace(key1.GetPubKey().GetID(), SigPair(key1.GetPubKey(), der_sig));
+    pstt.inputs[0].partial_sigs.emplace(key2.GetPubKey().GetID(), SigPair(key2.GetPubKey(), schnorr_sig));
+
+    BOOST_CHECK(!pstt.inputs[0].IsSane());
+}
+
+BOOST_AUTO_TEST_CASE(pstt_issane_accepts_uniform_scheme)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    CKey key1, key2;
+    key1.MakeNewKey(true);
+    key2.MakeNewKey(true);
+
+    std::vector<unsigned char> sig1(CPubKey::COMPACT_SIGNATURE_SIZE, 0x22);
+    std::vector<unsigned char> sig2(CPubKey::COMPACT_SIGNATURE_SIZE, 0x33);
+
+    pstt.inputs[0].partial_sigs.emplace(key1.GetPubKey().GetID(), SigPair(key1.GetPubKey(), sig1));
+    pstt.inputs[0].partial_sigs.emplace(key2.GetPubKey().GetID(), SigPair(key2.GetPubKey(), sig2));
+
+    BOOST_CHECK(pstt.inputs[0].IsSane());
+}
+
+// -----------------------------------------------------------------------
+// Container-format edge cases
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_wrong_magic)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    std::vector<unsigned char> data = SerializeObj(pstt);
+    data[0] = 'x';
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_input_rejects_missing_separator)
+{
+    PSTTInput input = MakeBasicInput(InsecureRand256(), 0, MakeSimpleUtxoTx(RandomP2PKHScript(), 1000));
+    std::vector<unsigned char> data = SerializeObj(input);
+    BOOST_REQUIRE(!data.empty());
+    BOOST_REQUIRE_EQUAL(data.back(), 0x00); // PSTT_SEPARATOR
+    data.pop_back(); // drop the separator -> stream ends with no terminating empty key
+    BOOST_CHECK_THROW(UnserializeObj<PSTTInput>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_duplicate_key)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << PSTT_MAGIC_BYTES;
+    SerializeToVector(ss, PSTT_GLOBAL_TX_FEATURES);
+    SerializeToVector(ss, (int32_t)1);
+    // Duplicate PSTT_GLOBAL_TX_FEATURES record.
+    SerializeToVector(ss, PSTT_GLOBAL_TX_FEATURES);
+    SerializeToVector(ss, (int32_t)1);
+    SerializeToVector(ss, PSTT_GLOBAL_INPUT_COUNT);
+    WriteCompactSize(ss, 0);
+    SerializeToVector(ss, PSTT_GLOBAL_OUTPUT_COUNT);
+    WriteCompactSize(ss, 0);
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_count_mismatch)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << PSTT_MAGIC_BYTES;
+    SerializeToVector(ss, PSTT_GLOBAL_TX_FEATURES);
+    SerializeToVector(ss, (int32_t)1);
+    SerializeToVector(ss, PSTT_GLOBAL_INPUT_COUNT);
+    WriteCompactSize(ss, 1); // claims 1 input
+    SerializeToVector(ss, PSTT_GLOBAL_OUTPUT_COUNT);
+    WriteCompactSize(ss, 0);
+    ss << PSTT_SEPARATOR;
+    // ... but no input map follows.
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_global_unsigned_tx_record)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << PSTT_MAGIC_BYTES;
+    SerializeToVector(ss, (uint8_t)0x00); // reserved global key
+    SerializeToVector(ss, (int32_t)1);
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_version_too_high)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << PSTT_MAGIC_BYTES;
+    SerializeToVector(ss, PSTT_GLOBAL_TX_FEATURES);
+    SerializeToVector(ss, (int32_t)1);
+    SerializeToVector(ss, PSTT_GLOBAL_VERSION);
+    SerializeToVector(ss, (uint32_t)1);
+    SerializeToVector(ss, PSTT_GLOBAL_INPUT_COUNT);
+    WriteCompactSize(ss, 0);
+    SerializeToVector(ss, PSTT_GLOBAL_OUTPUT_COUNT);
+    WriteCompactSize(ss, 0);
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_missing_required_globals)
+{
+    // Missing PSTT_GLOBAL_TX_FEATURES entirely.
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << PSTT_MAGIC_BYTES;
+    SerializeToVector(ss, PSTT_GLOBAL_INPUT_COUNT);
+    WriteCompactSize(ss, 0);
+    SerializeToVector(ss, PSTT_GLOBAL_OUTPUT_COUNT);
+    WriteCompactSize(ss, 0);
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rejects_reserved_input_keytype)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    SerializeToVector(ss, (uint8_t)0x01); // reserved: witness UTXO
+    ss << std::vector<unsigned char>{0x00};
+    ss << PSTT_SEPARATOR;
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    BOOST_CHECK_THROW(UnserializeObj<PSTTInput>(data), std::ios_base::failure);
+}
+
+// truncated-value: a field's declared <valuelen> exceeds the bytes actually
+// remaining.
+BOOST_AUTO_TEST_CASE(pstt_rejects_truncated_value)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    SerializeToVector(ss, PSTT_GLOBAL_FALLBACK_LOCKTIME);
+    WriteCompactSize(ss, 4); // claims a 4-byte value...
+    ss.write("\x01\x02", 2); // ...but only 2 bytes actually follow before EOF
+
+    std::vector<unsigned char> data(ss.begin(), ss.end());
+    CDataStream ss2(data, SER_NETWORK, PROTOCOL_VERSION);
+    boost::optional<uint32_t> dummy;
+    BOOST_CHECK_THROW({
+        uint32_t v;
+        UnserializeFromVector(ss2, v);
+    }, std::ios_base::failure);
+}
+
+// -----------------------------------------------------------------------
+// xpub round-trip
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_xpub_roundtrip_matching_prefix)
+{
+    // Unit tests default to TAPYRUS_OP_MODE::PROD (test_tapyrus.cpp's
+    // BasicTestingSetup), so PROD's prefix is the one that must succeed here.
+    CExtPubKey xpub;
+    CKey key;
+    key.MakeNewKey(true);
+    xpub.pubkey = key.GetPubKey();
+    xpub.nDepth = 1;
+    xpub.nChild = 0;
+    xpub.chaincode.SetNull();
+
+    std::vector<unsigned char> keydata = SerializeXpubKeyData(xpub);
+    BOOST_CHECK_EQUAL(keydata.size(), PSTT_XPUB_KEYDATA_SIZE);
+    CExtPubKey parsed = ParseXpubKeyData(keydata);
+    BOOST_CHECK(parsed == xpub);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_xpub_rejects_wrong_network_prefix)
+{
+    CExtPubKey xpub;
+    CKey key;
+    key.MakeNewKey(true);
+    xpub.pubkey = key.GetPubKey();
+    xpub.nDepth = 0;
+    xpub.nChild = 0;
+    xpub.chaincode.SetNull();
+
+    std::vector<unsigned char> keydata = SerializeXpubKeyData(xpub);
+    // Corrupt the 4-byte prefix to the *other* real Tapyrus network's prefix
+    // (DEV, since this test suite runs under PROD) -- must still throw, not
+    // silently accept, per the strict Params()-only prefix policy.
+    const std::vector<unsigned char>& dev_prefix = {0x04, 0x35, 0x87, 0xCF};
+    std::copy(dev_prefix.begin(), dev_prefix.end(), keydata.begin());
+    BOOST_CHECK_THROW(ParseXpubKeyData(keydata), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_xpub_rejects_unknown_prefix)
+{
+    CExtPubKey xpub;
+    CKey key;
+    key.MakeNewKey(true);
+    xpub.pubkey = key.GetPubKey();
+    xpub.nDepth = 0;
+    xpub.nChild = 0;
+    xpub.chaincode.SetNull();
+
+    std::vector<unsigned char> keydata = SerializeXpubKeyData(xpub);
+    keydata[0] = 0xDE;
+    keydata[1] = 0xAD;
+    keydata[2] = 0xBE;
+    keydata[3] = 0xEF;
+    BOOST_CHECK_THROW(ParseXpubKeyData(keydata), std::ios_base::failure);
+}
+
+// -----------------------------------------------------------------------
+// tx_features permissive round-trip
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_tx_features_roundtrip_any_value)
+{
+    for (int32_t v : {0, 1, 42, INT32_MIN}) {
+        PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+        pstt.tx_features = v;
+        std::vector<unsigned char> data = SerializeObj(pstt);
+        PartiallySignedTapyrusTransaction parsed = UnserializeObj<PartiallySignedTapyrusTransaction>(data);
+        BOOST_CHECK_EQUAL(*parsed.tx_features, v);
+    }
+}
+
+// -----------------------------------------------------------------------
+// End-to-end valid/invalid transaction tests (mempool/consensus level)
+//
+// These build a PartiallySignedTapyrusTransaction, sign it via
+// SignPSTTInput, and extract a final transaction the way a real Extractor
+// would, then feed the result through AcceptToMemoryPool -- same pattern
+// as txvalidation_tests.cpp's testTx(), but the transaction is produced by
+// the PSTT pipeline (Creator/Updater/Signer/Extractor) instead of being
+// hand-built with a manually constructed scriptSig.
+//
+// ExtractForTest is a test-local reconstruction, not a call into pstt.cpp:
+// pstt.h has no public Extractor API yet (that's Finalizer/Extractor role
+// work), so this mirrors pstt.cpp's private MaterializeTransaction
+// (use_final_scriptsig=true) closely enough for these tests without
+// depending on unexported internals.
+// -----------------------------------------------------------------------
+
+static CMutableTransaction ExtractForTest(const PartiallySignedTapyrusTransaction& pstt)
+{
+    uint32_t locktime;
+    BOOST_REQUIRE(ComputeLocktime(pstt, locktime));
+    CMutableTransaction mtx;
+    mtx.nFeatures = pstt.tx_features.value_or(CTransaction::CURRENT_FEATURES);
+    mtx.nLockTime = locktime;
+    for (const PSTTInput& input : pstt.inputs) {
+        BOOST_REQUIRE(!input.final_script_sig.empty());
+        CTxIn txin;
+        txin.prevout = COutPoint(input.previous_txid, input.prev_out_index);
+        txin.nSequence = input.sequence.value_or(0xFFFFFFFFu);
+        txin.scriptSig = input.final_script_sig;
+        mtx.vin.push_back(std::move(txin));
+    }
+    for (const PSTTOutput& output : pstt.outputs) {
+        mtx.vout.emplace_back(output.amount.value_or(0), output.script);
+    }
+    return mtx;
+}
+
+// Signs input `index` in place: runs SignPSTTInput, then applies
+// FromSignatureData to store the result, mirroring what a real Signer RPC
+// does once SignPSTTInput reports OK.
+static void SignInputForTest(PartiallySignedTapyrusTransaction& pstt, unsigned int index,
+                              const SigningProvider& provider, SignatureScheme scheme = SignatureScheme::ECDSA,
+                              int sighash = SIGHASH_ALL)
+{
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(provider, pstt, index, sigdata, sighash, scheme);
+    BOOST_REQUIRE(result == PSTTSignResult::OK);
+    pstt.inputs[index].FromSignatureData(sigdata);
+    BOOST_REQUIRE(sigdata.complete);
+}
+
+static void CheckMempoolResult(TestChainSetup& setup, const CTransactionRef& tx, bool expect_success,
+                                const std::string& expect_reject_reason = "")
+{
+    CTxMempoolAcceptanceOptions opt;
+    opt.flags = MempoolAcceptanceFlags::BYPASSS_LIMITS;
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_EQUAL(expect_success, AcceptToMemoryPool(tx, opt));
+    }
+    if (expect_success) {
+        BOOST_CHECK(opt.state.IsValid());
+        std::vector<CMutableTransaction> txs{CMutableTransaction(*tx)};
+        setup.CreateAndProcessBlock(txs, CScript() << ToByteVector(setup.coinbaseKey.GetPubKey()) << OP_CHECKSIG);
+    } else {
+        BOOST_CHECK(opt.state.IsInvalid());
+        if (!expect_reject_reason.empty()) {
+            BOOST_CHECK_EQUAL(opt.state.GetRejectReason(), expect_reject_reason);
+        }
+    }
+}
+
+static CScript P2PKHScriptFor(const CKey& key)
+{
+    CScript script;
+    script << OP_DUP << OP_HASH160 << ToByteVector(key.GetPubKey().GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    return script;
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_p2pk_coinbase_spend, TestChainSetup)
+{
+    // m_coinbase_txns[0]'s output is P2PK to coinbaseKey (TestChainSetup's own
+    // construction) -- the simplest possible PSTT-signed spend.
+    const CTransactionRef& prevTx = m_coinbase_txns[0];
+    CKey destKey;
+    destKey.MakeNewKey(true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = prevTx->GetHashMalFix();
+    input.prev_out_index = 0;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    input.utxo = prevTx;
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = prevTx->vout[0].nValue - CENT;
+    output.script = P2PKHScriptFor(destKey);
+    pstt.outputs.push_back(output);
+
+    FlatSigningProvider provider;
+    provider.keys[coinbaseKey.GetPubKey().GetID()] = coinbaseKey;
+
+    SignInputForTest(pstt, 0, provider);
+
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(pstt)), true);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_schnorr_spend, TestChainSetup)
+{
+    // Same shape as the ECDSA case above, but signed with the Schnorr scheme --
+    // exercises SignPSTTInput's scheme threading end to end.
+    const CTransactionRef& prevTx = m_coinbase_txns[0];
+    CKey destKey;
+    destKey.MakeNewKey(true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = prevTx->GetHashMalFix();
+    input.prev_out_index = 0;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    input.utxo = prevTx;
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = prevTx->vout[0].nValue - CENT;
+    output.script = P2PKHScriptFor(destKey);
+    pstt.outputs.push_back(output);
+
+    FlatSigningProvider provider;
+    provider.keys[coinbaseKey.GetPubKey().GetID()] = coinbaseKey;
+
+    SignInputForTest(pstt, 0, provider, SignatureScheme::SCHNORR);
+
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(pstt)), true);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_wrong_key, TestChainSetup)
+{
+    // Signed with a key that doesn't match m_coinbase_txns[0]'s P2PK script --
+    // ProduceSignature can't complete the script, so SignPSTTInput never
+    // reaches OK; there is no extractable transaction to feed to the mempool.
+    const CTransactionRef& prevTx = m_coinbase_txns[0];
+    CKey wrongKey;
+    wrongKey.MakeNewKey(true);
+    CKey destKey;
+    destKey.MakeNewKey(true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = prevTx->GetHashMalFix();
+    input.prev_out_index = 0;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    input.utxo = prevTx;
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = prevTx->vout[0].nValue - CENT;
+    output.script = P2PKHScriptFor(destKey);
+    pstt.outputs.push_back(output);
+
+    FlatSigningProvider provider;
+    provider.keys[wrongKey.GetPubKey().GetID()] = wrongKey;
+
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(provider, pstt, 0, sigdata, SIGHASH_ALL, SignatureScheme::ECDSA);
+    BOOST_CHECK(result == PSTTSignResult::OK); // SignPSTTInput itself succeeds...
+    BOOST_CHECK(!sigdata.complete); // ...but the script it produced doesn't satisfy scriptPubKey
+}
+
+// Builds a two-transaction chain (P2PK coinbase spend -> P2PKH) via the PSTT
+// pipeline, mining each so the second's output is a confirmed, spendable
+// P2PKH coin. Returns {tx, spendKey} for the confirmed P2PKH output.
+static std::pair<CTransactionRef, CKey> MakeConfirmedP2PKHCoin(TestChainSetup& setup, const CTransactionRef& coinbaseTx)
+{
+    CKey destKey;
+    destKey.MakeNewKey(true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = coinbaseTx->GetHashMalFix();
+    input.prev_out_index = 0;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    input.utxo = coinbaseTx;
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = coinbaseTx->vout[0].nValue - CENT;
+    output.script = P2PKHScriptFor(destKey);
+    pstt.outputs.push_back(output);
+
+    FlatSigningProvider provider;
+    provider.keys[setup.coinbaseKey.GetPubKey().GetID()] = setup.coinbaseKey;
+    SignInputForTest(pstt, 0, provider);
+
+    CTransactionRef tx = MakeTransactionRef(ExtractForTest(pstt));
+    CheckMempoolResult(setup, tx, true);
+    return {tx, destKey};
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_colored_issue_and_transfer, TestChainSetup)
+{
+    // Confirm a spendable P2PKH TPC coin, then issue a colored coin from it.
+    CTransactionRef p2pkhTx;
+    CKey issuerKey;
+    std::tie(p2pkhTx, issuerKey) = MakeConfirmedP2PKHCoin(*this, m_coinbase_txns[1]);
+
+    ColorIdentifier colorId(p2pkhTx->vout[0].scriptPubKey);
+    CKey holderKey;
+    holderKey.MakeNewKey(true);
+    CScript coloredScript = CScript() << colorId.toVector() << OP_COLOR
+                                       << OP_DUP << OP_HASH160 << ToByteVector(holderKey.GetPubKey().GetID())
+                                       << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    PartiallySignedTapyrusTransaction issuePstt;
+    issuePstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput issueInput;
+    issueInput.previous_txid = p2pkhTx->GetHashMalFix();
+    issueInput.prev_out_index = 0;
+    issueInput.previous_txid_set = true;
+    issueInput.prev_out_index_set = true;
+    issueInput.utxo = p2pkhTx;
+    issuePstt.inputs.push_back(issueInput);
+
+    PSTTOutput issueOutput;
+    issueOutput.amount = 100 * CENT;
+    issueOutput.script = coloredScript;
+    issuePstt.outputs.push_back(issueOutput);
+
+    FlatSigningProvider issueProvider;
+    issueProvider.keys[issuerKey.GetPubKey().GetID()] = issuerKey;
+    issueProvider.pubkeys[issuerKey.GetPubKey().GetID()] = issuerKey.GetPubKey();
+    SignInputForTest(issuePstt, 0, issueProvider);
+
+    CTransactionRef issueTx = MakeTransactionRef(ExtractForTest(issuePstt));
+    CheckMempoolResult(*this, issueTx, true);
+
+    // Transfer the colored coin, paying the TPC fee from a second coinbase spend
+    // confirmed the same way -- exercises a two-input PSTT with two different
+    // signing keys, matching the Fee-Provider-style multi-party shape.
+    CTransactionRef feeTx;
+    CKey feeKey;
+    std::tie(feeTx, feeKey) = MakeConfirmedP2PKHCoin(*this, m_coinbase_txns[2]);
+
+    CKey recipientKey;
+    recipientKey.MakeNewKey(true);
+    CScript recipientColoredScript = CScript() << colorId.toVector() << OP_COLOR
+                                                 << OP_DUP << OP_HASH160 << ToByteVector(recipientKey.GetPubKey().GetID())
+                                                 << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    PartiallySignedTapyrusTransaction transferPstt;
+    transferPstt.tx_features = CTransaction::CURRENT_FEATURES;
+
+    PSTTInput coloredInput;
+    coloredInput.previous_txid = issueTx->GetHashMalFix();
+    coloredInput.prev_out_index = 0;
+    coloredInput.previous_txid_set = true;
+    coloredInput.prev_out_index_set = true;
+    coloredInput.utxo = issueTx;
+    transferPstt.inputs.push_back(coloredInput);
+
+    PSTTInput feeInput;
+    feeInput.previous_txid = feeTx->GetHashMalFix();
+    feeInput.prev_out_index = 0;
+    feeInput.previous_txid_set = true;
+    feeInput.prev_out_index_set = true;
+    feeInput.utxo = feeTx;
+    transferPstt.inputs.push_back(feeInput);
+
+    PSTTOutput transferOutput;
+    transferOutput.amount = 100 * CENT; // full colored balance preserved
+    transferOutput.script = recipientColoredScript;
+    transferPstt.outputs.push_back(transferOutput);
+
+    FlatSigningProvider coloredProvider;
+    coloredProvider.keys[holderKey.GetPubKey().GetID()] = holderKey;
+    coloredProvider.pubkeys[holderKey.GetPubKey().GetID()] = holderKey.GetPubKey();
+    SignInputForTest(transferPstt, 0, coloredProvider);
+
+    FlatSigningProvider feeProvider;
+    feeProvider.keys[feeKey.GetPubKey().GetID()] = feeKey;
+    feeProvider.pubkeys[feeKey.GetPubKey().GetID()] = feeKey.GetPubKey();
+    SignInputForTest(transferPstt, 1, feeProvider);
+
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(transferPstt)), true);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_token_without_fee, TestChainSetup)
+{
+    // Same colored issue as above, but the transfer has no separate TPC fee
+    // input -- consensus rejects a colored transfer that pays no TPC fee.
+    CTransactionRef p2pkhTx;
+    CKey issuerKey;
+    std::tie(p2pkhTx, issuerKey) = MakeConfirmedP2PKHCoin(*this, m_coinbase_txns[1]);
+
+    ColorIdentifier colorId(p2pkhTx->vout[0].scriptPubKey);
+    CKey holderKey;
+    holderKey.MakeNewKey(true);
+    CScript coloredScript = CScript() << colorId.toVector() << OP_COLOR
+                                       << OP_DUP << OP_HASH160 << ToByteVector(holderKey.GetPubKey().GetID())
+                                       << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    PartiallySignedTapyrusTransaction issuePstt;
+    issuePstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput issueInput;
+    issueInput.previous_txid = p2pkhTx->GetHashMalFix();
+    issueInput.prev_out_index = 0;
+    issueInput.previous_txid_set = true;
+    issueInput.prev_out_index_set = true;
+    issueInput.utxo = p2pkhTx;
+    issuePstt.inputs.push_back(issueInput);
+
+    PSTTOutput issueOutput;
+    issueOutput.amount = 100 * CENT;
+    issueOutput.script = coloredScript;
+    issuePstt.outputs.push_back(issueOutput);
+
+    FlatSigningProvider issueProvider;
+    issueProvider.keys[issuerKey.GetPubKey().GetID()] = issuerKey;
+    issueProvider.pubkeys[issuerKey.GetPubKey().GetID()] = issuerKey.GetPubKey();
+    SignInputForTest(issuePstt, 0, issueProvider);
+
+    CTransactionRef issueTx = MakeTransactionRef(ExtractForTest(issuePstt));
+    CheckMempoolResult(*this, issueTx, true);
+
+    CKey recipientKey;
+    recipientKey.MakeNewKey(true);
+    CScript recipientColoredScript = CScript() << colorId.toVector() << OP_COLOR
+                                                 << OP_DUP << OP_HASH160 << ToByteVector(recipientKey.GetPubKey().GetID())
+                                                 << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    PartiallySignedTapyrusTransaction transferPstt;
+    transferPstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput coloredInput;
+    coloredInput.previous_txid = issueTx->GetHashMalFix();
+    coloredInput.prev_out_index = 0;
+    coloredInput.previous_txid_set = true;
+    coloredInput.prev_out_index_set = true;
+    coloredInput.utxo = issueTx;
+    transferPstt.inputs.push_back(coloredInput);
+
+    PSTTOutput transferOutput;
+    transferOutput.amount = 100 * CENT;
+    transferOutput.script = recipientColoredScript;
+    transferPstt.outputs.push_back(transferOutput);
+
+    FlatSigningProvider coloredProvider;
+    coloredProvider.keys[holderKey.GetPubKey().GetID()] = holderKey;
+    coloredProvider.pubkeys[holderKey.GetPubKey().GetID()] = holderKey.GetPubKey();
+    SignInputForTest(transferPstt, 0, coloredProvider);
+
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(transferPstt)), false, "bad-txns-token-without-fee");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/data/tip174_SOURCE.md
+++ b/test/functional/data/tip174_SOURCE.md
@@ -1,0 +1,17 @@
+# Source of `tip174_valid.json` / `tip174_invalid.json`
+
+Fetched from:
+
+* Repository: `chaintope/tips`
+* Branch: `docs/174_add_pstt_tip`
+* Commit: `38fb1a4440f2f077c8c1a18076c8cdc3b53ce4da`
+* Path: `tip-0174/valid.json`, `tip-0174/invalid.json`
+
+Pinned deliberately (per the PSTT implementation plan, §9a/Phase 0): a bare branch name
+would let a later fixture regeneration silently drift the test vectors this suite asserts
+against. Bumping to a newer commit is a deliberate, reviewable action — re-fetch the two
+files from the new commit, update the commit hash above, and re-run the full `rpc_pstt.py`
+suite (including the `--scheme SCHNORR` variant) to confirm nothing regressed.
+
+See `tip-0174/README.md` in that repository for the fixture schema and generation
+conventions (dev-network parameters, deterministic key derivation, RFC 6979 nonces).

--- a/test/functional/data/tip174_invalid.json
+++ b/test/functional/data/tip174_invalid.json
@@ -1,0 +1,242 @@
+[
+  {
+    "id": "wrong-magic",
+    "description": "Magic bytes are the Bitcoin PSBT magic (psbt 0xFF) instead of pstt 0xFF.",
+    "pstt": "cHNidP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "magic must be 0x70 0x73 0x74 0x74 0xFF"
+    }
+  },
+  {
+    "id": "missing-map-separator",
+    "description": "The final output map is not terminated by a 0x00 separator.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "every map must be terminated by 0x00"
+    }
+  },
+  {
+    "id": "duplicate-key",
+    "description": "The global map contains two records with the same complete key (PSTT_GLOBAL_TX_FEATURES).",
+    "pstt": "cHN0dP8BAgQBAAAAAQIEAQAAAAEEAQEBBQEBAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "a map must not contain two records with the same complete key"
+    }
+  },
+  {
+    "id": "missing-global-tx-features",
+    "description": "The global map lacks the required PSTT_GLOBAL_TX_FEATURES record.",
+    "pstt": "cHN0dP8BBAEBAQUBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_TX_FEATURES is required"
+    }
+  },
+  {
+    "id": "missing-input-previous-txid",
+    "description": "An input map lacks the required PSTT_IN_PREVIOUS_TXID record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_PREVIOUS_TXID is required in every input map"
+    }
+  },
+  {
+    "id": "missing-output-amount",
+    "description": "An output map lacks the required PSTT_OUT_AMOUNT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_OUT_AMOUNT is required in every output map"
+    }
+  },
+  {
+    "id": "count-mismatch",
+    "description": "PSTT_GLOBAL_INPUT_COUNT declares 2 inputs but only one input map is present.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "the numbers of input/output maps must match the declared counts"
+    }
+  },
+  {
+    "id": "utxo-txid-mismatch",
+    "description": "PSTT_IN_UTXO contains a transaction whose hashMalFix does not equal PSTT_IN_PREVIOUS_TXID.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIBDwQAAAAAAQBVAQAAAAEREREREREREREREREREREREREREREREREREREREREREQAAAAAA/////wFQwwAAAAAAABl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "the Signer must not sign when the UTXO txid does not match PSTT_IN_PREVIOUS_TXID"
+    }
+  },
+  {
+    "id": "global-unsigned-tx-record",
+    "description": "The global map contains a record with the reserved type value 0x00 (the BIP-174 global unsigned transaction).",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAFUBAAAAARERERERERERERERERERERERERERERERERERERERERERAAAAAAD/////AVDDAAAAAAAAGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwAAAAAAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "global type value 0x00 is reserved and must not be used"
+    }
+  },
+  {
+    "id": "version-too-high",
+    "description": "PSTT_GLOBAL_VERSION is 1, which is higher than the only defined version (0).",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEB+wQBAAAAAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "software must reject a PSTT with a version number higher than 0"
+    }
+  },
+  {
+    "id": "contradictory-locktimes",
+    "description": "One input requires only a time-based locktime and another requires only a height-based locktime; no single locktime kind satisfies both.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAREEAPFTZQABDiADAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEPBAEAAAABEgT0AQAAAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "no locktime kind is acceptable to all inputs; the PSTT cannot produce a valid transaction"
+    }
+  },
+  {
+    "id": "single-without-corresponding-output",
+    "description": "Input index 1 carries a SIGHASH_SINGLE partial signature but the transaction has only one output.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEOIAMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAQ8EAQAAACICAxuExVZ7EmRAmV0+1aq6BWXXHhg0YEgZ/5wX9enV3QePRzBEAiAiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIgIgMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMDAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "an input whose index has no corresponding output must not be signed with SIGHASH_SINGLE"
+    }
+  },
+  {
+    "id": "missing-input-output-index",
+    "description": "An input map has PSTT_IN_PREVIOUS_TXID but lacks the required PSTT_IN_OUTPUT_INDEX record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_OUTPUT_INDEX is required in every input map"
+    }
+  },
+  {
+    "id": "missing-output-script",
+    "description": "An output map has PSTT_OUT_AMOUNT but lacks the required PSTT_OUT_SCRIPT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_OUT_SCRIPT is required in every output map"
+    }
+  },
+  {
+    "id": "time-locktime-too-low",
+    "description": "PSTT_IN_REQUIRED_TIME_LOCKTIME is 499999999, one less than the required minimum of 500000000.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAREE/2TNHQABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_REQUIRED_TIME_LOCKTIME must be greater than or equal to 500000000"
+    }
+  },
+  {
+    "id": "height-locktime-too-high",
+    "description": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME is 500000000, which is the boundary reserved for time-based locktimes.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAARIEAGXNHQABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME must be less than 500000000"
+    }
+  },
+  {
+    "id": "height-locktime-zero",
+    "description": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME is 0, which is excluded by the \"greater than 0\" requirement.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAARIEAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_REQUIRED_HEIGHT_LOCKTIME must be greater than 0"
+    }
+  },
+  {
+    "id": "missing-input-count",
+    "description": "The global map lacks the required PSTT_GLOBAL_INPUT_COUNT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQUBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_INPUT_COUNT is required"
+    }
+  },
+  {
+    "id": "missing-output-count",
+    "description": "The global map lacks the required PSTT_GLOBAL_OUTPUT_COUNT record.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_GLOBAL_OUTPUT_COUNT is required"
+    }
+  },
+  {
+    "id": "nonempty-keydata-on-none-field",
+    "description": "PSTT_GLOBAL_TX_FEATURES carries one byte of keydata, but its definition lists no key data.",
+    "pstt": "cHN0dP8CAqoEAQAAAAEEAQEBBQEBAAEOIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ8EAAAAAAABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "<keydata> must be empty when a field's definition lists no key data"
+    }
+  },
+  {
+    "id": "malformed-pubkey-length",
+    "description": "The keydata of a PSTT_IN_PARTIAL_SIG record is 32 bytes, neither the 33-byte compressed nor the 65-byte uncompressed length a public key must have.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAIQIDG4TFVnsSZECZXT7VqroFZdceGDRgSBn/nBf16dXdB0cwRAIgIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiICIDMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzAQABAwhAnAAAAAAAAAEEGXapFAAAAAAAAAAAAAAAAAAAAAAAAAAAiKwA",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "PSTT_IN_PARTIAL_SIG keydata must be a 33- or 65-byte public key"
+    }
+  },
+  {
+    "id": "redeem-script-hash-mismatch",
+    "description": "PSTT_IN_REDEEM_SCRIPT is OP_2, but the P2SH output's scriptPubKey commits to HASH160(OP_1); the redeem script does not hash to the committed value.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gc79xovhD/E/ApAVmkfQWytam66jlRLjz4bjJvoNXmR8BDwQAAAAAAQBTAQAAAAFERERERERERERERERERERERERERERERERERERERERERAAAAAAA/////wFQwwAAAAAAABepFNoXRem1Sb0L+hpWmXHHfrowzVpLhwAAAAABBAFSAAEDCECcAAAAAAAAAQQZdqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrAA=",
+    "expected": {
+      "valid": false,
+      "stage": "rule",
+      "reason": "the Signer must not sign when the redeem script does not hash to the value committed in the output's scriptPubKey"
+    }
+  },
+  {
+    "id": "truncated-value",
+    "description": "The final output map's PSTT_OUT_SCRIPT record declares a valuelen one byte longer than the data actually present in the buffer.",
+    "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBDwQAAAAAAAEDCECcAAAAAAAAAQQadqkUAAAAAAAAAAAAAAAAAAAAAAAAAACIrA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "<valuelen> must not exceed the number of bytes remaining in the map"
+    }
+  },
+  {
+    "id": "non-minimal-keytype",
+    "description": "PSTT_GLOBAL_TX_FEATURES' <keytype> is encoded as 0xfd 0x02 0x00 (3 bytes) instead of the minimal single byte 0x02.",
+    "pstt": "cHN0dP8D/QIABAEAAAABBAEBAQUBAQABDiABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEPBAAAAAAAAQMIQJwAAAAAAAABBBl2qRQAAAAAAAAAAAAAAAAAAAAAAAAAAIisAA==",
+    "expected": {
+      "valid": false,
+      "stage": "parse",
+      "reason": "<keytype> must be minimally encoded"
+    }
+  }
+]

--- a/test/functional/data/tip174_valid.json
+++ b/test/functional/data/tip174_valid.json
@@ -1,0 +1,462 @@
+[
+  {
+    "id": "p2pkh-ecdsa",
+    "description": "Single P2PKH input signed with ECDSA (SIGHASH_ALL). Pays 60000 tapy to key 1, 39000 tapy change to key 2, fee 1000 tapy. Keys derive from SHA256(\"TIP-174 test vectors\") at m/44'/2377'/0'/0/i on the dev network. From the updated stage onward, the global map also carries a PSTT_GLOBAL_XPUB record for the account-level key (m/44'/2377'/0'), matching the derivation paths in the BIP32_DERIVATION records.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "59c74c5dd65e2d98d723df091aca2cc253b3c90f8286d83977ce25a457b505a3",
+        "signature": "30450221009c120b0cae2c886085c8b13bcde12137fd799db34a4dfc566389b9a264cd8e4a02201236e69f58915e61b842b665e24215a81743ed1a6530065f03f1ed8c67eb517e01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQJPAQQ1h88D30yFpYAAAADhUDs3mDmTEa5u9RuYwYJm2crUdVwT8grGLRVRPUhrIQJm6CZUg1hZuZFr6NZ7yiMNp5XLXUnAPvZC39ghvDurQhDwVlWsLAAAgEkJAIAAAACAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQJPAQQ1h88D30yFpYAAAADhUDs3mDmTEa5u9RuYwYJm2crUdVwT8grGLRVRPUhrIQJm6CZUg1hZuZFr6NZ7yiMNp5XLXUnAPvZC39ghvDurQhDwVlWsLAAAgEkJAIAAAACAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQCcEgsMriyIYIXIsTvN4SE3/Xmds0pN/FZjibmiZM2OSgIgEjbmn1iRXmG4QrZl4kIVqBdD7RplMAZfA/HtjGfrUX4BAAEDCGDqAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwhYmAAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQJPAQQ1h88D30yFpYAAAADhUDs3mDmTEa5u9RuYwYJm2crUdVwT8grGLRVRPUhrIQJm6CZUg1hZuZFr6NZ7yiMNp5XLXUnAPvZC39ghvDurQhDwVlWsLAAAgEkJAIAAAACAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABB2tIMEUCIQCcEgsMriyIYIXIsTvN4SE3/Xmds0pN/FZjibmiZM2OSgIgEjbmn1iRXmG4QrZl4kIVqBdD7RplMAZfA/HtjGfrUX4BIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwhg6gAAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIWJgAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "95a96f3323e3e84152d2c67c2303a6e4fa4f6ad7a8506d118f5ae0cddc12f6d7"
+      }
+    ],
+    "extracted_tx": "01000000017824d5e5d7143a2a4c7d41409421a7e2163c3164703ea8926df7d31a7becd1d4000000006b4830450221009c120b0cae2c886085c8b13bcde12137fd799db34a4dfc566389b9a264cd8e4a02201236e69f58915e61b842b665e24215a81743ed1a6530065f03f1ed8c67eb517e012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff0260ea0000000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac58980000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "6c733ca3e9d0dd72947382cfe78554ae8768963ff71fa78631a8fe65d2085f35"
+  },
+  {
+    "id": "p2pkh-schnorr",
+    "description": "Single P2PKH input signed with the Tapyrus Schnorr scheme (65-byte signature, SIGHASH_ALL). Pays 55000 tapy to key 1, 44500 tapy change to key 2, fee 500 tapy.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "b8bd1e97f414f878937e7622635902e018b4d4dd0f14ec12ec13e15d2b1a24af",
+        "signature": "1e481ecbd932e089da0578454834d4b56ae80907e20d3c7a5dc1c246e1fc9821e24f5e3c75e8d2d33cf5d37fcbe4efb48553f224c0a0b06934e3635b82e2c5b301"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAAEDCNjWAAAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwjUrQAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAQBVAQAAAAGqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAAAQMI2NYAAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCNStAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAQBVAQAAAAGqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUEeSB7L2TLgidoFeEVINNS1augJB+INPHpdwcJG4fyYIeJPXjx16NLTPPXTf8vk77SFU/IkwKCwaTTjY1uC4sWzAQABAwjY1gAAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMI1K0AAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIAAQ4geCTV5dcUOipMfUFAlCGn4hY8MWRwPqiSbffTGnvs0dQBDwQAAAAAAQBVAQAAAAGqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHZEEeSB7L2TLgidoFeEVINNS1augJB+INPHpdwcJG4fyYIeJPXjx16NLTPPXTf8vk77SFU/IkwKCwaTTjY1uC4sWzASEC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkAAQMI2NYAAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCNStAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "ec6a5dd1bc7b9257f8cd8af2c2aa66da9e3217b7cda14ab202957a85ecbbcb0f"
+      }
+    ],
+    "extracted_tx": "01000000017824d5e5d7143a2a4c7d41409421a7e2163c3164703ea8926df7d31a7becd1d40000000064411e481ecbd932e089da0578454834d4b56ae80907e20d3c7a5dc1c246e1fc9821e24f5e3c75e8d2d33cf5d37fcbe4efb48553f224c0a0b06934e3635b82e2c5b3012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff02d8d60000000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88acd4ad0000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "d2f8184595f9ebf5a7b9d0be77dc08e03839fe3d7c8dce98bd40ca4d80be7324"
+  },
+  {
+    "id": "construction-stages",
+    "description": "Cooperative construction walk-through. The Creator starts with an empty PSTT (both modifiable flags set), a Constructor adds one P2PKH input and two outputs, construction is declared finished by clearing the flags, then the input is signed with ECDSA (SIGHASH_ALL), finalized, and extracted. The identification txid changes while inputs/outputs are added and stabilizes once construction is finished.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "d2a883e0a6c1beca67c266fde439b65e45a82fe84559ff2660b17914510e6aa9",
+        "signature": "3045022100da0969719206a9b9dd27b112d8dc912ea0f3fbe1b5213ac6b8b1ed9a446eaeae02205bad0ea6d7064c9f2ad5e7249ff5cf4dbf181b87f45122f7d5db2b2c5aa9c25b01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created-empty",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAAEFAQABBgEDAA==",
+        "identification_txid": "d21633ba23f70118185227be58a63527675641ad37967e2aa461559f577aec43",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "input-added",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQABBgEDAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAA=",
+        "identification_txid": "3d13ccdef1396ab5c8a7a091e658ad8fd64f406631a338a6bc2733cbd7e715c5",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "outputs-added",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEDAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAABAwhwEQEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMISHEAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisAA==",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "construction-finished",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAABAwhwEQEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMISHEAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisAA==",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhANoJaXGSBqm53SexEtjckS6g8/vhtSE6xrix7ZpEbq6uAiBbrQ6m1wZMnyrV5ySf9c9Nvxgbh/RRIvfV2yssWqnCWwEAAQMIcBEBAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCEhxAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQIBBgEAAAEOIHgk1eXXFDoqTH1BQJQhp+IWPDFkcD6okm330xp77NHUAQ8EAAAAAAEAVQEAAAABqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABB2tIMEUCIQDaCWlxkgapud0nsRLY3JEuoPP74bUhOsa4se2aRG6urgIgW60OptcGTJ8q1eckn/XPTb8YG4f0USL31dsrLFqpwlsBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwhwEQEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMISHEAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "4b4f954d9c0abbc733c9e16a9d7d28738261053ece236fa0702bfca9ff0b6ef0",
+        "tx_modifiable": 0
+      }
+    ],
+    "extracted_tx": "01000000017824d5e5d7143a2a4c7d41409421a7e2163c3164703ea8926df7d31a7becd1d4000000006b483045022100da0969719206a9b9dd27b112d8dc912ea0f3fbe1b5213ac6b8b1ed9a446eaeae02205bad0ea6d7064c9f2ad5e7249ff5cf4dbf181b87f45122f7d5db2b2c5aa9c25b012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff0270110100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac48710000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "001d1ef9c57226b157ff9e979e051e768d80988041df227696f779bc9f2a1666"
+  },
+  {
+    "id": "cp2pkh-transfer",
+    "description": "Colored Coin transfer. Input 0 spends a CP2PKH output holding 100 tokens of color 0xC1||SHA256(P2PKH script of key 0); input 1 spends a 20000 tapy P2PKH output paying the fee. Outputs: 100 tokens to CP2PKH(key 1), 19000 tapy change to P2PKH(key 2); fee 1000 tapy. The scriptCode of the CP2PKH input is the full scriptPubKey including the color identifier prefix; both inputs are signed with ECDSA (SIGHASH_ALL).",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "4b6d98d5f0914c47beb514f259d98bbf3fb6af7a8cedf23bd1a40b1da5ec39af",
+        "signature": "304402201f727d99e45a9c49f124e3775d6fc251f2aeba120fe16b0f3ea1a5f30ce8a36c0220444c093f6012eea4585a957ecf64b262f2933700c01ede76271f6a817e5db92b01"
+      },
+      {
+        "input": 1,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "b2c9dff783538fbd85dfe1c99362c482afac59a36fd257d5b8b6112d3c14be84",
+        "signature": "3044022032264842e7998757279863c168cf6ceb27308981d54f5317f40798b6b02f0ec9022046c4165f9fa0fe7965b820ee87576d536702676af8972d43bda62d74f4a8e21901"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAAEOIKqhrhJVXDN94q+sM+xiV/8lleA8pQBF0jekPw7eiYCBAQ8EAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAQB4AQAAAAG7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uwAAAAAA/////wFkAAAAAAAAADwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAAAABDiCqoa4SVVwzfeKvrDPsYlf/JZXgPKUARdI3pD8O3omAgQEPBAAAAAABAFUBAAAAAczMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAD/////ASBOAAAAAAAAGXapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAQB4AQAAAAG7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uwAAAAAA/////wFkAAAAAAAAADwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAACICAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJRzBEAiAfcn2Z5FqcSfEk43ddb8JR8q66Eg/haw8+oaXzDOijbAIgREwJP2AS7qRYWpV+z2SyYvKTNwDAHt52Jx9qgX5duSsBAAEOIKqhrhJVXDN94q+sM+xiV/8lleA8pQBF0jekPw7eiYCBAQ8EAAAAAAEAVQEAAAABzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMwAAAAAAP////8BIE4AAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlHMEQCIDImSELnmYdXJ5hjwWjPbOsnMImB1U9TF/QHmLawLw7JAiBGxBZfn6D+eWW4IO6HV21TZwJnaviXLUO9pi109KjiGQEAAQMIZAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIOEoAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4g1gO1BZsJ5wGiE7ZKSxAWCqz1Kv/RPC//h/SmibXu/qoBDwQAAAAAAQB4AQAAAAG7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uwAAAAAA/////wFkAAAAAAAAADwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQdqRzBEAiAfcn2Z5FqcSfEk43ddb8JR8q66Eg/haw8+oaXzDOijbAIgREwJP2AS7qRYWpV+z2SyYvKTNwDAHt52Jx9qgX5duSsBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABDiCqoa4SVVwzfeKvrDPsYlf/JZXgPKUARdI3pD8O3omAgQEPBAAAAAABAFUBAAAAAczMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMAAAAAAD/////ASBOAAAAAAAAGXapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQdqRzBEAiAyJkhC55mHVyeYY8Foz2zrJzCJgdVPUxf0B5i2sC8OyQIgRsQWX5+g/nlluCDuh1dtU2cCZ2r4ly1DvaYtdPSo4hkBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "e34dae9dac1b6f3c998f5091681c43ab30d9d05665722bf7b707b9259bbf72db"
+      }
+    ],
+    "extracted_tx": "0100000002d603b5059b09e701a213b64a4b10160aacf52affd13c2fff87f4a689b5eefeaa000000006a47304402201f727d99e45a9c49f124e3775d6fc251f2aeba120fe16b0f3ea1a5f30ce8a36c0220444c093f6012eea4585a957ecf64b262f2933700c01ede76271f6a817e5db92b012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffffaaa1ae12555c337de2afac33ec6257ff2595e03ca50045d237a43f0ede898081000000006a473044022032264842e7998757279863c168cf6ceb27308981d54f5317f40798b6b02f0ec9022046c4165f9fa0fe7965b820ee87576d536702676af8972d43bda62d74f4a8e219012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff0264000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac384a0000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "70b38e6892f519e4bb477f0f6d918c3e6bdf60f5852a292b549b0eb762e5239d"
+  },
+  {
+    "id": "cp2sh-multisig-combine",
+    "description": "A 2-of-2 CP2SH multisig token input (200 tokens, redeem script OP_2 <key3> <key4> OP_2 OP_CHECKMULTISIG) plus a P2PKH fee input. Signer A (holding key 3 and the fee key 0) and signer B (holding key 4) sign independently from the updated stage; a Combiner merges the two PSTTs into one. The scriptCode of the CP2SH input is the redeem script without the color identifier prefix. Signer B also attaches a record of type 0x20, which this TIP does not define; it must be preserved unchanged through the combined and finalized stages.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa",
+        "sighash_type": 1,
+        "script_code": "5221028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa21033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d0413552ae",
+        "sighash": "f19966624894c461c87c03d5bbf25ca73708fa15e90e36cd1f2a5f9b044e1030",
+        "signature": "304402205155c9fa07256ff832badaf0d2c0771f24557ae3eba587ec4b71673006710511022075b9f8b03ba332f98d8ae1e96211f5a75b6afc7920f439444067d88c0d6b2faa01"
+      },
+      {
+        "input": 0,
+        "pubkey": "033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d04135",
+        "sighash_type": 1,
+        "script_code": "5221028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa21033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d0413552ae",
+        "sighash": "f19966624894c461c87c03d5bbf25ca73708fa15e90e36cd1f2a5f9b044e1030",
+        "signature": "304402201e2bd73a2ded4a555dc5523a11ac0e4d781b44fcaf371054f291a6eb41d6673a02200d30cdf2d489d81ba0d147f4c200badbaa72875ef2a9c5fe79334a7b082f220101"
+      },
+      {
+        "input": 1,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "704aa3e208c25ef20badabeb4b9fc1805fc7ee1acd6a66e148172ed3e165a095",
+        "signature": "3045022100db867890a117c14dc844c8e753649f1559a08b498dc9c877aea869d662afe9bb02203a772978689fb369ac2af2a8bce661dd6c9ecbee61ff98cfbfd674dd631f40a501"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAAEOIBCmne4Q2FyRPio2x3b8dDpTlWGtb2AaupYqStN5GHCsAQ8EAAAAAAABAwjIAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwA",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAAAABDiAQpp3uENhckT4qNsd2/HQ6U5VhrW9gGrqWKkrTeRhwrAEPBAAAAAABAFUBAAAAAe7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7uAAAAAAD/////ASBOAAAAAAAAGXapFBTCXSxetySKOEH3TXTv47QGOzg/iKwAAAAAAQMEAQAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAAAABAwjIAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAABAwg4SgAAAAAAAAEEGXapFOVxZknojyIueLwhSn+ibr05gJzRiKwiAgNNq7UuzikWjCm6FglCOBMaqDJNLbFsU/0RUJBP8g9i+RjwVlWsLAAAgEkJAIAAAACAAAAAAAIAAAAA",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "signed-a",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAACICAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqRzBEAiBRVcn6ByVv+DK62vDSwHcfJFV64+ulh+xLcWcwBnEFEQIgdbn4sDujMvmNiuHpYhH1p1tq/Hkg9DlEQGfYjA1rL6oBAAEOIBCmne4Q2FyRPio2x3b8dDpTlWGtb2AaupYqStN5GHCsAQ8EAAAAAAEAVQEAAAAB7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u4AAAAAAP////8BIE4AAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQDbhniQoRfBTchEyOdTZJ8VWaCLSY3JyHeuqGnWYq/puwIgOncpeGifs2msKvKovOZh3Wyey+5h/5jPv9Z03WMfQKUBAAEDCMgAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "signed-b",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAACICAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1RzBEAiAeK9c6Le1KVV3FUjoRrA5NeBtE/K83EFTykabrQdZnOgIgDTDN8tSJ2Bug0Uf0wgC626pyh17yqcX+eTNKewgvIgEBASAMZnV0dXJlLWZpZWxkAAEOIBCmne4Q2FyRPio2x3b8dDpTlWGtb2AaupYqStN5GHCsAQ8EAAAAAAEAVQEAAAAB7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u4AAAAAAP////8BIE4AAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAAAEDCMgAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "combined",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEDBAEAAAABBEdSIQKLbV0uioUbrTUGXy7vAKUDk89hw8I3n70ztgZKhjiEqiEDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVSriIGAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqGPBWVawsAACASQkAgAAAAIAAAAAAAwAAACIGAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1GPBWVawsAACASQkAgAAAAIAAAAAABAAAACICAottXS6KhRutNQZfLu8ApQOTz2HDwjefvTO2BkqGOISqRzBEAiBRVcn6ByVv+DK62vDSwHcfJFV64+ulh+xLcWcwBnEFEQIgdbn4sDujMvmNiuHpYhH1p1tq/Hkg9DlEQGfYjA1rL6oBIgIDPJXgZ17i/qMG7+qkaFI9PgwFPCXeS+H/S08YFnXQQTVHMEQCIB4r1zot7UpVXcVSOhGsDk14G0T8rzcQVPKRputB1mc6AiANMM3y1InYG6DRR/TCALrbqnKHXvKpxf55M0p7CC8iAQEBIAxmdXR1cmUtZmllbGQAAQ4gEKad7hDYXJE+KjbHdvx0OlOVYa1vYBq6lipK03kYcKwBDwQAAAAAAQBVAQAAAAHu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7gAAAAAA/////wEgTgAAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhANuGeJChF8FNyETI51NknxVZoItJjcnId66oadZir+m7AiA6dyl4aJ+zaawq8qi85mHdbJ7L7mH/mM+/1nTdYx9ApQEAAQMIyAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIOEoAAAAAAAABBBl2qRTlcWZJ6I8iLni8IUp/om69OYCc0YisIgIDTau1Ls4pFowpuhYJQjgTGqgyTS2xbFP9EVCQT/IPYvkY8FZVrCwAAIBJCQCAAAAAgAAAAAACAAAAAA==",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIAAQ4ghVmpNP0WCaO7xZHDc4zKbUMtqP24VWM7448W1/lZHQsBDwQAAAAAAQB2AQAAAAHd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3QAAAAAA/////wHIAAAAAAAAADohwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvKkUOyFDvSW5YUzkG8OGCXCJq4EGl8SHAAAAAAEH2QBHMEQCIFFVyfoHJW/4Mrra8NLAdx8kVXrj66WH7EtxZzAGcQURAiB1ufiwO6My+Y2K4eliEfWnW2r8eSD0OURAZ9iMDWsvqgFHMEQCIB4r1zot7UpVXcVSOhGsDk14G0T8rzcQVPKRputB1mc6AiANMM3y1InYG6DRR/TCALrbqnKHXvKpxf55M0p7CC8iAQFHUiECi21dLoqFG601Bl8u7wClA5PPYcPCN5+9M7YGSoY4hKohAzyV4Gde4v6jBu/qpGhSPT4MBTwl3kvh/0tPGBZ10EE1Uq4BIAxmdXR1cmUtZmllbGQAAQ4gEKad7hDYXJE+KjbHdvx0OlOVYa1vYBq6lipK03kYcKwBDwQAAAAAAQBVAQAAAAHu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7gAAAAAA/////wEgTgAAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHa0gwRQIhANuGeJChF8FNyETI51NknxVZoItJjcnId66oadZir+m7AiA6dyl4aJ+zaawq8qi85mHdbJ7L7mH/mM+/1nTdYx9ApQEhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEDCMgAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkU5XFmSeiPIi54vCFKf6JuvTmAnNGIrCICA02rtS7OKRaMKboWCUI4ExqoMk0tsWxT/RFQkE/yD2L5GPBWVawsAACASQkAgAAAAIAAAAAAAgAAAAA=",
+        "identification_txid": "936875f1e861669edecd2a9d0e017781f812b26eb5107129e639cb7d3f46a34f"
+      }
+    ],
+    "extracted_tx": "01000000028559a934fd1609a3bbc591c3738cca6d432da8fdb855633be38f16d7f9591d0b00000000d90047304402205155c9fa07256ff832badaf0d2c0771f24557ae3eba587ec4b71673006710511022075b9f8b03ba332f98d8ae1e96211f5a75b6afc7920f439444067d88c0d6b2faa0147304402201e2bd73a2ded4a555dc5523a11ac0e4d781b44fcaf371054f291a6eb41d6673a02200d30cdf2d489d81ba0d147f4c200badbaa72875ef2a9c5fe79334a7b082f220101475221028b6d5d2e8a851bad35065f2eef00a50393cf61c3c2379fbd33b6064a863884aa21033c95e0675ee2fea306efeaa468523d3e0c053c25de4be1ff4b4f181675d0413552aeffffffff10a69dee10d85c913e2a36c776fc743a539561ad6f601aba962a4ad3791870ac000000006b483045022100db867890a117c14dc844c8e753649f1559a08b498dc9c877aea869d662afe9bb02203a772978689fb369ac2af2a8bce661dd6c9ecbee61ff98cfbfd674dd631f40a5012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff02c8000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac384a0000000000001976a914e5716649e88f222e78bc214a7fa26ebd39809cd188ac00000000",
+    "final_txid": "da211c6cdba004ac37152f2a7013586db2944cca8ac1fcc6631f5baf42a21768"
+  },
+  {
+    "id": "fee-provider-noninteractive",
+    "description": "Fee provider workflow, non-interactive variant (exact-fee UTXO). The user constructs a 100-token CP2PKH transfer with no TPC and signs with SIGHASH_ALL|SIGHASH_ANYONECANPAY, leaving the Inputs Modifiable flag set. The fee provider adds one 1000-tapy P2PKH input whose value is exactly the fee, signs it with SIGHASH_ALL (clearing Inputs Modifiable), finalizes, and extracts. The user's sighash is computed over the single-input transaction and stays valid after the fee input is added, which the verifier confirms by recomputing it from the final two-input transaction.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 129,
+        "script_code": "21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "35b3893b789210b9f1df1efe10a42937d358dc926d0f8d3315e9cf124c8a4906",
+        "signature": "3045022100ab18c9918bda646dc7817540ddf9a26d060bc276d307e86a5ef0e601eab36ad40220242b87c4ba7c8de3adcdfd688527d46a5529f365a15f570b6eca9c78990e7e1b81"
+      },
+      {
+        "input": 1,
+        "pubkey": "03030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341",
+        "sighash_type": 1,
+        "script_code": "76a914dcac7d84c6844c82f715802a834c5671bdc5821288ac",
+        "sighash": "1a6c6e2a5a94b28a066dcd64a88f43d987944b635a1790576feb0085872ed564",
+        "signature": "3045022100b8cc4f119e0d783b095d6687745011f16b369a667d94d9d41a472f91a8d15eea0220653574b5b025439f0c937c605ebd6541076859ab6ca7141ac592b9dcab63dad901"
+      }
+    ],
+    "stages": [
+      {
+        "name": "user-constructed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBBgEBAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "bb32395f8e351572b8eb1432ba664cca2f9346b3734e80eff2fec33e28c18e5e",
+        "tx_modifiable": 1
+      },
+      {
+        "name": "user-signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBBgEBAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBIEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EAAQMIZAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "bb32395f8e351572b8eb1432ba664cca2f9346b3734e80eff2fec33e28c18e5e",
+        "tx_modifiable": 1
+      },
+      {
+        "name": "provider-added-input",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEBBgEBAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBIEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EAAQ4gi7aNx87XGuA6v/+z6UcGmjaQVtwpjke/skKK8pvs9l0BDwQAAAAAAAEDCGQAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAA==",
+        "identification_txid": "e4c1f43399af0cf7b7d895c09f26a5ed3a6ea60249c83b5e66e6ab27e4f7c13a",
+        "tx_modifiable": 1
+      },
+      {
+        "name": "provider-signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEBBgEAAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBIEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAAiAgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyUgwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EAAQ4gi7aNx87XGuA6v/+z6UcGmjaQVtwpjke/skKK8pvs9l0BDwQAAAAAAQBVAQAAAAHy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8gAAAAAA/////wHoAwAAAAAAABl2qRTcrH2ExoRMgvcVgCqDTFZxvcWCEoisAAAAACIGAwMMmt+dqqUNF5wE/Baj+/eYXjICE0NoAwCipRH0LANBGPBWVawsAACASQkAgAAAAIAAAAAABQAAACICAwMMmt+dqqUNF5wE/Baj+/eYXjICE0NoAwCipRH0LANBSDBFAiEAuMxPEZ4NeDsJXWaHdFAR8Ws2mmZ9lNnUGkcvkajRXuoCIGU1dLWwJUOfDJN8YF69ZUEHaFmrbKcUGsWSudyrY9rZAQABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "e4c1f43399af0cf7b7d895c09f26a5ed3a6ea60249c83b5e66e6ab27e4f7c13a",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQEBBgEAAAEOIAOemco6/ra8aNcan5VF7DZxq2F983TeOQdh7zLLh/AhAQ8EAAAAAAEAeAEAAAAB8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fEAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHa0gwRQIhAKsYyZGL2mRtx4F1QN35om0GC8J20wfoal7w5gHqs2rUAiAkK4fEunyN463N/WiFJ9RqVSnzZaFfVwtuypx4mQ5+G4EhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEOIIu2jcfO1xrgOr//s+lHBpo2kFbcKY5Hv7JCivKb7PZdAQ8EAAAAAAEAVQEAAAAB8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vIAAAAAAP////8B6AMAAAAAAAAZdqkU3Kx9hMaETIL3FYAqg0xWcb3FghKIrAAAAAABB2tIMEUCIQC4zE8Rng14OwldZod0UBHxazaaZn2U2dQaRy+RqNFe6gIgZTV0tbAlQ58Mk3xgXr1lQQdoWatspxQaxZK53Ktj2tkBIQMDDJrfnaqlDRecBPwWo/v3mF4yAhNDaAMAoqUR9CwDQQABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "e4c1f43399af0cf7b7d895c09f26a5ed3a6ea60249c83b5e66e6ab27e4f7c13a",
+        "tx_modifiable": 0
+      }
+    ],
+    "extracted_tx": "0100000002039e99ca3afeb6bc68d71a9f9545ec3671ab617df374de390761ef32cb87f021000000006b483045022100ab18c9918bda646dc7817540ddf9a26d060bc276d307e86a5ef0e601eab36ad40220242b87c4ba7c8de3adcdfd688527d46a5529f365a15f570b6eca9c78990e7e1b812102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff8bb68dc7ced71ae03abfffb3e947069a369056dc298e47bfb2428af29becf65d000000006b483045022100b8cc4f119e0d783b095d6687745011f16b369a667d94d9d41a472f91a8d15eea0220653574b5b025439f0c937c605ebd6541076859ab6ca7141ac592b9dcab63dad9012103030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341ffffffff0164000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac00000000",
+    "final_txid": "4266397ab1b64bc2ef2988c3e98566447e10e0265657bb27bfd94ac343c0b140"
+  },
+  {
+    "id": "fee-provider-interactive",
+    "description": "Fee provider workflow, interactive variant (with change output). The user sends an unsigned 100-token CP2PKH transfer with both modifiable flags set. The provider, acting as Constructor, adds a 20000-tapy P2PKH fee input and a 19000-tapy change output (fee 1000), attaches its input's UTXO, and clears both flags to declare construction finished. Both parties then sign with SIGHASH_ALL, finalize, and extract.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "0dd82b63fe177415da9f800a05e375c0fc18847183989673d8e77dc596e6d860",
+        "signature": "3045022100914efefa503aeab2aac785328f475463f86ee41669287c802b61e939d097033102202bedaed2e3b3008827dd61bee610d2e6f6a5ee265ff06f1b17aa52080807c4fa01"
+      },
+      {
+        "input": 1,
+        "pubkey": "03030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341",
+        "sighash_type": 1,
+        "script_code": "76a914dcac7d84c6844c82f715802a834c5671bdc5821288ac",
+        "sighash": "f822b1b4621a4281bfd843918b9f8f86543dfcb46cc2c155a735d1ae2e89e6ca",
+        "signature": "3044022071ee759ea4df8c39e7799999f958e8e9474c6d87caaa6d3cd6899c40930aadeb02200aad507220232e074d5caefabba138e5995e58dc54087e914e5715ee4eb57feb01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "user-constructed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBBgEDAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAABAwhkAAAAAAAAAAEEPCHBvcNexyOQtRKPE4MB+tkTKfF9Rasx1Dr6PeogbypaG8C8dqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "18bdedafe492235e4b0f5a774d1e7317f41536b4eec6427be90113a1f47e363e",
+        "tx_modifiable": 3
+      },
+      {
+        "name": "provider-constructed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIBBgEAAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAABDiCqTkoBOxybnOO2CwnW40rwLnOat8xXG5CBuVp8/xrxhgEPBAAAAAABAFUBAAAAAfPz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/PzAAAAAAD/////ASBOAAAAAAAAGXapFNysfYTGhEyC9xWAKoNMVnG9xYISiKwAAAAAAAEDCGQAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkUNs1RHDntnYJbTbzDWNm0liyQp0WIrCICArDrs/3AwNduzz2Bk5by9oZGwyYeHL2quM3iYPlIRc5yGPBWVawsAACASQkAgAAAAIAAAAAABgAAAAA=",
+        "identification_txid": "f5b31c17e398a2be443d9c79cbe9bfeb41b835fcaa03aca6a841cdc813f74a96",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIBBgEAAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAEAeAEAAAAB9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PQAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAACIGAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJGPBWVawsAACASQkAgAAAAIAAAAAAAAAAACICAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJSDBFAiEAkU7++lA66rKqx4Uyj0dUY/hu5BZpKHyAK2HpOdCXAzECICvtrtLjswCIJ91hvuYQ0ub2pe4mX/BvGxeqUggIB8T6AQABDiCqTkoBOxybnOO2CwnW40rwLnOat8xXG5CBuVp8/xrxhgEPBAAAAAABAFUBAAAAAfPz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/PzAAAAAAD/////ASBOAAAAAAAAGXapFNysfYTGhEyC9xWAKoNMVnG9xYISiKwAAAAAIgYDAwya352qpQ0XnAT8FqP795heMgITQ2gDAKKlEfQsA0EY8FZVrCwAAIBJCQCAAAAAgAAAAAAFAAAAIgIDAwya352qpQ0XnAT8FqP795heMgITQ2gDAKKlEfQsA0FHMEQCIHHudZ6k34w553mZmflY6OlHTG2HyqptPNaJnECTCq3rAiAKrVByICMuB01crvq7oTjlmV5Y3FQIfpFOVxXuTrV/6wEAAQMIZAAAAAAAAAABBDwhwb3DXscjkLUSjxODAfrZEynxfUWrMdQ6+j3qIG8qWhvAvHapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwAAQMIOEoAAAAAAAABBBl2qRQ2zVEcOe2dgltNvMNY2bSWLJCnRYisIgICsOuz/cDA127PPYGTlvL2hkbDJh4cvaq4zeJg+UhFznIY8FZVrCwAAIBJCQCAAAAAgAAAAAAGAAAAAA==",
+        "identification_txid": "f5b31c17e398a2be443d9c79cbe9bfeb41b835fcaa03aca6a841cdc813f74a96",
+        "tx_modifiable": 0
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAgEFAQIBBgEAAAEOIPxomTHBQJdE34WoWglGI66Tn86zIxCX9nvPIMS7uUveAQ8EAAAAAAEAeAEAAAAB9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PQAAAAAAP////8BZAAAAAAAAAA8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEHa0gwRQIhAJFO/vpQOuqyqseFMo9HVGP4buQWaSh8gCth6TnQlwMxAiAr7a7S47MAiCfdYb7mENLm9qXuJl/wbxsXqlIICAfE+gEhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEOIKpOSgE7HJuc47YLCdbjSvAuc5q3zFcbkIG5Wnz/GvGGAQ8EAAAAAAEAVQEAAAAB8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/Pz8/MAAAAAAP////8BIE4AAAAAAAAZdqkU3Kx9hMaETIL3FYAqg0xWcb3FghKIrAAAAAABB2pHMEQCIHHudZ6k34w553mZmflY6OlHTG2HyqptPNaJnECTCq3rAiAKrVByICMuB01crvq7oTjlmV5Y3FQIfpFOVxXuTrV/6wEhAwMMmt+dqqUNF5wE/Baj+/eYXjICE0NoAwCipRH0LANBAAEDCGQAAAAAAAAAAQQ8IcG9w17HI5C1Eo8TgwH62RMp8X1FqzHUOvo96iBvKlobwLx2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAAEDCDhKAAAAAAAAAQQZdqkUNs1RHDntnYJbTbzDWNm0liyQp0WIrCICArDrs/3AwNduzz2Bk5by9oZGwyYeHL2quM3iYPlIRc5yGPBWVawsAACASQkAgAAAAIAAAAAABgAAAAA=",
+        "identification_txid": "f5b31c17e398a2be443d9c79cbe9bfeb41b835fcaa03aca6a841cdc813f74a96",
+        "tx_modifiable": 0
+      }
+    ],
+    "extracted_tx": "0100000002fc689931c1409744df85a85a094623ae939fceb3231097f67bcf20c4bbb94bde000000006b483045022100914efefa503aeab2aac785328f475463f86ee41669287c802b61e939d097033102202bedaed2e3b3008827dd61bee610d2e6f6a5ee265ff06f1b17aa52080807c4fa012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffffaa4e4a013b1c9b9ce3b60b09d6e34af02e739ab7cc571b9081b95a7cff1af186000000006a473044022071ee759ea4df8c39e7799999f958e8e9474c6d87caaa6d3cd6899c40930aadeb02200aad507220232e074d5caefabba138e5995e58dc54087e914e5715ee4eb57feb012103030c9adf9daaa50d179c04fc16a3fbf7985e32021343680300a2a511f42c0341ffffffff0264000000000000003c21c1bdc35ec72390b5128f138301fad91329f17d45ab31d43afa3dea206f2a5a1bc0bc76a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac384a0000000000001976a91436cd511c39ed9d825b4dbcc358d9b4962c90a74588ac00000000",
+    "final_txid": "ef4b6a8521e3d009ffe5973c3b1b88b6a97233b32c86e82fbd2d4dc62ecabcf8"
+  },
+  {
+    "id": "locktime-height",
+    "description": "A single input requires a height-based locktime (PSTT_IN_REQUIRED_HEIGHT_LOCKTIME = 680000) and no other input specifies a locktime, so the transaction locktime is 680000 (Determining the Locktime, \"one input specifies a required locktime, of one kind\").",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "d5549d43f566aeb6292d20132f716f6018d84c8a8f08e686bc9404d8ba149aa6",
+        "signature": "304402205da95d3ffde07abca5bd3e281d640199a582acb14bbe96991538f1be4fdab6ac022003a3ede7b8ea487aa2fb16a076c098272c57b5183aaf4bb82419a12c9985df7201"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAARIEQGAKAAABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEgRAYAoAAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEgRAYAoAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlHMEQCIF2pXT/94Hq8pb0+KB1kAZmlgqyxS76WmRU48b5P2rasAiADo+3nuOpIeqL7FqB2wJgnLFe1GDqvS7gkGaEsmYXfcgEAAQMIuIIBAAAAAAABBBl2qRRXGiktwRu0cXAw8E1WRaxC8q5g34isAA==",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAESBEBgCgABB2pHMEQCIF2pXT/94Hq8pb0+KB1kAZmlgqyxS76WmRU48b5P2rasAiADo+3nuOpIeqL7FqB2wJgnLFe1GDqvS7gkGaEsmYXfcgEhAt/mWQ653FYthycv4SSPY+ntLOPrKHn87zCuPpJyCyzJAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "10260e3511b4c6401e54108f63f0bfe4cbad569db24d6af9c2f6ea3a502d599e"
+      }
+    ],
+    "extracted_tx": "0100000001a78f386585b9b62570b73329b3f89e507e8a22cd4fc4efd519c7e03e26d0b474000000006a47304402205da95d3ffde07abca5bd3e281d640199a582acb14bbe96991538f1be4fdab6ac022003a3ede7b8ea487aa2fb16a076c098272c57b5183aaf4bb82419a12c9985df72012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff01b8820100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac40600a00",
+    "final_txid": "075de6144189adb4b09fa28f710f810974059c6aeb1212512046a2b48c7d0a1e"
+  },
+  {
+    "id": "locktime-time",
+    "description": "A single input requires a time-based locktime (PSTT_IN_REQUIRED_TIME_LOCKTIME = 1700000000, a Unix timestamp) and no other input specifies a locktime, so the transaction locktime is 1700000000.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "12ec77370034bd2f6d406007f2f5ccdb076431cf78e7d937f357708816aa6b58",
+        "signature": "3045022100d5ece9b63757ffb2b24d99b6265201b4db95517606a0ff654eb187e3e8062e8b02203db506e32abe48a41611564909aa2d6a54f08eec320868fdb63eb24a7e843fec01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAREEAPFTZQABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEQQA8VNlAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAEDBAEAAAAiBgLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyRjwVlWsLAAAgEkJAIAAAACAAAAAAAAAAAABEQQA8VNlIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQDV7Om2N1f/srJNmbYmUgG025VRdgag/2VOsYfj6AYuiwIgPbUG4yq+SKQWEVZJCaotalTwjuwyCGj9tj6ySn6EP+wBAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEAAQ4gp484ZYW5tiVwtzMps/ieUH6KIs1PxO/VGcfgPibQtHQBDwQAAAAAAQBVAQAAAAH29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29gAAAAAA/////wGghgEAAAAAABl2qRQUwl0sXrckijhB90107+O0Bjs4P4isAAAAAAERBADxU2UBB2tIMEUCIQDV7Om2N1f/srJNmbYmUgG025VRdgag/2VOsYfj6AYuiwIgPbUG4yq+SKQWEVZJCaotalTwjuwyCGj9tj6ySn6EP+wBIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "112cb6bd9b60f20f899b6322007c9e252729d07e8d838954bfd439bf5edbdb43"
+      }
+    ],
+    "extracted_tx": "0100000001a78f386585b9b62570b73329b3f89e507e8a22cd4fc4efd519c7e03e26d0b474000000006b483045022100d5ece9b63757ffb2b24d99b6265201b4db95517606a0ff654eb187e3e8062e8b02203db506e32abe48a41611564909aa2d6a54f08eec320868fdb63eb24a7e843fec012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff01b8820100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88ac00f15365",
+    "final_txid": "4a9f5bf3bd0999b22afeb9429bc02016562f5fff8c3682e45b819f584deba994"
+  },
+  {
+    "id": "locktime-fallback",
+    "description": "No input specifies a required locktime, but PSTT_GLOBAL_FALLBACK_LOCKTIME is 500, so the transaction locktime is 500 rather than the default of 0.",
+    "intermediates": [
+      {
+        "input": 0,
+        "pubkey": "02dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9",
+        "sighash_type": 1,
+        "script_code": "76a91414c25d2c5eb7248a3841f74d74efe3b4063b383f88ac",
+        "sighash": "5123c2f38c4ee4390e0d00d30b0bef3107e081a998abb09175a7b1f8dcc1a51f",
+        "signature": "3045022100ec502dda0d6972e9410ebb4b288d2e82aab2e8380d28775bc43da5129191618302203d71baff364054634a573446a0a59d7b08c90fbd62cf3b7b3a44848523592e6e01"
+      }
+    ],
+    "stages": [
+      {
+        "name": "created",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      },
+      {
+        "name": "updated",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAEAVQEAAAAB9vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vYAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      },
+      {
+        "name": "signed",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAEAVQEAAAAB9vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vYAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABAwQBAAAAIgYC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMkY8FZVrCwAAIBJCQCAAAAAgAAAAAAAAAAAIgIC3+ZZDrncVi2HJy/hJI9j6e0s4+soefzvMK4+knILLMlIMEUCIQDsUC3aDWly6UEOu0sojS6CqrLoOA0od1vEPaUSkZFhgwIgPXG6/zZAVGNKVzRGoKWdewjJD71izzt7OkSEhSNZLm4BAAEDCLiCAQAAAAAAAQQZdqkUVxopLcEbtHFwMPBNVkWsQvKuYN+IrAA=",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      },
+      {
+        "name": "finalized",
+        "pstt": "cHN0dP8BAgQBAAAAAQQBAQEFAQEBAwT0AQAAAAEOIKePOGWFubYlcLczKbP4nlB+iiLNT8Tv1RnH4D4m0LR0AQ8EAAAAAAEAVQEAAAAB9vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vYAAAAAAP////8BoIYBAAAAAAAZdqkUFMJdLF63JIo4QfdNdO/jtAY7OD+IrAAAAAABB2tIMEUCIQDsUC3aDWly6UEOu0sojS6CqrLoOA0od1vEPaUSkZFhgwIgPXG6/zZAVGNKVzRGoKWdewjJD71izzt7OkSEhSNZLm4BIQLf5lkOudxWLYcnL+Ekj2Pp7Szj6yh5/O8wrj6ScgssyQABAwi4ggEAAAAAAAEEGXapFFcaKS3BG7RxcDDwTVZFrELyrmDfiKwA",
+        "identification_txid": "5e07461667147a6bf46ed4ab8c3fac9693b9ce5e2183fb481a1d2dd461ab8f9c"
+      }
+    ],
+    "extracted_tx": "0100000001a78f386585b9b62570b73329b3f89e507e8a22cd4fc4efd519c7e03e26d0b474000000006b483045022100ec502dda0d6972e9410ebb4b288d2e82aab2e8380d28775bc43da5129191618302203d71baff364054634a573446a0a59d7b08c90fbd62cf3b7b3a44848523592e6e012102dfe6590eb9dc562d87272fe1248f63e9ed2ce3eb2879fcef30ae3e92720b2cc9ffffffff01b8820100000000001976a914571a292dc11bb4717030f04d5645ac42f2ae60df88acf4010000",
+    "final_txid": "38d4defaf8d239cc6923439d952b6f38a61d3909299f0f43adef32e9e8527719"
+  }
+]

--- a/test/functional/rpc_pstt.py
+++ b/test/functional/rpc_pstt.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2026 Chaintope Inc.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the Partially Signed Tapyrus Transaction (PSTT, TIP-174) RPCs.
+
+Ported from rpc_psbt.py's operational coverage, renamed to the PSTT RPC
+surface (see doc/tapyrus/pstt.md). rpc_psbt.py itself carried no
+segwit/witness/taproot/bech32-address content to begin with -- Tapyrus never
+had segwit -- so nothing needed excluding there; the one BIP-174-specific
+concept it did carry (non_witness_utxo, PSBT's "full previous tx" field) maps
+directly onto PSTT_IN_UTXO, which fills the same role under a new name.
+
+The old "BIP 174 Test Vectors" section (driven by data/rpc_psbt.json, BIP-174's
+own bucket-shaped fixture file) is replaced outright by TIP-174's own fixtures
+(data/tip174_valid.json / data/tip174_invalid.json -- see data/tip174_SOURCE.md
+for provenance) -- the two schemas are structurally incompatible (PSBT v0's
+global map carries a whole embedded CMutableTransaction under key 0x00, which
+PSTT reserves as must-reject), so there is no meaningful migration path.
+
+Note: this file assumes the createpstt/converttopstt/addinputtopstt/
+addoutputtopstt/finalizepsttconstruction/combinepstt/finalizepstt/extractpstt/
+decodepstt/walletcreatefundedpstt/walletupdatepstt/walletprocesspstt/
+walletsignpstt RPCs described in doc/tapyrus/pstt.md exist. It is not
+runnable until those land (non-wallet RPCs, Constructor/Combiner/Finalizer/
+Extractor primitives, and the wallet glue). decodepstt's exact JSON field
+names are a best-effort match to doc/tapyrus/pstt.md and may need small
+adjustment once that RPC actually ships.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error, find_output, sync_blocks, TAPYRUS_MODES
+from test_framework.blocktools import create_colored_transaction
+
+from decimal import Decimal
+
+import json
+import os
+
+MAX_BIP125_RBF_SEQUENCE = 0xfffffffd
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+
+REQUIRED_VALID_ENTRY_KEYS = {'id', 'description', 'intermediates', 'stages', 'extracted_tx', 'final_txid'}
+REQUIRED_STAGE_KEYS = {'name', 'pstt'}
+REQUIRED_INVALID_ENTRY_KEYS = {'id', 'description', 'pstt', 'expected'}
+REQUIRED_EXPECTED_KEYS = {'valid', 'stage', 'reason'}
+VALID_STAGE_NAMES = {'parse', 'rule'}
+
+
+def load_valid_fixtures():
+    """Load tip174_valid.json and validate its top-level schema defensively.
+
+    Fails loudly (raises) rather than silently accepting a malformed/misread schema, per
+    the plan's §9b instruction: a subtle schema misread should surface immediately, not
+    silently pass zero test cases.
+    """
+    path = os.path.join(DATA_DIR, 'tip174_valid.json')
+    with open(path, encoding='utf-8') as f:
+        entries = json.load(f)
+    if not isinstance(entries, list):
+        raise AssertionError("tip174_valid.json: expected a top-level array, got %s" % type(entries).__name__)
+    for entry in entries:
+        missing = REQUIRED_VALID_ENTRY_KEYS - entry.keys()
+        if missing:
+            raise AssertionError("tip174_valid.json entry %r missing required key(s): %s" % (entry.get('id', '?'), sorted(missing)))
+        if not isinstance(entry['stages'], list) or not entry['stages']:
+            raise AssertionError("tip174_valid.json entry %r: 'stages' must be a non-empty array" % entry['id'])
+        for stage in entry['stages']:
+            missing = REQUIRED_STAGE_KEYS - stage.keys()
+            if missing:
+                raise AssertionError(
+                    "tip174_valid.json entry %r stage %r missing required key(s): %s"
+                    % (entry['id'], stage.get('name', '?'), sorted(missing)))
+    return entries
+
+
+def load_invalid_fixtures():
+    """Load tip174_invalid.json and validate its top-level schema defensively."""
+    path = os.path.join(DATA_DIR, 'tip174_invalid.json')
+    with open(path, encoding='utf-8') as f:
+        entries = json.load(f)
+    if not isinstance(entries, list):
+        raise AssertionError("tip174_invalid.json: expected a top-level array, got %s" % type(entries).__name__)
+    for entry in entries:
+        missing = REQUIRED_INVALID_ENTRY_KEYS - entry.keys()
+        if missing:
+            raise AssertionError("tip174_invalid.json entry %r missing required key(s): %s" % (entry.get('id', '?'), sorted(missing)))
+        expected = entry['expected']
+        missing = REQUIRED_EXPECTED_KEYS - expected.keys()
+        if missing:
+            raise AssertionError("tip174_invalid.json entry %r 'expected' missing required key(s): %s" % (entry['id'], sorted(missing)))
+        if expected['valid'] is not False:
+            raise AssertionError("tip174_invalid.json entry %r: expected.valid must be false" % entry['id'])
+        if expected['stage'] not in VALID_STAGE_NAMES:
+            raise AssertionError(
+                "tip174_invalid.json entry %r: expected.stage must be one of %s, got %r"
+                % (entry['id'], sorted(VALID_STAGE_NAMES), expected['stage']))
+    return entries
+
+
+class PSTTTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
+    def run_test(self):
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+        #create tokens
+        colorId = create_colored_transaction(2, 100, self.nodes[0])['color']
+        self.sync_all()
+        self.nodes[2].generate(1, self.signblockprivkey_wif)
+
+        # Create and fund a raw tx for sending 10 TPC
+        psttx1 = self.nodes[0].walletcreatefundedpstt([], {self.nodes[2].getnewaddress():10})['pstt']
+
+        # Node 1 should not be able to add anything to it but still return the psttx same as before
+        psttx = self.nodes[1].walletprocesspstt(psttx1)['pstt']
+        assert_equal(psttx1, psttx)
+
+        # Sign the transaction and send
+        signed_tx = self.nodes[0].walletprocesspstt(psttx1)['pstt']
+        final_tx = self.nodes[0].finalizepstt(signed_tx)['hex']
+        self.nodes[0].sendrawtransaction(final_tx, True)
+
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+        self.sync_all()
+
+        # Create and fund a raw tx for sending colored coin
+        psttx2 = self.nodes[0].walletcreatefundedpstt([], {self.nodes[2].getnewaddress("tokenpstt", colorId):10, self.nodes[0].getnewaddress("tokenpstt", colorId):90})['pstt']
+
+        psttx = self.nodes[1].walletprocesspstt(psttx2)['pstt']
+        assert_equal(psttx2, psttx)
+        signed_tx = self.nodes[0].walletprocesspstt(psttx2)['pstt']
+
+        final_tx = self.nodes[0].finalizepstt(signed_tx)['hex']
+        self.nodes[0].sendrawtransaction(final_tx, True)
+
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+        self.sync_all()
+
+        # Test decodepstt with colored coin inputs
+        self.log.info('Test decodepstt with colored coin inputs')
+        cc_pstt = self.nodes[0].walletcreatefundedpstt(
+            [],
+            {self.nodes[2].getnewaddress("decdpstt", colorId): 5,
+             self.nodes[0].getnewaddress("decdpstt", colorId): 85}
+        )['pstt']
+        # walletprocesspstt attaches PSTT_IN_UTXO for each input
+        cc_processed = self.nodes[0].walletprocesspstt(cc_pstt)
+        assert_equal(cc_processed['complete'], True)
+        cc_decoded = self.nodes[0].decodepstt(cc_processed['pstt'])
+        for inp in cc_decoded['inputs']:
+            assert 'utxo' in inp
+        # decision #15 (doc/tapyrus/pstt.md): every input/output is annotated
+        # with the existing token/amount display convention.
+        for out in cc_decoded['outputs']:
+            assert 'token' in out
+            assert 'amount' in out
+
+        # Test walletprocesspstt rejects out-of-bounds prevout.n
+        self.log.info('Test walletprocesspstt rejects out-of-bounds prevout.n')
+        utxo = self.nodes[0].listunspent()[0]
+        raw_utxo_tx = self.nodes[0].getrawtransaction(utxo['txid'], True)
+        oob_vout = len(raw_utxo_tx['vout']) + 5
+        bad_pstt = self.nodes[0].createpstt(
+            [{"previous_txid": utxo['txid'], "output_index": oob_vout}],
+            {self.nodes[0].getnewaddress(): utxo['amount'] - Decimal('0.01')}
+        )
+        assert_raises_rpc_error(-22, "Input prevout index out of range",
+                                self.nodes[0].walletprocesspstt, bad_pstt)
+
+        # Create p2sh and p2pkh addresses
+        pubkey0 = self.nodes[0].getaddressinfo(self.nodes[0].getnewaddress())['pubkey']
+        pubkey1 = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress())['pubkey']
+        pubkey2 = self.nodes[2].getaddressinfo(self.nodes[2].getnewaddress())['pubkey']
+        p2sh = self.nodes[1].addmultisigaddress(2, [pubkey0, pubkey1, pubkey2], "")['address']
+        p2pkh = self.nodes[1].getnewaddress("")
+        cp2pkh = self.nodes[1].getnewaddress("", colorId)
+
+        # fund those addresses
+        rawtx = self.nodes[0].createrawtransaction([], {p2sh:10, p2pkh:10})
+        rawtx = self.nodes[0].fundrawtransaction(rawtx, {"changePosition":2})
+        rawtx = self.nodes[0].createrawtransaction([], {cp2pkh :10})
+        rawtx = self.nodes[0].fundrawtransaction(rawtx)
+        rawtx = self.nodes[0].createrawtransaction([], {p2sh:30, p2pkh:30, cp2pkh : 10})
+        rawtx = self.nodes[0].fundrawtransaction(rawtx)
+        signed_tx = self.nodes[0].signrawtransactionwithwallet(rawtx['hex'], [], "ALL", self.options.scheme)['hex']
+        txid = self.nodes[0].sendrawtransaction(signed_tx, True)
+        self.nodes[0].generate(6, self.signblockprivkey_wif)
+        self.sync_all()
+
+        # Find the output pos
+        p2sh_pos = -1
+        p2pkh_pos = -1
+        decoded = self.nodes[0].decoderawtransaction(signed_tx)
+        for out in decoded['vout']:
+            if out['scriptPubKey']['addresses'][0] == p2sh:
+                p2sh_pos = out['n']
+            elif out['scriptPubKey']['addresses'][0] == p2pkh:
+                p2pkh_pos = out['n']
+
+        # spend single key from node 1
+        rawtx = self.nodes[1].walletcreatefundedpstt([{"previous_txid":txid,"output_index":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99})['pstt']
+        walletprocesspstt_out = self.nodes[1].walletprocesspstt(rawtx)
+        assert_equal(walletprocesspstt_out['complete'], True)
+        self.nodes[1].sendrawtransaction(self.nodes[1].finalizepstt(walletprocesspstt_out['pstt'])['hex'], True)
+
+        # partially sign multisig things with node 1
+        psttx = self.nodes[1].walletcreatefundedpstt([{"previous_txid":txid,"output_index":p2sh_pos}], {self.nodes[1].getnewaddress():29.99})['pstt']
+        walletprocesspstt_out = self.nodes[1].walletprocesspstt(psttx)
+        psttx = walletprocesspstt_out['pstt']
+        assert_equal(walletprocesspstt_out['complete'], False)
+
+        # partially sign with node 2. This should be complete and sendable
+        walletprocesspstt_out = self.nodes[2].walletprocesspstt(psttx)
+        assert_equal(walletprocesspstt_out['complete'], True)
+        self.nodes[2].sendrawtransaction(self.nodes[2].finalizepstt(walletprocesspstt_out['pstt'])['hex'], True)
+
+        # check that walletprocesspstt fails to decode a non-pstt
+        rawtx = self.nodes[1].createrawtransaction([{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():9.99})
+        assert_raises_rpc_error(-22, "TX decode failed", self.nodes[1].walletprocesspstt, rawtx)
+
+        # Convert a non-pstt to pstt and make sure we can decode it
+        rawtx = self.nodes[0].createrawtransaction([], {self.nodes[1].getnewaddress():10})
+        rawtx = self.nodes[0].fundrawtransaction(rawtx)
+        new_pstt = self.nodes[0].converttopstt(rawtx['hex'])
+        self.nodes[0].decodepstt(new_pstt)
+
+        # Make sure that a pstt with signatures cannot be converted
+        signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx['hex'], [], "ALL", self.options.scheme)
+        assert_raises_rpc_error(-22, "Inputs must not have scriptSigs", self.nodes[0].converttopstt, signedtx['hex'])
+
+        # Explicitly allow converting non-empty txs
+        new_pstt = self.nodes[0].converttopstt(rawtx['hex'])
+        self.nodes[0].decodepstt(new_pstt)
+
+        # Create outputs to nodes 1 and 2
+        node1_addr = self.nodes[1].getnewaddress()
+        node2_addr = self.nodes[2].getnewaddress()
+        txid1 = self.nodes[0].sendtoaddress(node1_addr, 13)
+        txid2 =self.nodes[0].sendtoaddress(node2_addr, 13)
+        self.nodes[0].generate(6, self.signblockprivkey_wif)
+        sync_blocks(self.nodes)
+        #mempool is not synched.
+        vout1 = find_output(self.nodes[1], txid1, 13)
+        vout2 = find_output(self.nodes[2], txid2, 13)
+
+        # Create a pstt spending outputs from nodes 1 and 2
+        pstt_orig = self.nodes[0].createpstt([{"previous_txid":txid1, "output_index":vout1}, {"previous_txid":txid2, "output_index":vout2}], {self.nodes[0].getnewaddress():25.999})
+
+        # Update pstts, should only have data for one input and not the other
+        pstt1 = self.nodes[1].walletprocesspstt(pstt_orig)['pstt']
+        pstt1_decoded = self.nodes[0].decodepstt(pstt1)
+        assert pstt1_decoded['inputs'][0] and not pstt1_decoded['inputs'][1]
+        pstt2 = self.nodes[2].walletprocesspstt(pstt_orig)['pstt']
+        pstt2_decoded = self.nodes[0].decodepstt(pstt2)
+        assert not pstt2_decoded['inputs'][0] and pstt2_decoded['inputs'][1]
+
+        # Combine, finalize, and send the pstts
+        combined = self.nodes[0].combinepstt([pstt1, pstt2])
+        finalized = self.nodes[0].finalizepstt(combined)['hex']
+        self.nodes[0].sendrawtransaction(finalized, True)
+        self.nodes[0].generate(6, self.signblockprivkey_wif)
+        sync_blocks(self.nodes)
+        #mempool is not synched.
+
+        # Test additional args in walletcreatefundedpstt
+        # Make sure both pre-included and funded inputs
+        # have the correct sequence numbers based on
+        # replaceable arg
+        block_height = self.nodes[0].getblockcount()
+        unspent = self.nodes[0].listunspent()[0]
+        psttx_info = self.nodes[0].walletcreatefundedpstt([{"previous_txid":unspent["txid"], "output_index":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height+2, {"replaceable":True}, False)
+        decoded_pstt = self.nodes[0].decodepstt(psttx_info["pstt"])
+        for pstt_in in decoded_pstt["inputs"]:
+           assert_equal(pstt_in["sequence"], MAX_BIP125_RBF_SEQUENCE)
+           assert "bip32_derivs" not in pstt_in
+        assert_equal(decoded_pstt["locktime"], block_height+2)
+
+        # Same construction with only locktime set
+        psttx_info = self.nodes[0].walletcreatefundedpstt([{"previous_txid":unspent["txid"], "output_index":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], block_height, {}, True)
+        decoded_pstt = self.nodes[0].decodepstt(psttx_info["pstt"])
+        for pstt_in in decoded_pstt["inputs"]:
+            assert pstt_in["sequence"] > MAX_BIP125_RBF_SEQUENCE
+            assert "bip32_derivs" in pstt_in
+        assert_equal(decoded_pstt["locktime"], block_height)
+
+        # Same construction without optional arguments
+        psttx_info = self.nodes[0].walletcreatefundedpstt([{"previous_txid":unspent["txid"], "output_index":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}])
+        decoded_pstt = self.nodes[0].decodepstt(psttx_info["pstt"])
+        for pstt_in in decoded_pstt["inputs"]:
+            assert pstt_in["sequence"] > MAX_BIP125_RBF_SEQUENCE
+        assert_equal(decoded_pstt["locktime"], 0)
+
+        # Test the ECDSA/Schnorr sigscheme parameter end to end
+        self.log.info('Test walletsignpstt/walletprocesspstt with sigscheme=SCHNORR')
+        schnorr_pstt = self.nodes[0].walletcreatefundedpstt([], {self.nodes[2].getnewaddress():5})['pstt']
+        schnorr_out = self.nodes[0].walletprocesspstt(schnorr_pstt, True, "ALL", False, "SCHNORR")
+        assert_equal(schnorr_out['complete'], True)
+        self.nodes[0].sendrawtransaction(self.nodes[0].finalizepstt(schnorr_out['pstt'])['hex'], True)
+        self.nodes[0].generate(1, self.signblockprivkey_wif)
+        self.sync_all()
+
+        # TIP-174 test vectors
+        self.test_tip174_fixtures()
+
+    def test_tip174_fixtures(self):
+        # TIP-174's fixtures are dev-network-only (WIF 0xef, P2PKH 0x6f, P2SH
+        # 0xc4, CP2PKH 0x70, CP2SH 0xc5, BIP32 tpub/tprv -- see
+        # data/tip174_SOURCE.md). Under the strict Params()-only xpub prefix
+        # policy (doc/tapyrus/pstt.md), a future accidental PROD-mode run of
+        # this test would otherwise fail confusingly, far from the actual
+        # cause, on the one xpub-bearing entry -- assert explicitly instead.
+        assert self.mode == TAPYRUS_MODES.DEV, (
+            "rpc_pstt.py's TIP-174 fixtures are dev-network-only; refusing to run under %s" % self.mode)
+
+        self.log.info("Loading TIP-174 fixtures (see data/tip174_SOURCE.md for provenance)")
+        valid_entries = load_valid_fixtures()
+        invalid_entries = load_invalid_fixtures()
+        self.log.info("Loaded %d valid workflow(s), %d invalid vector(s)", len(valid_entries), len(invalid_entries))
+
+        node = self.nodes[0]
+
+        # valid.json: walk every stage's PSTT, asserting it decodes and that
+        # identification_txid is constant across every stage in the entry (per
+        # spec, the identifier must not change as the PSTT is filled in).
+        # Re-deriving each intermediate stage from the previous one via our
+        # own RPCs isn't attempted here -- the fixtures were signed with a
+        # generator-internal deterministic master key (see data/tip174_SOURCE.md)
+        # that isn't loaded into any node's wallet, so "sign this ourselves and
+        # compare bytes" isn't available for the signed/updated stages. What is
+        # checked on every stage: it decodes without error, and (via decodepstt)
+        # its identification_txid matches every other stage in the same entry.
+        # What is checked with full strength, on the entry's LAST stage only:
+        # extractpstt reproduces extracted_tx exactly, and sendrawtransaction
+        # accepts it with the expected final_txid -- i.e. a real,
+        # network-valid transaction comes out the other end of the pipeline.
+        for entry in valid_entries:
+            identification_txids = set()
+            for stage in entry['stages']:
+                decoded = node.decodepstt(stage['pstt'])
+                if 'identification_txid' in stage:
+                    identification_txids.add(stage['identification_txid'])
+                    assert_equal(decoded['identification_txid'], stage['identification_txid'])
+            assert_equal(len(identification_txids), 1,
+                         "entry %r: identification_txid changed across stages" % entry['id'])
+
+            last_pstt = entry['stages'][-1]['pstt']
+            extracted = node.extractpstt(last_pstt)['hex']
+            assert_equal(extracted, entry['extracted_tx'])
+            txid = node.sendrawtransaction(extracted, True)
+            assert_equal(txid, entry['final_txid'])
+            node.generate(1, self.signblockprivkey_wif)
+
+        # invalid.json: "parse" entries must be rejected by decodepstt itself;
+        # "rule" entries must decode fine (structurally well-formed) but fail
+        # a role-primitive check -- finalizepstt's completeness pass runs
+        # every input through the same checks SignPSTTInput does (UTXO
+        # presence/match, redeem-script hash, SIGHASH_SINGLE bounds, locktime
+        # validity) via a dummy signing provider, so it's a generically
+        # applicable role check regardless of which specific rule an entry
+        # is exercising.
+        for entry in invalid_entries:
+            expected_stage = entry['expected']['stage']
+            if expected_stage == 'parse':
+                assert_raises_rpc_error(-22, "TX decode failed", node.decodepstt, entry['pstt'])
+            else:
+                node.decodepstt(entry['pstt']) # must not throw
+                result = node.finalizepstt(entry['pstt'], False)
+                assert_equal(result['complete'], False)
+
+
+if __name__ == '__main__':
+    PSTTTest().main()


### PR DESCRIPTION
Implements the Partially Signed Tapyrus Transaction format that replaces the inherited Bitcoin-shaped PSBT (BIP-174 v0): no global unsigned tx, per-input outpoint fields instead, Colored Coin aware, ECDSA/Schnorr aware. Full specification in doc/tapyrus/pstt.md.

- src/pstt.h / src/pstt.cpp: PartiallySignedTapyrusTransaction, PSTTInput, PSTTOutput structs with full wire-format Serialize/Unserialize, IsNull/ Merge/IsSane (incl. mixed ECDSA/Schnorr rejection and the per-field-class Combiner conflict policy), ComputeLocktime, GetIdentifier, the private MaterializeTransaction helper, xpub keydata helpers with a strict single-network prefix policy, and SignPSTTInput (ahead of its originally planned phase, since it was natural to land alongside the structs it depends on).
- src/test/pstt_tests.cpp: structural round-trip/format tests, verified against TIP-174's own published fixtures (all valid stages parse, all parse-stage invalid vectors throw, all rule-stage vectors parse-fine as the spec intends); plus mempool/consensus-level valid & invalid transaction tests in the style of txvalidation_tests.cpp (ECDSA spend, Schnorr spend, wrong-key rejection, colored-coin issue+transfer across a two-input/two-key PSTT, and a real bad-txns-token-without-fee rejection).
- test/functional/rpc_pstt.py: functional test ported from rpc_psbt.py's operational coverage to the PSTT RPC surface, plus a TIP-174-fixture- driven section (stage decoding, identifier stability, extract+broadcast on each entry's final stage, parse/rule dispatch for invalid vectors). Not yet runnable or registered in test_runner.py -- the RPCs it drives land in later phases.
- test/functional/data/tip174_valid.json, tip174_invalid.json, tip174_SOURCE.md: TIP-174's own test vectors, pinned to the exact chaintope/tips commit fetched.