### PR TITLE
Add PSTT (TIP-174) Phase 2+3: Signer, Combiner, Finalizer, Extractor RPCs

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -15,6 +15,7 @@ class CScript;
 class CTransaction;
 struct CMutableTransaction;
 struct PartiallySignedTransaction;
+struct PartiallySignedTapyrusTransaction;
 class uint256;
 class UniValue;
 
@@ -26,12 +27,14 @@ bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 uint256 ParseHashStr(const std::string&, const std::string& strName);
 std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);
 bool DecodePSBT(PartiallySignedTransaction& psbt, const std::string& base64_tx, std::string& error);
+bool DecodePSTT(PartiallySignedTapyrusTransaction& pstt, const std::string& base64_tx, std::string& error);
 int ParseSighashString(const UniValue& sighash);
 
 // core_write.cpp
 UniValue ValueFromAmount(const CAmount& amount);
 std::string FormatScript(const CScript& script);
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
+std::string EncodePSTT(const PartiallySignedTapyrusTransaction& pstt);
 std::string SighashToStr(unsigned char sighash_type);
 void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -18,6 +18,7 @@ struct PartiallySignedTransaction;
 struct PartiallySignedTapyrusTransaction;
 class uint256;
 class UniValue;
+enum class SignatureScheme;
 
 // core_read.cpp
 CScript ParseScript(const std::string& s);
@@ -29,6 +30,7 @@ std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strN
 bool DecodePSBT(PartiallySignedTransaction& psbt, const std::string& base64_tx, std::string& error);
 bool DecodePSTT(PartiallySignedTapyrusTransaction& pstt, const std::string& base64_tx, std::string& error);
 int ParseSighashString(const UniValue& sighash);
+SignatureScheme ParseSigSchemeString(const UniValue& sigscheme);
 
 // core_write.cpp
 UniValue ValueFromAmount(const CAmount& amount);

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -6,6 +6,7 @@
 
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <pstt.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <serialize.h>
@@ -156,6 +157,23 @@ bool DecodePSBT(PartiallySignedTransaction& psbt, const std::string& base64_tx, 
         ss_data >> psbt;
         if (!ss_data.empty()) {
             error = "extra data after PSBT";
+            return false;
+        }
+    } catch (const std::exception& e) {
+        error = e.what();
+        return false;
+    }
+    return true;
+}
+
+bool DecodePSTT(PartiallySignedTapyrusTransaction& pstt, const std::string& base64_tx, std::string& error)
+{
+    std::vector<unsigned char> tx_data = DecodeBase64(base64_tx.c_str());
+    CDataStream ss_data(tx_data, SER_NETWORK, PROTOCOL_VERSION);
+    try {
+        ss_data >> pstt;
+        if (!ss_data.empty()) {
+            error = "extra data after PSTT";
             return false;
         }
     } catch (const std::exception& e) {

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -225,3 +225,22 @@ int ParseSighashString(const UniValue& sighash)
     }
     return hash_type;
 }
+
+SignatureScheme ParseSigSchemeString(const UniValue& sigscheme)
+{
+    SignatureScheme scheme = SignatureScheme::ECDSA;
+    if (!sigscheme.isNull()) {
+        static std::map<std::string, SignatureScheme> map_sigscheme_values = {
+            {std::string("ECDSA"), SignatureScheme::ECDSA},
+            {std::string("SCHNORR"), SignatureScheme::SCHNORR},
+        };
+        std::string strSigScheme = sigscheme.get_str();
+        const auto& it = map_sigscheme_values.find(strSigScheme);
+        if (it != map_sigscheme_values.end()) {
+            scheme = it->second;
+        } else {
+            throw std::runtime_error(strSigScheme + " is not a valid sigscheme parameter.");
+        }
+    }
+    return scheme;
+}

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -8,6 +8,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <key_io.h>
+#include <pstt.h>
 #include <script/script.h>
 #include <script/standard.h>
 #include <serialize.h>
@@ -136,6 +137,13 @@ std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags)
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | serializeFlags);
     ssTx << tx;
     return HexStr(ssTx.begin(), ssTx.end());
+}
+
+std::string EncodePSTT(const PartiallySignedTapyrusTransaction& pstt)
+{
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << pstt;
+    return EncodeBase64((unsigned char*)ssTx.data(), ssTx.size());
 }
 
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address)

--- a/src/pstt.cpp
+++ b/src/pstt.cpp
@@ -925,6 +925,20 @@ uint256 PartiallySignedTapyrusTransaction::GetIdentifier() const
     return MaterializeTransaction(*this, locktime, /*force_zero_sequence=*/true, /*use_final_scriptsig=*/false).GetHashMalFix();
 }
 
+CMutableTransaction ExtractPSTT(const PartiallySignedTapyrusTransaction& pstt)
+{
+    for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
+        if (pstt.inputs[i].final_script_sig.empty()) {
+            throw std::runtime_error("Input " + std::to_string(i) + " is missing PSTT_IN_FINAL_SCRIPTSIG; cannot extract");
+        }
+    }
+    uint32_t locktime;
+    if (!ComputeLocktime(pstt, locktime)) {
+        throw std::runtime_error("PSTT has no valid locktime; cannot extract");
+    }
+    return MaterializeTransaction(pstt, locktime, /*force_zero_sequence=*/false, /*use_final_scriptsig=*/true);
+}
+
 // =======================================================================
 // Signer
 // =======================================================================

--- a/src/pstt.cpp
+++ b/src/pstt.cpp
@@ -927,6 +927,9 @@ uint256 PartiallySignedTapyrusTransaction::GetIdentifier() const
 
 CMutableTransaction ExtractPSTT(const PartiallySignedTapyrusTransaction& pstt)
 {
+    if (!pstt.IsSane()) {
+        throw std::runtime_error("PSTT is not sane; cannot extract");
+    }
     for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
         if (pstt.inputs[i].final_script_sig.empty()) {
             throw std::runtime_error("Input " + std::to_string(i) + " is missing PSTT_IN_FINAL_SCRIPTSIG; cannot extract");

--- a/src/pstt.h
+++ b/src/pstt.h
@@ -219,6 +219,12 @@ struct PartiallySignedTapyrusTransaction
  *  locktime kind is acceptable to every input that constrains one. */
 bool ComputeLocktime(const PartiallySignedTapyrusTransaction& pstt, uint32_t& locktime_out);
 
+/** Transaction Extractor. Requires every input to carry PSTT_IN_FINAL_SCRIPTSIG
+ *  (throws std::runtime_error naming the first input missing it otherwise),
+ *  computes the final locktime via ComputeLocktime, and materializes the
+ *  fully signed transaction ready for broadcast. */
+CMutableTransaction ExtractPSTT(const PartiallySignedTapyrusTransaction& pstt);
+
 // ---------------------------------------------------------------------
 // Signer result taxonomy
 // ---------------------------------------------------------------------

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -967,9 +967,7 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
         keystore.AddKey(key);
     }
 
-    SignatureScheme sigScheme(SignatureScheme::ECDSA);
-    if(!request.params[4].isNull() && request.params[4].get_str() == "SCHNORR")
-        sigScheme = SignatureScheme::SCHNORR;
+    SignatureScheme sigScheme = ParseSigSchemeString(request.params[4]);
 
     return SignTransaction(mtx, request.params[2], &keystore, true, request.params[3], sigScheme);
 }
@@ -1946,7 +1944,7 @@ UniValue combinepstt(const JSONRPCRequest& request)
         }
         try {
             merged_pstt.Merge(*it);
-        } catch (const std::invalid_argument& e) {
+        } catch (const std::exception& e) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Cannot combine PSTTs: %s", e.what()));
         }
     }
@@ -2167,9 +2165,7 @@ UniValue signpsttwithkey(const JSONRPCRequest& request)
     }
 
     int sighash = ParseSighashString(request.params[2]);
-    SignatureScheme sigScheme(SignatureScheme::ECDSA);
-    if (!request.params[3].isNull() && request.params[3].get_str() == "SCHNORR")
-        sigScheme = SignatureScheme::SCHNORR;
+    SignatureScheme sigScheme = ParseSigSchemeString(request.params[3]);
 
     bool complete = true;
     for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -6,6 +6,7 @@
 
 #include <chain.h>
 #include <coins.h>
+#include <coloridentifier.h>
 #include <compat/byteswap.h>
 #include <consensus/validation.h>
 #include <core_io.h>
@@ -19,6 +20,7 @@
 #include <policy/packages.h>
 #include <policy/rbf.h>
 #include <primitives/transaction.h>
+#include <pstt.h>
 #include <rpc/protocol.h>
 #include <rpc/rawtransaction.h>
 #include <rpc/server.h>
@@ -1671,6 +1673,327 @@ UniValue converttopsbt(const JSONRPCRequest& request)
     return EncodeBase64((unsigned char*)ssTx.data(), ssTx.size());
 }
 
+// ---------------------------------------------------------------------
+// PSTT (TIP-174) -- see doc/tapyrus/pstt.md
+// ---------------------------------------------------------------------
+
+// Mirrors addTokenKV's (rpcwallet.cpp) token/amount display convention, but
+// keyed off a scriptPubKey directly rather than a CTxDestination, matching
+// decision #15 in doc/tapyrus/pstt.md: color is always derived from the
+// script, never assumed from context.
+static void PushTokenAmount(const CScript& script, CAmount amount, UniValue& entry)
+{
+    ColorIdentifier colorId = GetColorIdFromScript(script);
+    entry.pushKV("token", colorId.toHexString());
+    entry.pushKV("amount", (colorId.type == TokenTypes::NONE ? ValueFromAmount(amount) : amount));
+}
+
+static void PsttInputToUniv(const PSTTInput& input, UniValue& in)
+{
+    in.pushKV("previous_txid", input.previous_txid.GetHex());
+    in.pushKV("output_index", (uint64_t)input.prev_out_index);
+
+    if (input.utxo) {
+        UniValue utxo_univ(UniValue::VOBJ);
+        TxToUniv(*input.utxo, uint256(), utxo_univ, false);
+        in.pushKV("utxo", utxo_univ);
+        if (input.prev_out_index < input.utxo->vout.size()) {
+            const CTxOut& out = input.utxo->vout[input.prev_out_index];
+            PushTokenAmount(out.scriptPubKey, out.nValue, in);
+        }
+    }
+
+    if (!input.partial_sigs.empty()) {
+        UniValue partial_sigs(UniValue::VOBJ);
+        for (const auto& sig : input.partial_sigs) {
+            partial_sigs.pushKV(HexStr(sig.second.first), HexStr(sig.second.second));
+        }
+        in.pushKV("partial_signatures", partial_sigs);
+    }
+
+    if (input.sighash_type > 0) {
+        in.pushKV("sighash", SighashToStr((unsigned char)input.sighash_type));
+    }
+
+    if (!input.redeem_script.empty()) {
+        UniValue r(UniValue::VOBJ);
+        ScriptToUniv(input.redeem_script, r, false);
+        in.pushKV("redeem_script", r);
+    }
+
+    if (!input.hd_keypaths.empty()) {
+        UniValue keypaths(UniValue::VARR);
+        for (auto entry : input.hd_keypaths) {
+            UniValue keypath(UniValue::VOBJ);
+            keypath.pushKV("pubkey", HexStr(entry.first));
+            uint32_t fingerprint = entry.second.at(0);
+            keypath.pushKV("master_fingerprint", strprintf("%08x", internal_bswap_32(fingerprint)));
+            entry.second.erase(entry.second.begin());
+            keypath.pushKV("path", WriteHDKeypath(entry.second));
+            keypaths.push_back(keypath);
+        }
+        in.pushKV("bip32_derivs", keypaths);
+    }
+
+    if (!input.final_script_sig.empty()) {
+        UniValue scriptsig(UniValue::VOBJ);
+        scriptsig.pushKV("asm", ScriptToAsmStr(input.final_script_sig, true));
+        scriptsig.pushKV("hex", HexStr(input.final_script_sig));
+        in.pushKV("final_scriptSig", scriptsig);
+    }
+
+    if (input.sequence) in.pushKV("sequence", (uint64_t)*input.sequence);
+    if (input.required_time_locktime) in.pushKV("required_time_locktime", (uint64_t)*input.required_time_locktime);
+    if (input.required_height_locktime) in.pushKV("required_height_locktime", (uint64_t)*input.required_height_locktime);
+
+    auto push_preimages = [&in](const char* name, const std::map<std::vector<unsigned char>, std::vector<unsigned char>>& map) {
+        if (map.empty()) return;
+        UniValue preimages(UniValue::VOBJ);
+        for (const auto& entry : map) {
+            preimages.pushKV(HexStr(entry.first), HexStr(entry.second));
+        }
+        in.pushKV(name, preimages);
+    };
+    push_preimages("ripemd160_preimages", input.ripemd160_preimages);
+    push_preimages("sha256_preimages", input.sha256_preimages);
+    push_preimages("hash160_preimages", input.hash160_preimages);
+    push_preimages("hash256_preimages", input.hash256_preimages);
+
+    if (!input.unknown.empty()) {
+        UniValue unknowns(UniValue::VOBJ);
+        for (auto entry : input.unknown) {
+            unknowns.pushKV(HexStr(entry.first), HexStr(entry.second));
+        }
+        in.pushKV("unknown", unknowns);
+    }
+}
+
+static void PsttOutputToUniv(const PSTTOutput& output, UniValue& out)
+{
+    if (output.amount) out.pushKV("amount_raw", *output.amount);
+    if (!output.script.empty()) {
+        UniValue s(UniValue::VOBJ);
+        ScriptPubKeyToUniv(output.script, s, true);
+        out.pushKV("script", s);
+        if (output.amount) PushTokenAmount(output.script, *output.amount, out);
+    }
+
+    if (!output.redeem_script.empty()) {
+        UniValue r(UniValue::VOBJ);
+        ScriptToUniv(output.redeem_script, r, false);
+        out.pushKV("redeem_script", r);
+    }
+
+    if (!output.hd_keypaths.empty()) {
+        UniValue keypaths(UniValue::VARR);
+        for (auto entry : output.hd_keypaths) {
+            UniValue keypath(UniValue::VOBJ);
+            keypath.pushKV("pubkey", HexStr(entry.first));
+            uint32_t fingerprint = entry.second.at(0);
+            keypath.pushKV("master_fingerprint", strprintf("%08x", internal_bswap_32(fingerprint)));
+            entry.second.erase(entry.second.begin());
+            keypath.pushKV("path", WriteHDKeypath(entry.second));
+            keypaths.push_back(keypath);
+        }
+        out.pushKV("bip32_derivs", keypaths);
+    }
+
+    if (!output.unknown.empty()) {
+        UniValue unknowns(UniValue::VOBJ);
+        for (auto entry : output.unknown) {
+            unknowns.pushKV(HexStr(entry.first), HexStr(entry.second));
+        }
+        out.pushKV("unknown", unknowns);
+    }
+}
+
+UniValue decodepstt(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "decodepstt \"pstt\"\n"
+            "\nReturn a JSON object representing the serialized, base64-encoded "
+            "Partially Signed Tapyrus Transaction (see doc/tapyrus/pstt.md).\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"            (string, required) The PSTT base64 string\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("decodepstt", "\"pstt\"")
+    );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR});
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    UniValue result(UniValue::VOBJ);
+
+    if (pstt.tx_features) result.pushKV("tx_features", *pstt.tx_features);
+    if (pstt.fallback_locktime) result.pushKV("fallback_locktime", (uint64_t)*pstt.fallback_locktime);
+    if (pstt.tx_modifiable) {
+        UniValue mod(UniValue::VOBJ);
+        mod.pushKV("inputs_modifiable", bool(*pstt.tx_modifiable & PSTT_TXMOD_INPUTS_MODIFIABLE));
+        mod.pushKV("outputs_modifiable", bool(*pstt.tx_modifiable & PSTT_TXMOD_OUTPUTS_MODIFIABLE));
+        mod.pushKV("has_sighash_single", bool(*pstt.tx_modifiable & PSTT_TXMOD_HAS_SIGHASH_SINGLE));
+        result.pushKV("tx_modifiable", mod);
+    }
+    if (pstt.version) result.pushKV("version", (uint64_t)*pstt.version);
+
+    if (!pstt.xpubs.empty()) {
+        UniValue xpubs(UniValue::VARR);
+        for (const auto& entry : pstt.xpubs) {
+            UniValue x(UniValue::VOBJ);
+            x.pushKV("xpub", HexStr(SerializeXpubKeyData(entry.first)));
+            std::vector<uint32_t> path = entry.second;
+            if (!path.empty()) {
+                uint32_t fingerprint = path.at(0);
+                x.pushKV("master_fingerprint", strprintf("%08x", internal_bswap_32(fingerprint)));
+                path.erase(path.begin());
+                x.pushKV("path", WriteHDKeypath(path));
+            }
+            xpubs.push_back(x);
+        }
+        result.pushKV("xpubs", xpubs);
+    }
+
+    uint32_t locktime;
+    if (ComputeLocktime(pstt, locktime)) {
+        result.pushKV("locktime", (uint64_t)locktime);
+    }
+    try {
+        result.pushKV("identification_txid", pstt.GetIdentifier().GetHex());
+    } catch (const std::exception&) {
+        // No valid locktime yet (contradictory required locktimes) -- the
+        // identifier can't be computed; omit rather than error, since
+        // decodepstt is an inspection tool and this is exactly the kind of
+        // malformed-but-parseable PSTT it should still be able to show.
+    }
+
+    if (!pstt.unknown.empty()) {
+        UniValue unknowns(UniValue::VOBJ);
+        for (auto entry : pstt.unknown) {
+            unknowns.pushKV(HexStr(entry.first), HexStr(entry.second));
+        }
+        result.pushKV("unknown", unknowns);
+    }
+
+    UniValue inputs(UniValue::VARR);
+    for (const PSTTInput& input : pstt.inputs) {
+        UniValue in(UniValue::VOBJ);
+        PsttInputToUniv(input, in);
+        inputs.push_back(in);
+    }
+    result.pushKV("inputs", inputs);
+
+    UniValue outputs(UniValue::VARR);
+    for (const PSTTOutput& output : pstt.outputs) {
+        UniValue out(UniValue::VOBJ);
+        PsttOutputToUniv(output, out);
+        outputs.push_back(out);
+    }
+    result.pushKV("outputs", outputs);
+
+    return result;
+}
+
+UniValue signpsttwithkey(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 4)
+        throw std::runtime_error(
+            "signpsttwithkey \"pstt\" [\"privatekey1\",...] ( \"sighashtype\" \"sigscheme\" )\n"
+            "\nSign inputs of a PSTT with the given private keys (Signer role, no wallet required).\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"                          (string, required) The PSTT base64 string\n"
+            "2. \"privkeys\"                      (string, required) A json array of base58-encoded private keys for signing\n"
+            "    [\n"
+            "      \"privatekey\"                  (string) private key in base58-encoding\n"
+            "      ,...\n"
+            "    ]\n"
+            "3. \"sighashtype\"                    (string, optional, default=ALL) The signature hash type. Must be one of\n"
+            "       \"ALL\"\n"
+            "       \"NONE\"\n"
+            "       \"SINGLE\"\n"
+            "       \"ALL|ANYONECANPAY\"\n"
+            "       \"NONE|ANYONECANPAY\"\n"
+            "       \"SINGLE|ANYONECANPAY\"\n"
+            "4. \"sigscheme\"                    (string, optional, default=ECDSA) The signature scheme to use\n"
+            "       \"ECDSA\"\n"
+            "       \"SCHNORR\"\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"pstt\" : \"value\",          (string) The base64-encoded partially signed transaction\n"
+            "  \"complete\" : true|false,   (boolean) If every input with a UTXO now has a complete signature\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("signpsttwithkey", "\"mypstt\" \"[\\\"key1\\\",\\\"key2\\\"]\"")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR, UniValue::VSTR, UniValue::VSTR}, true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    FlatSigningProvider provider;
+    const UniValue& keys = request.params[1].get_array();
+    for (unsigned int idx = 0; idx < keys.size(); ++idx) {
+        UniValue k = keys[idx];
+        CKey key = DecodeSecret(k.get_str());
+        if (!key.IsValid()) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
+        }
+        CPubKey pubkey = key.GetPubKey();
+        provider.keys[pubkey.GetID()] = key;
+        provider.pubkeys[pubkey.GetID()] = pubkey;
+    }
+    // Redeem scripts already attached to inputs by an earlier Updater step
+    // are made available for P2SH/CP2SH resolution.
+    for (const PSTTInput& in : pstt.inputs) {
+        if (!in.redeem_script.empty()) {
+            provider.scripts[CScriptID(in.redeem_script)] = in.redeem_script;
+        }
+    }
+
+    int sighash = ParseSighashString(request.params[2]);
+    SignatureScheme sigScheme(SignatureScheme::ECDSA);
+    if (!request.params[3].isNull() && request.params[3].get_str() == "SCHNORR")
+        sigScheme = SignatureScheme::SCHNORR;
+
+    bool complete = true;
+    for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
+        PSTTInput& input = pstt.inputs.at(i);
+        if (!input.final_script_sig.empty()) continue; // already finalized
+        SignatureData sigdata;
+        PSTTSignResult result = SignPSTTInput(provider, pstt, i, sigdata, sighash, sigScheme);
+        if (result == PSTTSignResult::MISSING_UTXO) {
+            // Not this call's job to complain -- an incremental multi-party
+            // PSTT may genuinely have inputs no one has attached a UTXO to
+            // yet; leave it for a later Updater/Signer round.
+            complete = false;
+            continue;
+        }
+        if (result != PSTTSignResult::OK) {
+            throw JSONRPCError(RPC_TRANSACTION_ERROR, strprintf("Signing input %d failed: %s", i, PSTTSignResultToString(result)));
+        }
+        input.FromSignatureData(sigdata);
+        if (!sigdata.complete) complete = false;
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("pstt", EncodePSTT(pstt));
+    result.pushKV("complete", complete);
+    return result;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                            actor (function)            argNames
   //  --------------------- ------------------------        -----------------------     ----------
@@ -1687,6 +2010,9 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "finalizepsbt",                 &finalizepsbt,              {"psbt", "extract"} },
     { "rawtransactions",    "createpsbt",                   &createpsbt,                {"inputs","outputs","locktime","replaceable"} },
     { "rawtransactions",    "converttopsbt",                &converttopsbt,             {"hexstring","permitsigdata"} },
+
+    { "rawtransactions",    "decodepstt",                   &decodepstt,                {"pstt"} },
+    { "rawtransactions",    "signpsttwithkey",               &signpsttwithkey,           {"pstt","privkeys","sighashtype","sigscheme"} },
 
     { "blockchain",         "gettxoutproof",                &gettxoutproof,             {"txids", "blockhash"} },
     { "blockchain",         "verifytxoutproof",             &verifytxoutproof,          {"proof"} },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1711,8 +1711,8 @@ static void PsttInputToUniv(const PSTTInput& input, UniValue& in)
         in.pushKV("partial_signatures", partial_sigs);
     }
 
-    if (input.sighash_type > 0) {
-        in.pushKV("sighash", SighashToStr((unsigned char)input.sighash_type));
+    if (input.sighash_type) {
+        in.pushKV("sighash", SighashToStr((unsigned char)*input.sighash_type));
     }
 
     if (!input.redeem_script.empty()) {
@@ -1967,7 +1967,7 @@ UniValue combinepstt(const JSONRPCRequest& request)
 // derivation.
 static int FinalizeSighashFor(const PSTTInput& input)
 {
-    return input.sighash_type > 0 ? input.sighash_type : SIGHASH_ALL;
+    return input.sighash_type ? *input.sighash_type : SIGHASH_ALL;
 }
 
 static SignatureScheme FinalizeSigSchemeFor(const PSTTInput& input)
@@ -2041,7 +2041,7 @@ UniValue finalizepstt(const JSONRPCRequest& request)
         // Finalizer field policy: keep required fields, PSTT_IN_UTXO and
         // unknowns; strip everything only useful during signing.
         input.partial_sigs.clear();
-        input.sighash_type = 0;
+        input.sighash_type = boost::none;
         input.redeem_script.clear();
         input.hd_keypaths.clear();
         input.ripemd160_preimages.clear();

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1900,6 +1900,209 @@ UniValue decodepstt(const JSONRPCRequest& request)
     return result;
 }
 
+UniValue combinepstt(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "combinepstt [\"pstt\",...]\n"
+            "\nCombine multiple partially signed Tapyrus transactions that all refer to\n"
+            "the same underlying transaction into one. Implements the Combiner role.\n"
+
+            "\nArguments:\n"
+            "1. \"txs\"                   (string) A json array of base64 strings of partially signed transactions\n"
+            "    [\n"
+            "      \"pstt\"             (string) A base64 string of a PSTT\n"
+            "      ,...\n"
+            "    ]\n"
+
+            "\nResult:\n"
+            "  \"pstt\"          (string) The base64-encoded combined partially signed transaction\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("combinepstt", "[\"mybase64_1\", \"mybase64_2\", \"mybase64_3\"]")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VARR}, true);
+
+    std::vector<PartiallySignedTapyrusTransaction> psttxs;
+    UniValue txs = request.params[0].get_array();
+    for (unsigned int i = 0; i < txs.size(); ++i) {
+        PartiallySignedTapyrusTransaction pstt;
+        std::string error;
+        if (!DecodePSTT(pstt, txs[i].get_str(), error)) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+        }
+        psttxs.push_back(pstt);
+    }
+
+    if (psttxs.empty()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'txs' cannot be empty");
+    }
+
+    PartiallySignedTapyrusTransaction merged_pstt(psttxs[0]);
+    for (auto it = std::next(psttxs.begin()); it != psttxs.end(); ++it) {
+        if (!merged_pstt.HasSameIdentifierAs(*it)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "PSTTs do not refer to the same transaction.");
+        }
+        try {
+            merged_pstt.Merge(*it);
+        } catch (const std::invalid_argument& e) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Cannot combine PSTTs: %s", e.what()));
+        }
+    }
+    if (!merged_pstt.IsSane()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Merged PSTT is inconsistent");
+    }
+
+    return EncodePSTT(merged_pstt);
+}
+
+// The dummy provider's per-input sighash/scheme is derived from what the
+// input itself already carries, not hardcoded: this makes SignPSTTInput's
+// sighash-conflict and scheme-conflict pre-checks unreachable here by
+// construction (they can only ever fire against a mismatch with what we
+// pass in), so finalization only ever fails for a genuine structural reason
+// (missing/mismatched UTXO, bad redeem script, contradictory locktime, an
+// out-of-range SIGHASH_SINGLE), never a spurious conflict against our own
+// derivation.
+static int FinalizeSighashFor(const PSTTInput& input)
+{
+    return input.sighash_type > 0 ? input.sighash_type : SIGHASH_ALL;
+}
+
+static SignatureScheme FinalizeSigSchemeFor(const PSTTInput& input)
+{
+    if (input.partial_sigs.empty()) return SignatureScheme::ECDSA;
+    const std::vector<unsigned char>& sig = input.partial_sigs.begin()->second.second;
+    return sig.size() == CPubKey::COMPACT_SIGNATURE_SIZE ? SignatureScheme::SCHNORR : SignatureScheme::ECDSA;
+}
+
+UniValue finalizepstt(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
+        throw std::runtime_error(
+            "finalizepstt \"pstt\" ( extract )\n"
+            "\nFinalize the inputs of a PSTT. If every input is fully signed, produces a\n"
+            "network-serialized transaction that can be broadcast with sendrawtransaction.\n"
+            "Otherwise returns a PSTT with PSTT_IN_FINAL_SCRIPTSIG filled in for the inputs\n"
+            "that are complete. Implements the Finalizer and (optionally) Extractor roles.\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"                 (string, required) A base64 string of a PSTT\n"
+            "2. \"extract\"              (boolean, optional, default=true) If true and the transaction is complete,\n"
+            "                             extract and return the complete transaction in normal network serialization\n"
+            "                             instead of the PSTT.\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"pstt\" : \"value\",          (string) The base64-encoded partially signed transaction if not extracted\n"
+            "  \"hex\" : \"value\",           (string) The hex-encoded network transaction if extracted\n"
+            "  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("finalizepstt", "\"pstt\"")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL}, true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    if (pstt.tx_modifiable && (*pstt.tx_modifiable & (PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE)) != 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "PSTT construction is not finished (inputs and/or outputs are still modifiable)");
+    }
+
+    bool complete = true;
+    for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
+        PSTTInput& input = pstt.inputs.at(i);
+        if (!input.final_script_sig.empty()) continue; // already finalized
+
+        SignatureData sigdata;
+        PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, i, sigdata,
+                                               FinalizeSighashFor(input), FinalizeSigSchemeFor(input));
+        if (result == PSTTSignResult::MISSING_UTXO) {
+            complete = false;
+            continue;
+        }
+        if (result != PSTTSignResult::OK) {
+            throw JSONRPCError(RPC_TRANSACTION_ERROR, strprintf("Finalizing input %d failed: %s", i, PSTTSignResultToString(result)));
+        }
+
+        input.FromSignatureData(sigdata);
+        if (!sigdata.complete) {
+            complete = false;
+            continue;
+        }
+
+        // Finalizer field policy: keep required fields, PSTT_IN_UTXO and
+        // unknowns; strip everything only useful during signing.
+        input.partial_sigs.clear();
+        input.sighash_type = 0;
+        input.redeem_script.clear();
+        input.hd_keypaths.clear();
+        input.ripemd160_preimages.clear();
+        input.sha256_preimages.clear();
+        input.hash160_preimages.clear();
+        input.hash256_preimages.clear();
+    }
+
+    UniValue result(UniValue::VOBJ);
+    bool extract = request.params[1].isNull() || request.params[1].get_bool();
+    if (complete && extract) {
+        CMutableTransaction mtx = ExtractPSTT(pstt);
+        CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+        ssTx << mtx;
+        result.pushKV("hex", HexStr(ssTx.begin(), ssTx.end()));
+    } else {
+        result.pushKV("pstt", EncodePSTT(pstt));
+    }
+    result.pushKV("complete", complete);
+    return result;
+}
+
+UniValue extractpstt(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "extractpstt \"pstt\"\n"
+            "\nExtract the fully signed transaction from a PSTT and return it in network\n"
+            "serialization, ready to be broadcast with sendrawtransaction. Implements the\n"
+            "Transaction Extractor role. Throws if any input is missing PSTT_IN_FINAL_SCRIPTSIG.\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"                 (string, required) A base64 string of a PSTT\n"
+
+            "\nResult:\n"
+            "  \"hex\"              (string) The hex-encoded network transaction\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("extractpstt", "\"pstt\"")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR});
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    CMutableTransaction mtx;
+    try {
+        mtx = ExtractPSTT(pstt);
+    } catch (const std::runtime_error& e) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, e.what());
+    }
+
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << mtx;
+    return HexStr(ssTx.begin(), ssTx.end());
+}
+
 UniValue signpsttwithkey(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 4)
@@ -2012,6 +2215,9 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "converttopsbt",                &converttopsbt,             {"hexstring","permitsigdata"} },
 
     { "rawtransactions",    "decodepstt",                   &decodepstt,                {"pstt"} },
+    { "rawtransactions",    "combinepstt",                  &combinepstt,               {"txs"} },
+    { "rawtransactions",    "finalizepstt",                 &finalizepstt,              {"pstt", "extract"} },
+    { "rawtransactions",    "extractpstt",                  &extractpstt,               {"pstt"} },
     { "rawtransactions",    "signpsttwithkey",               &signpsttwithkey,           {"pstt","privkeys","sighashtype","sigscheme"} },
 
     { "blockchain",         "gettxoutproof",                &gettxoutproof,             {"txids", "blockhash"} },

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -185,6 +185,7 @@ if(ENABLE_WALLET)
             ../wallet/test/wallet_tests.cpp
             ../wallet/test/create_transaction_tests.cpp
             ../wallet/test/test_tapyrus_wallet.cpp
+            ../wallet/test/pstt_wallet_tests.cpp
     )
 endif()
 

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -10,7 +10,9 @@
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <key.h>
+#include <key_io.h>
 #include <policy/policy.h>
+#include <random.h>
 #include <rpc/server.h>
 #include <script/script.h>
 #include <script/standard.h>
@@ -1073,6 +1075,254 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_extractpstt_throws_when_incomplete, TestingSetu
     extractParams.push_back(EncodePSTT(MakeBasicPstt()));
 
     BOOST_CHECK_THROW(CallPsttRPC("extractpstt", extractParams), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_signpsttwithkey_p2pk_coinbase_spend, TestChainSetup)
+{
+    // Same shape as pstt_extract_valid_p2pk_coinbase_spend, but signed
+    // through the real registered signpsttwithkey actor (tableRPC) instead
+    // of calling SignPSTTInput directly -- covers WIF-string parsing,
+    // sighash/sigscheme string parsing, and the pstt/complete JSON result.
+    const CTransactionRef& prevTx = m_coinbase_txns[0];
+    CKey destKey;
+    destKey.MakeNewKey(true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = prevTx->GetHashMalFix();
+    input.prev_out_index = 0;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    input.utxo = prevTx;
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = prevTx->vout[0].nValue - CENT;
+    output.script = P2PKHScriptFor(destKey);
+    pstt.outputs.push_back(output);
+
+    UniValue keys(UniValue::VARR);
+    keys.push_back(EncodeSecret(coinbaseKey));
+
+    UniValue signParams(UniValue::VARR);
+    signParams.push_back(EncodePSTT(pstt));
+    signParams.push_back(keys);
+    UniValue signResult = CallPsttRPC("signpsttwithkey", signParams);
+    BOOST_REQUIRE(signResult.isObject());
+    BOOST_CHECK(signResult.find_value("complete").get_bool());
+
+    PartiallySignedTapyrusTransaction signedPstt;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(signedPstt, signResult.find_value("pstt").get_str(), decodeError));
+    BOOST_CHECK(!signedPstt.inputs[0].final_script_sig.empty());
+
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(signedPstt)), true);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_signpsttwithkey_rejects_invalid_sigscheme, TestingSetup)
+{
+    // Confirms the RPC handler itself (not just ParseSigSchemeString in
+    // isolation) rejects an unrecognized sigscheme string rather than
+    // silently falling back to ECDSA. CallPsttRPC invokes the registered
+    // actor function pointer directly, bypassing the JSON-RPC dispatch
+    // wrapper (rpc/server.cpp) that would otherwise convert a bare
+    // std::exception into a UniValue JSONRPCError for a real client -- so
+    // here the raw std::runtime_error ParseSigSchemeString throws is what
+    // surfaces, unlike the JSONRPCError-based throws elsewhere in this file.
+    UniValue keys(UniValue::VARR);
+
+    UniValue signParams(UniValue::VARR);
+    signParams.push_back(EncodePSTT(MakeBasicPstt()));
+    signParams.push_back(keys);
+    signParams.push_back(UniValue("ALL"));
+    signParams.push_back(UniValue("Schnorr")); // wrong case -- must not silently mean SCHNORR or ECDSA
+
+    BOOST_CHECK_THROW(CallPsttRPC("signpsttwithkey", signParams), std::runtime_error);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_strips_signing_only_fields, TestChainSetup)
+{
+    // finalizepstt's field-strip policy (rawtransaction.cpp) is meant to
+    // clear everything only useful during signing once an input is
+    // finalized. PSTTInput::FromSignatureData already clears partial_sigs/
+    // hd_keypaths/redeem_script itself on completion, so to actually
+    // exercise finalizepstt's own explicit strip statements this attaches
+    // fields FromSignatureData never touches (sighash_type, a preimage).
+    MultisigSpendPair fx = MakeUnmergedMultisigSpendPair(*this);
+    PartiallySignedTapyrusTransaction merged = fx.signedByA;
+    merged.Merge(fx.signedByB);
+    BOOST_REQUIRE_EQUAL(merged.inputs[0].partial_sigs.size(), 2U);
+    BOOST_REQUIRE(merged.inputs[0].final_script_sig.empty());
+
+    merged.inputs[0].sighash_type = SIGHASH_ALL;
+    merged.inputs[0].ripemd160_preimages[std::vector<unsigned char>(20, 0xAB)] = std::vector<unsigned char>{0x01, 0x02};
+
+    UniValue finalizeParams(UniValue::VARR);
+    finalizeParams.push_back(EncodePSTT(merged));
+    finalizeParams.push_back(UniValue(false)); // extract=false -- inspect the PSTT, not the extracted tx
+    UniValue finalizeResult = CallPsttRPC("finalizepstt", finalizeParams);
+    BOOST_REQUIRE(finalizeResult.find_value("complete").get_bool());
+
+    PartiallySignedTapyrusTransaction finalized;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(finalized, finalizeResult.find_value("pstt").get_str(), decodeError));
+
+    const PSTTInput& in = finalized.inputs[0];
+    BOOST_CHECK(!in.final_script_sig.empty());
+    BOOST_CHECK(in.partial_sigs.empty());
+    BOOST_CHECK(!in.sighash_type);
+    BOOST_CHECK(in.redeem_script.empty());
+    BOOST_CHECK(in.hd_keypaths.empty());
+    BOOST_CHECK(in.ripemd160_preimages.empty());
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_partial_completion_mixed_missing_utxo, TestChainSetup)
+{
+    // Input 0 has both required multisig partial sigs already (finalizepstt
+    // can complete it). Input 1 has a previous_txid/prev_out_index but no
+    // attached UTXO at all -- as if a co-signer's Constructor/Updater step
+    // hasn't happened yet. finalizepstt must finalize what it can and
+    // report complete=false for the whole PSTT, not throw.
+    //
+    // Both inputs must be part of the transaction shape from the moment
+    // each cosigner signs -- SIGHASH_ALL covers every input's prevout, so
+    // appending input 1 only after input 0 was already signed (as a plain
+    // reuse of MakeUnmergedMultisigSpendPair's 1-input fixture would do)
+    // changes the signed tx shape and invalidates both partial sigs.
+    CKey keyA, keyB;
+    keyA.MakeNewKey(true);
+    keyB.MakeNewKey(true);
+    CScript redeemScript = GetScriptForMultisig(2, {keyA.GetPubKey(), keyB.GetPubKey()});
+    CScript scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
+
+    const CTransactionRef& coinbaseTx = m_coinbase_txns[0];
+    PartiallySignedTapyrusTransaction fundingPstt;
+    fundingPstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput fundingInput;
+    fundingInput.previous_txid = coinbaseTx->GetHashMalFix();
+    fundingInput.prev_out_index = 0;
+    fundingInput.previous_txid_set = true;
+    fundingInput.prev_out_index_set = true;
+    fundingInput.utxo = coinbaseTx;
+    fundingPstt.inputs.push_back(fundingInput);
+    PSTTOutput fundingOutput;
+    fundingOutput.amount = coinbaseTx->vout[0].nValue - CENT;
+    fundingOutput.script = scriptPubKey;
+    fundingPstt.outputs.push_back(fundingOutput);
+    FlatSigningProvider fundingProvider;
+    fundingProvider.keys[coinbaseKey.GetPubKey().GetID()] = coinbaseKey;
+    SignInputForTest(fundingPstt, 0, fundingProvider);
+    CTransactionRef multisigUtxo = MakeTransactionRef(ExtractPSTT(fundingPstt));
+    CheckMempoolResult(*this, multisigUtxo, true);
+
+    CKey destKey;
+    destKey.MakeNewKey(true);
+    uint256 missingUtxoTxid = GetRandHash(); // same placeholder on both sides, so Merge() sees matching inputs
+
+    auto makeSpend = [&]() {
+        PartiallySignedTapyrusTransaction pstt;
+        pstt.tx_features = CTransaction::CURRENT_FEATURES;
+
+        PSTTInput multisigInput;
+        multisigInput.previous_txid = multisigUtxo->GetHashMalFix();
+        multisigInput.prev_out_index = 0;
+        multisigInput.previous_txid_set = true;
+        multisigInput.prev_out_index_set = true;
+        multisigInput.utxo = multisigUtxo;
+        multisigInput.redeem_script = redeemScript;
+        pstt.inputs.push_back(multisigInput);
+
+        PSTTInput missingUtxoInput;
+        missingUtxoInput.previous_txid = missingUtxoTxid;
+        missingUtxoInput.prev_out_index = 0;
+        missingUtxoInput.previous_txid_set = true;
+        missingUtxoInput.prev_out_index_set = true;
+        pstt.inputs.push_back(missingUtxoInput);
+
+        PSTTOutput output;
+        output.amount = multisigUtxo->vout[0].nValue - CENT;
+        output.script = P2PKHScriptFor(destKey);
+        pstt.outputs.push_back(output);
+        return pstt;
+    };
+
+    PartiallySignedTapyrusTransaction signedByA = makeSpend();
+    FlatSigningProvider providerA;
+    providerA.keys[keyA.GetPubKey().GetID()] = keyA;
+    SignatureData sigdataA;
+    BOOST_REQUIRE(SignPSTTInput(providerA, signedByA, 0, sigdataA, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    signedByA.inputs[0].FromSignatureData(sigdataA);
+    BOOST_REQUIRE(!sigdataA.complete);
+
+    PartiallySignedTapyrusTransaction signedByB = makeSpend();
+    FlatSigningProvider providerB;
+    providerB.keys[keyB.GetPubKey().GetID()] = keyB;
+    SignatureData sigdataB;
+    BOOST_REQUIRE(SignPSTTInput(providerB, signedByB, 0, sigdataB, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    signedByB.inputs[0].FromSignatureData(sigdataB);
+    BOOST_REQUIRE(!sigdataB.complete);
+
+    PartiallySignedTapyrusTransaction pstt = signedByA;
+    pstt.Merge(signedByB);
+    BOOST_REQUIRE_EQUAL(pstt.inputs[0].partial_sigs.size(), 2U);
+
+    UniValue finalizeParams(UniValue::VARR);
+    finalizeParams.push_back(EncodePSTT(pstt));
+    finalizeParams.push_back(UniValue(false));
+    UniValue finalizeResult = CallPsttRPC("finalizepstt", finalizeParams);
+    BOOST_CHECK(!finalizeResult.find_value("complete").get_bool());
+    BOOST_CHECK(finalizeResult.find_value("hex").isNull());
+
+    PartiallySignedTapyrusTransaction result;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(result, finalizeResult.find_value("pstt").get_str(), decodeError));
+    BOOST_CHECK(!result.inputs[0].final_script_sig.empty()); // completable input got finalized
+    BOOST_CHECK(result.inputs[1].final_script_sig.empty());  // MISSING_UTXO input left alone
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_shape, TestChainSetup)
+{
+    // Asserts decodepstt's JSON shape (top-level keys plus per-input/
+    // per-output nested shapes), not just that it doesn't throw.
+    MultisigSpendPair fx = MakeUnmergedMultisigSpendPair(*this);
+    PartiallySignedTapyrusTransaction pstt = fx.signedByA;
+    pstt.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE;
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_REQUIRE(decoded.isObject());
+    BOOST_CHECK(decoded.exists("tx_features"));
+    BOOST_REQUIRE(decoded.exists("tx_modifiable"));
+    const UniValue& mod = decoded.find_value("tx_modifiable");
+    BOOST_REQUIRE(mod.isObject());
+    BOOST_CHECK(mod.find_value("inputs_modifiable").get_bool());
+    BOOST_CHECK(mod.find_value("outputs_modifiable").get_bool());
+    BOOST_CHECK(!mod.find_value("has_sighash_single").get_bool());
+    BOOST_CHECK(decoded.exists("identification_txid"));
+
+    BOOST_REQUIRE(decoded.exists("inputs"));
+    const UniValue& inputs = decoded.find_value("inputs");
+    BOOST_REQUIRE(inputs.isArray());
+    BOOST_REQUIRE_EQUAL(inputs.size(), 1U);
+    const UniValue& in0 = inputs[0];
+    BOOST_CHECK(in0.exists("previous_txid"));
+    BOOST_CHECK(in0.exists("output_index"));
+    BOOST_CHECK(in0.exists("utxo"));
+    BOOST_REQUIRE(in0.exists("partial_signatures"));
+    BOOST_CHECK(in0.find_value("partial_signatures").isObject());
+    BOOST_CHECK(in0.exists("redeem_script"));
+    BOOST_CHECK(!in0.exists("final_scriptSig")); // not finalized yet
+
+    BOOST_REQUIRE(decoded.exists("outputs"));
+    const UniValue& outputs = decoded.find_value("outputs");
+    BOOST_REQUIRE(outputs.isArray());
+    BOOST_REQUIRE_EQUAL(outputs.size(), 1U);
+    const UniValue& out0 = outputs[0];
+    BOOST_CHECK(out0.exists("amount_raw"));
+    BOOST_CHECK(out0.exists("script"));
 }
 
 // -----------------------------------------------------------------------

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -8,8 +8,10 @@
 #include <chainparams.h>
 #include <coloridentifier.h>
 #include <consensus/validation.h>
+#include <core_io.h>
 #include <key.h>
 #include <policy/policy.h>
+#include <rpc/server.h>
 #include <script/script.h>
 #include <script/standard.h>
 #include <streams.h>
@@ -845,12 +847,21 @@ BOOST_AUTO_TEST_CASE(pstt_merge_picks_first_on_sighash_type_conflict)
 }
 
 // -----------------------------------------------------------------------
-// End-to-end Combine -> Finalize -> Extract, mirroring the finalizepstt RPC's
-// completeness detection (SignPSTTInput against an empty/dummy provider)
-// without depending on the RPC layer itself.
+// Shared fixture: funds a 2-of-2 P2SH multisig UTXO and returns two
+// independently-signed (one key each), not-yet-merged spends of it. Reused
+// by both the library-level Combine/Finalize/Extract test below and the
+// RPC-dispatch-level tests further down.
 // -----------------------------------------------------------------------
 
-BOOST_FIXTURE_TEST_CASE(pstt_combine_finalize_extract_p2sh_multisig, TestChainSetup)
+struct MultisigSpendPair
+{
+    CScript redeemScript;
+    CTransactionRef multisigUtxo;
+    PartiallySignedTapyrusTransaction signedByA; // one of two required signatures
+    PartiallySignedTapyrusTransaction signedByB; // the other
+};
+
+static MultisigSpendPair MakeUnmergedMultisigSpendPair(TestChainSetup& setup)
 {
     CKey keyA, keyB;
     keyA.MakeNewKey(true);
@@ -858,7 +869,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_combine_finalize_extract_p2sh_multisig, TestChainSe
     CScript redeemScript = GetScriptForMultisig(2, {keyA.GetPubKey(), keyB.GetPubKey()});
     CScript scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
 
-    const CTransactionRef& coinbaseTx = m_coinbase_txns[0];
+    const CTransactionRef& coinbaseTx = setup.m_coinbase_txns[0];
     PartiallySignedTapyrusTransaction fundingPstt;
     fundingPstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput fundingInput;
@@ -874,10 +885,10 @@ BOOST_FIXTURE_TEST_CASE(pstt_combine_finalize_extract_p2sh_multisig, TestChainSe
     fundingPstt.outputs.push_back(fundingOutput);
 
     FlatSigningProvider fundingProvider;
-    fundingProvider.keys[coinbaseKey.GetPubKey().GetID()] = coinbaseKey;
+    fundingProvider.keys[setup.coinbaseKey.GetPubKey().GetID()] = setup.coinbaseKey;
     SignInputForTest(fundingPstt, 0, fundingProvider);
     CTransactionRef multisigUtxo = MakeTransactionRef(ExtractPSTT(fundingPstt));
-    CheckMempoolResult(*this, multisigUtxo, true);
+    CheckMempoolResult(setup, multisigUtxo, true);
 
     // Two independent parties each build the same spend and sign it with
     // their own key only.
@@ -901,39 +912,167 @@ BOOST_FIXTURE_TEST_CASE(pstt_combine_finalize_extract_p2sh_multisig, TestChainSe
         return pstt;
     };
 
-    PartiallySignedTapyrusTransaction pstt1 = makeSpend();
+    PartiallySignedTapyrusTransaction signedByA = makeSpend();
     FlatSigningProvider providerA;
     providerA.keys[keyA.GetPubKey().GetID()] = keyA;
     SignatureData sigdataA;
-    BOOST_REQUIRE(SignPSTTInput(providerA, pstt1, 0, sigdataA, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
-    pstt1.inputs[0].FromSignatureData(sigdataA);
-    BOOST_CHECK(!sigdataA.complete); // one of two required signatures
+    BOOST_REQUIRE(SignPSTTInput(providerA, signedByA, 0, sigdataA, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    signedByA.inputs[0].FromSignatureData(sigdataA);
+    BOOST_REQUIRE(!sigdataA.complete);
 
-    PartiallySignedTapyrusTransaction pstt2 = makeSpend();
+    PartiallySignedTapyrusTransaction signedByB = makeSpend();
     FlatSigningProvider providerB;
     providerB.keys[keyB.GetPubKey().GetID()] = keyB;
     SignatureData sigdataB;
-    BOOST_REQUIRE(SignPSTTInput(providerB, pstt2, 0, sigdataB, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
-    pstt2.inputs[0].FromSignatureData(sigdataB);
-    BOOST_CHECK(!sigdataB.complete);
+    BOOST_REQUIRE(SignPSTTInput(providerB, signedByB, 0, sigdataB, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    signedByB.inputs[0].FromSignatureData(sigdataB);
+    BOOST_REQUIRE(!sigdataB.complete);
+
+    return {redeemScript, multisigUtxo, signedByA, signedByB};
+}
+
+// -----------------------------------------------------------------------
+// End-to-end Combine -> Finalize -> Extract, mirroring the finalizepstt RPC's
+// completeness detection (SignPSTTInput against an empty/dummy provider)
+// without depending on the RPC layer itself.
+// -----------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(pstt_combine_finalize_extract_p2sh_multisig, TestChainSetup)
+{
+    MultisigSpendPair fx = MakeUnmergedMultisigSpendPair(*this);
+    PartiallySignedTapyrusTransaction merged = fx.signedByA;
 
     // Combiner: merge the two independently-signed copies.
-    BOOST_REQUIRE(pstt1.HasSameIdentifierAs(pstt2));
-    pstt1.Merge(pstt2);
-    BOOST_CHECK(pstt1.IsSane());
-    BOOST_CHECK_EQUAL(pstt1.inputs[0].partial_sigs.size(), 2U);
+    BOOST_REQUIRE(merged.HasSameIdentifierAs(fx.signedByB));
+    merged.Merge(fx.signedByB);
+    BOOST_CHECK(merged.IsSane());
+    BOOST_CHECK_EQUAL(merged.inputs[0].partial_sigs.size(), 2U);
 
     // Finalizer: mirrors finalizepstt's DUMMY_SIGNING_PROVIDER completeness
     // check -- an empty provider can't add new signatures, only combine the
     // two partial ones already present into a complete scriptSig.
     SignatureData finalSigdata;
-    BOOST_REQUIRE(SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt1, 0, finalSigdata, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    BOOST_REQUIRE(SignPSTTInput(DUMMY_SIGNING_PROVIDER, merged, 0, finalSigdata, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
     BOOST_CHECK(finalSigdata.complete);
-    pstt1.inputs[0].FromSignatureData(finalSigdata);
-    BOOST_CHECK(!pstt1.inputs[0].final_script_sig.empty());
+    merged.inputs[0].FromSignatureData(finalSigdata);
+    BOOST_CHECK(!merged.inputs[0].final_script_sig.empty());
 
     // Extractor: produces a sendrawtransaction-acceptable transaction.
-    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(pstt1)), true);
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(merged)), true);
+}
+
+// -----------------------------------------------------------------------
+// RPC-dispatch-level tests. The tests above exercise SignPSTTInput/Merge/
+// ExtractPSTT directly; these instead go through the real registered
+// combinepstt/finalizepstt/extractpstt actors (tableRPC), so argument
+// parsing, base64/JSON encoding, and error wrapping are covered too, not
+// just the pstt.cpp library calls underneath them.
+// -----------------------------------------------------------------------
+
+static UniValue CallPsttRPC(const std::string& method, const UniValue& params)
+{
+    BOOST_REQUIRE(tableRPC[method]);
+    JSONRPCRequest request;
+    request.strMethod = method;
+    request.params = params;
+    request.fHelp = false;
+    rpcfn_type fn = tableRPC[method]->actor;
+    return (*fn)(request);
+}
+
+static CMutableTransaction DecodeHexTxForTest(const std::string& hex)
+{
+    CDataStream ss(ParseHex(hex), SER_NETWORK, PROTOCOL_VERSION);
+    CMutableTransaction mtx;
+    ss >> mtx;
+    return mtx;
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_combine_finalize_extract_roundtrip, TestChainSetup)
+{
+    MultisigSpendPair fx = MakeUnmergedMultisigSpendPair(*this);
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(fx.signedByA));
+    txs.push_back(EncodePSTT(fx.signedByB));
+    UniValue combineParams(UniValue::VARR);
+    combineParams.push_back(txs);
+    UniValue combined = CallPsttRPC("combinepstt", combineParams);
+    BOOST_REQUIRE(combined.isStr());
+
+    PartiallySignedTapyrusTransaction mergedPstt;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(mergedPstt, combined.get_str(), decodeError));
+    BOOST_CHECK_EQUAL(mergedPstt.inputs[0].partial_sigs.size(), 2U);
+
+    UniValue finalizeParams(UniValue::VARR);
+    finalizeParams.push_back(combined.get_str());
+    finalizeParams.push_back(UniValue(true));
+    UniValue finalizeResult = CallPsttRPC("finalizepstt", finalizeParams);
+    BOOST_REQUIRE(finalizeResult.isObject());
+    BOOST_CHECK(finalizeResult.find_value("complete").get_bool());
+
+    CTransactionRef finalTx = MakeTransactionRef(DecodeHexTxForTest(finalizeResult.find_value("hex").get_str()));
+    CheckMempoolResult(*this, finalTx, true);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_no_extract_then_extractpstt, TestChainSetup)
+{
+    MultisigSpendPair fx = MakeUnmergedMultisigSpendPair(*this);
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(fx.signedByA));
+    txs.push_back(EncodePSTT(fx.signedByB));
+    UniValue combineParams(UniValue::VARR);
+    combineParams.push_back(txs);
+    UniValue combined = CallPsttRPC("combinepstt", combineParams);
+
+    UniValue finalizeParams(UniValue::VARR);
+    finalizeParams.push_back(combined.get_str());
+    finalizeParams.push_back(UniValue(false)); // extract=false -> expect a "pstt" field back, not "hex"
+    UniValue finalizeResult = CallPsttRPC("finalizepstt", finalizeParams);
+    BOOST_CHECK(finalizeResult.find_value("complete").get_bool());
+    BOOST_CHECK(finalizeResult.find_value("hex").isNull());
+    std::string finalizedPsttB64 = finalizeResult.find_value("pstt").get_str();
+
+    UniValue extractParams(UniValue::VARR);
+    extractParams.push_back(finalizedPsttB64);
+    UniValue extracted = CallPsttRPC("extractpstt", extractParams);
+    BOOST_REQUIRE(extracted.isStr());
+
+    CTransactionRef finalTx = MakeTransactionRef(DecodeHexTxForTest(extracted.get_str()));
+    CheckMempoolResult(*this, finalTx, true);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_combinepstt_rejects_different_identifiers, TestingSetup)
+{
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(MakeBasicPstt()));
+    txs.push_back(EncodePSTT(MakeBasicPstt())); // fresh random utxo/scripts -> different identifier
+    UniValue combineParams(UniValue::VARR);
+    combineParams.push_back(txs);
+
+    BOOST_CHECK_THROW(CallPsttRPC("combinepstt", combineParams), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_refuses_while_modifiable, TestingSetup)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE;
+
+    UniValue finalizeParams(UniValue::VARR);
+    finalizeParams.push_back(EncodePSTT(pstt));
+
+    BOOST_CHECK_THROW(CallPsttRPC("finalizepstt", finalizeParams), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_extractpstt_throws_when_incomplete, TestingSetup)
+{
+    // No final_script_sig on the one input -- not finalized yet.
+    UniValue extractParams(UniValue::VARR);
+    extractParams.push_back(EncodePSTT(MakeBasicPstt()));
+
+    BOOST_CHECK_THROW(CallPsttRPC("extractpstt", extractParams), UniValue);
 }
 
 // -----------------------------------------------------------------------

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -11,6 +11,7 @@
 #include <key.h>
 #include <policy/policy.h>
 #include <script/script.h>
+#include <script/standard.h>
 #include <streams.h>
 #include <test/test_tapyrus.h>
 #include <txmempool.h>
@@ -467,33 +468,10 @@ BOOST_AUTO_TEST_CASE(pstt_tx_features_roundtrip_any_value)
 // the PSTT pipeline (Creator/Updater/Signer/Extractor) instead of being
 // hand-built with a manually constructed scriptSig.
 //
-// ExtractForTest is a test-local reconstruction, not a call into pstt.cpp:
-// pstt.h has no public Extractor API yet (that's Finalizer/Extractor role
-// work), so this mirrors pstt.cpp's private MaterializeTransaction
-// (use_final_scriptsig=true) closely enough for these tests without
-// depending on unexported internals.
+// Phase 3 added a real, public Extractor (pstt.h's ExtractPSTT) -- these
+// tests now call it directly instead of the test-local reconstruction that
+// used to stand in for it.
 // -----------------------------------------------------------------------
-
-static CMutableTransaction ExtractForTest(const PartiallySignedTapyrusTransaction& pstt)
-{
-    uint32_t locktime;
-    BOOST_REQUIRE(ComputeLocktime(pstt, locktime));
-    CMutableTransaction mtx;
-    mtx.nFeatures = pstt.tx_features.value_or(CTransaction::CURRENT_FEATURES);
-    mtx.nLockTime = locktime;
-    for (const PSTTInput& input : pstt.inputs) {
-        BOOST_REQUIRE(!input.final_script_sig.empty());
-        CTxIn txin;
-        txin.prevout = COutPoint(input.previous_txid, input.prev_out_index);
-        txin.nSequence = input.sequence.value_or(0xFFFFFFFFu);
-        txin.scriptSig = input.final_script_sig;
-        mtx.vin.push_back(std::move(txin));
-    }
-    for (const PSTTOutput& output : pstt.outputs) {
-        mtx.vout.emplace_back(output.amount.value_or(0), output.script);
-    }
-    return mtx;
-}
 
 // Signs input `index` in place: runs SignPSTTInput, then applies
 // FromSignatureData to store the result, mirroring what a real Signer RPC
@@ -565,7 +543,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_p2pk_coinbase_spend, TestChainSetup)
 
     SignInputForTest(pstt, 0, provider);
 
-    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(pstt)), true);
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(pstt)), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_schnorr_spend, TestChainSetup)
@@ -596,7 +574,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_schnorr_spend, TestChainSetup)
 
     SignInputForTest(pstt, 0, provider, SignatureScheme::SCHNORR);
 
-    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(pstt)), true);
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(pstt)), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_wrong_key, TestChainSetup)
@@ -661,7 +639,7 @@ static std::pair<CTransactionRef, CKey> MakeConfirmedP2PKHCoin(TestChainSetup& s
     provider.keys[setup.coinbaseKey.GetPubKey().GetID()] = setup.coinbaseKey;
     SignInputForTest(pstt, 0, provider);
 
-    CTransactionRef tx = MakeTransactionRef(ExtractForTest(pstt));
+    CTransactionRef tx = MakeTransactionRef(ExtractPSTT(pstt));
     CheckMempoolResult(setup, tx, true);
     return {tx, destKey};
 }
@@ -700,7 +678,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_colored_issue_and_transfer, TestChain
     issueProvider.pubkeys[issuerKey.GetPubKey().GetID()] = issuerKey.GetPubKey();
     SignInputForTest(issuePstt, 0, issueProvider);
 
-    CTransactionRef issueTx = MakeTransactionRef(ExtractForTest(issuePstt));
+    CTransactionRef issueTx = MakeTransactionRef(ExtractPSTT(issuePstt));
     CheckMempoolResult(*this, issueTx, true);
 
     // Transfer the colored coin, paying the TPC fee from a second coinbase spend
@@ -750,7 +728,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_colored_issue_and_transfer, TestChain
     feeProvider.pubkeys[feeKey.GetPubKey().GetID()] = feeKey.GetPubKey();
     SignInputForTest(transferPstt, 1, feeProvider);
 
-    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(transferPstt)), true);
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(transferPstt)), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_token_without_fee, TestChainSetup)
@@ -788,7 +766,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_token_without_fee, TestChainSetup)
     issueProvider.pubkeys[issuerKey.GetPubKey().GetID()] = issuerKey.GetPubKey();
     SignInputForTest(issuePstt, 0, issueProvider);
 
-    CTransactionRef issueTx = MakeTransactionRef(ExtractForTest(issuePstt));
+    CTransactionRef issueTx = MakeTransactionRef(ExtractPSTT(issuePstt));
     CheckMempoolResult(*this, issueTx, true);
 
     CKey recipientKey;
@@ -817,7 +795,145 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_token_without_fee, TestChainSetup)
     coloredProvider.pubkeys[holderKey.GetPubKey().GetID()] = holderKey.GetPubKey();
     SignInputForTest(transferPstt, 0, coloredProvider);
 
-    CheckMempoolResult(*this, MakeTransactionRef(ExtractForTest(transferPstt)), false, "bad-txns-token-without-fee");
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(transferPstt)), false, "bad-txns-token-without-fee");
+}
+
+// -----------------------------------------------------------------------
+// Extractor
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_extractpstt_throws_on_missing_final_scriptsig)
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    // No final_script_sig set on the one input -- not finalized yet.
+    BOOST_CHECK_THROW(ExtractPSTT(pstt), std::runtime_error);
+}
+
+// -----------------------------------------------------------------------
+// Combiner (Merge conflict policy)
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_merge_refuses_conflicting_partial_sig)
+{
+    PartiallySignedTapyrusTransaction a = MakeBasicPstt();
+    PartiallySignedTapyrusTransaction b = a;
+
+    CKey key;
+    key.MakeNewKey(true);
+    std::vector<unsigned char> sig1(71, 0x11);
+    sig1.push_back(SIGHASH_ALL);
+    std::vector<unsigned char> sig2(71, 0x22);
+    sig2.push_back(SIGHASH_ALL);
+    a.inputs[0].partial_sigs.emplace(key.GetPubKey().GetID(), SigPair(key.GetPubKey(), sig1));
+    b.inputs[0].partial_sigs.emplace(key.GetPubKey().GetID(), SigPair(key.GetPubKey(), sig2));
+
+    BOOST_CHECK_THROW(a.Merge(b), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_merge_picks_first_on_sighash_type_conflict)
+{
+    // PSTT_IN_SIGHASH_TYPE is explicitly in the pick-first tier (not
+    // refuse, not must-match): harmless duplication of a neutral field
+    // should merge silently, keeping whichever side merges into.
+    PartiallySignedTapyrusTransaction a = MakeBasicPstt();
+    PartiallySignedTapyrusTransaction b = a;
+    a.inputs[0].sighash_type = SIGHASH_ALL;
+    b.inputs[0].sighash_type = SIGHASH_NONE;
+
+    BOOST_CHECK_NO_THROW(a.Merge(b));
+    BOOST_CHECK_EQUAL(a.inputs[0].sighash_type, SIGHASH_ALL);
+}
+
+// -----------------------------------------------------------------------
+// End-to-end Combine -> Finalize -> Extract, mirroring the finalizepstt RPC's
+// completeness detection (SignPSTTInput against an empty/dummy provider)
+// without depending on the RPC layer itself.
+// -----------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(pstt_combine_finalize_extract_p2sh_multisig, TestChainSetup)
+{
+    CKey keyA, keyB;
+    keyA.MakeNewKey(true);
+    keyB.MakeNewKey(true);
+    CScript redeemScript = GetScriptForMultisig(2, {keyA.GetPubKey(), keyB.GetPubKey()});
+    CScript scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
+
+    const CTransactionRef& coinbaseTx = m_coinbase_txns[0];
+    PartiallySignedTapyrusTransaction fundingPstt;
+    fundingPstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput fundingInput;
+    fundingInput.previous_txid = coinbaseTx->GetHashMalFix();
+    fundingInput.prev_out_index = 0;
+    fundingInput.previous_txid_set = true;
+    fundingInput.prev_out_index_set = true;
+    fundingInput.utxo = coinbaseTx;
+    fundingPstt.inputs.push_back(fundingInput);
+    PSTTOutput fundingOutput;
+    fundingOutput.amount = coinbaseTx->vout[0].nValue - CENT;
+    fundingOutput.script = scriptPubKey;
+    fundingPstt.outputs.push_back(fundingOutput);
+
+    FlatSigningProvider fundingProvider;
+    fundingProvider.keys[coinbaseKey.GetPubKey().GetID()] = coinbaseKey;
+    SignInputForTest(fundingPstt, 0, fundingProvider);
+    CTransactionRef multisigUtxo = MakeTransactionRef(ExtractPSTT(fundingPstt));
+    CheckMempoolResult(*this, multisigUtxo, true);
+
+    // Two independent parties each build the same spend and sign it with
+    // their own key only.
+    CKey destKey;
+    destKey.MakeNewKey(true);
+    auto makeSpend = [&]() {
+        PartiallySignedTapyrusTransaction pstt;
+        pstt.tx_features = CTransaction::CURRENT_FEATURES;
+        PSTTInput input;
+        input.previous_txid = multisigUtxo->GetHashMalFix();
+        input.prev_out_index = 0;
+        input.previous_txid_set = true;
+        input.prev_out_index_set = true;
+        input.utxo = multisigUtxo;
+        input.redeem_script = redeemScript;
+        pstt.inputs.push_back(input);
+        PSTTOutput output;
+        output.amount = multisigUtxo->vout[0].nValue - CENT;
+        output.script = P2PKHScriptFor(destKey);
+        pstt.outputs.push_back(output);
+        return pstt;
+    };
+
+    PartiallySignedTapyrusTransaction pstt1 = makeSpend();
+    FlatSigningProvider providerA;
+    providerA.keys[keyA.GetPubKey().GetID()] = keyA;
+    SignatureData sigdataA;
+    BOOST_REQUIRE(SignPSTTInput(providerA, pstt1, 0, sigdataA, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    pstt1.inputs[0].FromSignatureData(sigdataA);
+    BOOST_CHECK(!sigdataA.complete); // one of two required signatures
+
+    PartiallySignedTapyrusTransaction pstt2 = makeSpend();
+    FlatSigningProvider providerB;
+    providerB.keys[keyB.GetPubKey().GetID()] = keyB;
+    SignatureData sigdataB;
+    BOOST_REQUIRE(SignPSTTInput(providerB, pstt2, 0, sigdataB, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    pstt2.inputs[0].FromSignatureData(sigdataB);
+    BOOST_CHECK(!sigdataB.complete);
+
+    // Combiner: merge the two independently-signed copies.
+    BOOST_REQUIRE(pstt1.HasSameIdentifierAs(pstt2));
+    pstt1.Merge(pstt2);
+    BOOST_CHECK(pstt1.IsSane());
+    BOOST_CHECK_EQUAL(pstt1.inputs[0].partial_sigs.size(), 2U);
+
+    // Finalizer: mirrors finalizepstt's DUMMY_SIGNING_PROVIDER completeness
+    // check -- an empty provider can't add new signatures, only combine the
+    // two partial ones already present into a complete scriptSig.
+    SignatureData finalSigdata;
+    BOOST_REQUIRE(SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt1, 0, finalSigdata, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    BOOST_CHECK(finalSigdata.complete);
+    pstt1.inputs[0].FromSignatureData(finalSigdata);
+    BOOST_CHECK(!pstt1.inputs[0].final_script_sig.empty());
+
+    // Extractor: produces a sendrawtransaction-acceptable transaction.
+    CheckMempoolResult(*this, MakeTransactionRef(ExtractPSTT(pstt1)), true);
 }
 
 // -----------------------------------------------------------------------

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -843,7 +843,7 @@ BOOST_AUTO_TEST_CASE(pstt_merge_picks_first_on_sighash_type_conflict)
     b.inputs[0].sighash_type = SIGHASH_NONE;
 
     BOOST_CHECK_NO_THROW(a.Merge(b));
-    BOOST_CHECK_EQUAL(a.inputs[0].sighash_type, SIGHASH_ALL);
+    BOOST_CHECK_EQUAL(*a.inputs[0].sighash_type, SIGHASH_ALL);
 }
 
 // -----------------------------------------------------------------------

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(tapyrus_wallet STATIC
         fees.cpp
         init.cpp
         ../interfaces/wallet.cpp
+        pstt.cpp
         rpcdump.cpp
         rpcwallet.cpp
         wallet.cpp

--- a/src/wallet/pstt.cpp
+++ b/src/wallet/pstt.cpp
@@ -33,7 +33,7 @@ bool FillPSTT(const CWallet* pwallet, PartiallySignedTapyrusTransaction& pstt, i
             }
         }
 
-        if (sign && input.sighash_type > 0 && input.sighash_type != sighash_type) {
+        if (sign && input.sighash_type && *input.sighash_type != sighash_type) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Specified Sighash and sighash in PSTT do not match.");
         }
 

--- a/src/wallet/pstt.cpp
+++ b/src/wallet/pstt.cpp
@@ -7,7 +7,6 @@
 #include <coloridentifier.h>
 #include <rpc/protocol.h>
 #include <script/sign.h>
-#include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 
 bool FillPSTT(const CWallet* pwallet, PartiallySignedTapyrusTransaction& pstt, int sighash_type, bool sign,

--- a/src/wallet/pstt.cpp
+++ b/src/wallet/pstt.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/pstt.h>
+
+#include <coloridentifier.h>
+#include <rpc/protocol.h>
+#include <script/sign.h>
+#include <wallet/rpcwallet.h>
+#include <wallet/wallet.h>
+
+bool FillPSTT(const CWallet* pwallet, PartiallySignedTapyrusTransaction& pstt, int sighash_type, bool sign,
+              bool bip32derivs, SignatureScheme sigScheme)
+{
+    LOCK(pwallet->cs_wallet);
+    bool complete = true;
+
+    for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
+        PSTTInput& input = pstt.inputs.at(i);
+
+        // Updater: attach the UTXO from the wallet if we don't already have
+        // one. If we don't know about this input, skip it and let someone
+        // else deal with it -- the Updater must not add/remove/alter inputs,
+        // only fill in fields on what's already there.
+        if (!input.utxo && input.previous_txid_set) {
+            const auto it = pwallet->mapWallet.find(input.previous_txid);
+            if (it != pwallet->mapWallet.end()) {
+                const CWalletTx& wtx = it->second;
+                if (input.prev_out_index_set && input.prev_out_index >= wtx.tx->vout.size()) {
+                    throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Input prevout index out of range");
+                }
+                input.utxo = wtx.tx;
+            }
+        }
+
+        if (sign && input.sighash_type > 0 && input.sighash_type != sighash_type) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Specified Sighash and sighash in PSTT do not match.");
+        }
+
+        if (!input.final_script_sig.empty()) {
+            continue; // already finalized, nothing to update or sign
+        }
+
+        SignatureData sigdata;
+        PSTTSignResult result = sign
+            ? SignPSTTInput(*pwallet, pstt, i, sigdata, sighash_type, sigScheme)
+            : SignPSTTInput(PublicOnlySigningProvider(pwallet), pstt, i, sigdata, sighash_type, sigScheme);
+
+        if (result == PSTTSignResult::MISSING_UTXO) {
+            // Not this call's problem to solve -- an incremental multi-party
+            // PSTT may genuinely have inputs no one has attached a UTXO to
+            // yet; leave it for a later Updater/Signer round.
+            complete = false;
+        } else if (result != PSTTSignResult::OK) {
+            throw JSONRPCError(RPC_TRANSACTION_ERROR,
+                strprintf("Filling/signing input %d failed: %s", i, PSTTSignResultToString(result)));
+        } else {
+            input.FromSignatureData(sigdata);
+            if (!sigdata.complete) complete = false;
+        }
+
+        if (bip32derivs) {
+            for (const auto& pubkey_it : sigdata.misc_pubkeys) {
+                AddKeypathToMap(pwallet, pubkey_it.first, input.hd_keypaths);
+            }
+        }
+    }
+
+    // Fill in BIP32 keypaths for outputs so hardware wallets/watch-only
+    // signers can identify change. Outputs don't need signing, so this uses
+    // a throwaway dummy transaction purely to reuse ProduceSignature's
+    // pubkey-discovery machinery (mirrors FillPSBT's own documented
+    // approach in rpcwallet.cpp: "Dummy tx so we can use ProduceSignature to
+    // get stuff out" -- there, a real embedded tx happened to be available
+    // to piggyback on; PSTT has no such global tx, so the dummy is built
+    // explicitly here instead).
+    if (bip32derivs) {
+        CMutableTransaction dummy_tx;
+        dummy_tx.vin.push_back(CTxIn());
+        for (unsigned int i = 0; i < pstt.outputs.size(); ++i) {
+            const PSTTOutput& output = pstt.outputs.at(i);
+            if (!output.amount || output.script.empty()) continue;
+
+            SignatureData sigdata;
+            output.FillSignatureData(sigdata);
+            MutableTransactionSignatureCreator creator(&dummy_tx, 0, *output.amount, SIGHASH_ALL);
+            ProduceSignature(*pwallet, creator, output.script, sigdata);
+
+            for (const auto& pubkey_it : sigdata.misc_pubkeys) {
+                AddKeypathToMap(pwallet, pubkey_it.first, pstt.outputs.at(i).hd_keypaths);
+            }
+        }
+    }
+
+    return complete;
+}
+
+void ComputePsttColorBalances(const PartiallySignedTapyrusTransaction& pstt,
+                               TxColoredCoinBalancesMap& in, TxColoredCoinBalancesMap& out)
+{
+    for (const PSTTInput& input : pstt.inputs) {
+        if (!input.utxo || !input.prev_out_index_set || input.prev_out_index >= input.utxo->vout.size()) {
+            continue; // color/amount not knowable without an attached UTXO
+        }
+        const CTxOut& utxo_out = input.utxo->vout[input.prev_out_index];
+        ColorIdentifier colorId = GetColorIdFromScript(utxo_out.scriptPubKey);
+        in[colorId] += utxo_out.nValue;
+    }
+    for (const PSTTOutput& output : pstt.outputs) {
+        if (!output.amount || output.script.empty()) continue;
+        ColorIdentifier colorId = GetColorIdFromScript(output.script);
+        out[colorId] += *output.amount;
+    }
+}

--- a/src/wallet/pstt.h
+++ b/src/wallet/pstt.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef TAPYRUS_WALLET_PSTT_H
+#define TAPYRUS_WALLET_PSTT_H
+
+#include <coloridentifier.h>
+#include <pstt.h>
+
+class CWallet;
+
+/** The real Updater (see doc/tapyrus/pstt.md): attaches PSTT_IN_UTXO from
+ *  mapWallet for any input that doesn't already have one, PSTT_IN_REDEEM_SCRIPT
+ *  via the wallet's own SigningProvider::GetCScript, *_BIP32_DERIVATION records
+ *  for both inputs and outputs (if bip32derivs), and never adds/removes/
+ *  reorders inputs or outputs -- only ever mutates fields on what's already
+ *  there.
+ *
+ *  If sign is true, also acts as the Signer: attempts SignPSTTInput on every
+ *  input that isn't already finalized, using the wallet's real keys. If sign
+ *  is false, the same signing pass still runs but through a public-keys-only
+ *  view of the wallet (PublicOnlySigningProvider), so redeem scripts and
+ *  BIP32 paths still get discovered without producing any signature.
+ *
+ *  Returns true iff every input that has a UTXO now carries a complete
+ *  signature (an input with no UTXO yet is not this function's problem to
+ *  solve -- see PSTTSignResult::MISSING_UTXO -- it's left for a later
+ *  Updater/Signer round, exactly as an incremental multi-party PSTT expects). */
+bool FillPSTT(const CWallet* pwallet, PartiallySignedTapyrusTransaction& pstt, int sighash_type, bool sign,
+              bool bip32derivs, SignatureScheme sigScheme = SignatureScheme::ECDSA);
+
+/** Sums per-color balances across a PSTT's inputs (via each input's attached
+ *  UTXO) and outputs, keyed by ColorIdentifier -- TPC is simply the entry
+ *  keyed by the default/NONE-type identifier, never a structurally separate
+ *  field. Color is always derived from the relevant scriptPubKey via
+ *  GetColorIdFromScript(), never assumed. Inputs with no UTXO attached yet
+ *  are skipped (their color/amount isn't knowable). */
+void ComputePsttColorBalances(const PartiallySignedTapyrusTransaction& pstt,
+                               TxColoredCoinBalancesMap& in, TxColoredCoinBalancesMap& out);
+
+#endif // TAPYRUS_WALLET_PSTT_H

--- a/src/wallet/pstt.h
+++ b/src/wallet/pstt.h
@@ -39,4 +39,12 @@ bool FillPSTT(const CWallet* pwallet, PartiallySignedTapyrusTransaction& pstt, i
 void ComputePsttColorBalances(const PartiallySignedTapyrusTransaction& pstt,
                                TxColoredCoinBalancesMap& in, TxColoredCoinBalancesMap& out);
 
+// Shared by FillPSBT (wallet/rpcwallet.cpp) and FillPSTT (this file): looks up
+// a key's HD derivation metadata in the wallet and, if found, records it.
+// Declared here rather than wallet/rpcwallet.h so wallet/pstt.cpp doesn't need
+// to include that header at all -- avoids a wallet/pstt <-> wallet/rpcwallet
+// circular include (rpcwallet.cpp already includes this header for FillPSTT,
+// so the declaration stays visible where the function is defined).
+void AddKeypathToMap(const CWallet* pwallet, const CKeyID& keyID, std::map<CPubKey, std::vector<uint32_t>>& hd_keypaths);
+
 #endif // TAPYRUS_WALLET_PSTT_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -18,6 +18,7 @@
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
+#include <pstt.h>
 #include <rpc/mining.h>
 #include <rpc/protocol.h>
 #include <rpc/rawtransaction.h>
@@ -30,6 +31,7 @@
 #include <utilmoneystr.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>
+#include <wallet/pstt.h>
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
@@ -4108,6 +4110,197 @@ UniValue walletprocesspsbt(const JSONRPCRequest& request)
     return result;
 }
 
+static SignatureScheme ParseSigSchemeParam(const UniValue& param)
+{
+    if (!param.isNull() && param.get_str() == "SCHNORR") return SignatureScheme::SCHNORR;
+    return SignatureScheme::ECDSA;
+}
+
+UniValue walletupdatepstt(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
+        throw std::runtime_error(
+            "walletupdatepstt \"pstt\" ( bip32derivs )\n"
+            "\nUpdate a PSTT with input information from our wallet.\n"
+            "This is the Updater role only -- it never signs.\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"                      (string, required) The transaction base64 string\n"
+            "2. bip32derivs                    (boolean, optional, default=false) If true, includes the BIP 32 derivation paths for public keys if we know them\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"pstt\" : \"value\",          (string) The base64-encoded partially signed transaction\n"
+            "  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("walletupdatepstt", "\"pstt\"")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL});
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    bool bip32derivs = request.params[1].isNull() ? false : request.params[1].get_bool();
+    bool complete = FillPSTT(pwallet, pstt, 1, /*sign=*/false, bip32derivs);
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("pstt", EncodePSTT(pstt));
+    result.pushKV("complete", complete);
+    return result;
+}
+
+UniValue walletsignpstt(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
+        throw std::runtime_error(
+            "walletsignpstt \"pstt\" ( \"sighashtype\" \"sigscheme\" )\n"
+            "\nSign a PSTT's inputs using our wallet's keys.\n"
+            "This is the Signer role only -- it relies on a prior Updater step\n"
+            "(walletupdatepstt) having already attached each input's UTXO.\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"                      (string, required) The transaction base64 string\n"
+            "2. \"sighashtype\"            (string, optional, default=ALL) The signature hash type to sign with if not specified by the PSTT. Must be one of\n"
+            "       \"ALL\"\n"
+            "       \"NONE\"\n"
+            "       \"SINGLE\"\n"
+            "       \"ALL|ANYONECANPAY\"\n"
+            "       \"NONE|ANYONECANPAY\"\n"
+            "       \"SINGLE|ANYONECANPAY\"\n"
+            "3. \"sigscheme\"              (string, optional, default=ECDSA) \"ECDSA\" or \"SCHNORR\"\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"pstt\" : \"value\",          (string) The base64-encoded partially signed transaction\n"
+            "  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("walletsignpstt", "\"pstt\"")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR});
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    int sighash = ParseSighashString(request.params[1]);
+    SignatureScheme sigScheme = ParseSigSchemeParam(request.params[2]);
+
+    LOCK(pwallet->cs_wallet);
+    bool complete = true;
+    for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
+        PSTTInput& input = pstt.inputs.at(i);
+        if (!input.final_script_sig.empty()) continue; // already finalized
+
+        if (input.sighash_type > 0 && input.sighash_type != sighash) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Specified Sighash and sighash in PSTT do not match.");
+        }
+
+        SignatureData sigdata;
+        PSTTSignResult result = SignPSTTInput(*pwallet, pstt, i, sigdata, sighash, sigScheme);
+        if (result == PSTTSignResult::MISSING_UTXO) {
+            // Not this call's job -- run walletupdatepstt (or a peer's
+            // Updater step) first for inputs it doesn't know about yet.
+            complete = false;
+            continue;
+        }
+        if (result != PSTTSignResult::OK) {
+            throw JSONRPCError(RPC_TRANSACTION_ERROR, strprintf("Signing input %d failed: %s", i, PSTTSignResultToString(result)));
+        }
+        input.FromSignatureData(sigdata);
+        if (!sigdata.complete) complete = false;
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("pstt", EncodePSTT(pstt));
+    result.pushKV("complete", complete);
+    return result;
+}
+
+UniValue walletprocesspstt(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 5)
+        throw std::runtime_error(
+            "walletprocesspstt \"pstt\" ( sign \"sighashtype\" bip32derivs \"sigscheme\" )\n"
+            "\nUpdate a PSTT with input information from our wallet and then sign inputs\n"
+            "that we can sign for.\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"                      (string, required) The transaction base64 string\n"
+            "2. sign                          (boolean, optional, default=true) Also sign the transaction when updating\n"
+            "3. \"sighashtype\"            (string, optional, default=ALL) The signature hash type to sign with if not specified by the PSTT. Must be one of\n"
+            "       \"ALL\"\n"
+            "       \"NONE\"\n"
+            "       \"SINGLE\"\n"
+            "       \"ALL|ANYONECANPAY\"\n"
+            "       \"NONE|ANYONECANPAY\"\n"
+            "       \"SINGLE|ANYONECANPAY\"\n"
+            "4. bip32derivs                    (boolean, optional, default=false) If true, includes the BIP 32 derivation paths for public keys if we know them\n"
+            "5. \"sigscheme\"              (string, optional, default=ECDSA) \"ECDSA\" or \"SCHNORR\"\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"pstt\" : \"value\",          (string) The base64-encoded partially signed transaction\n"
+            "  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("walletprocesspstt", "\"pstt\"")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL, UniValue::VSTR, UniValue::VBOOL, UniValue::VSTR});
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    int sighash = ParseSighashString(request.params[2]);
+    bool sign = request.params[1].isNull() ? true : request.params[1].get_bool();
+    bool bip32derivs = request.params[3].isNull() ? false : request.params[3].get_bool();
+    SignatureScheme sigScheme = ParseSigSchemeParam(request.params[4]);
+    bool complete = FillPSTT(pwallet, pstt, sighash, sign, bip32derivs, sigScheme);
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("pstt", EncodePSTT(pstt));
+    result.pushKV("complete", complete);
+    return result;
+}
+
 UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -4740,6 +4933,9 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "fundrawtransaction",               &fundrawtransaction,            {"hexstring","options"} },
     { "wallet",             "walletprocesspsbt",                &walletprocesspsbt,             {"psbt","sign","sighashtype","bip32derivs"} },
     { "wallet",             "walletcreatefundedpsbt",           &walletcreatefundedpsbt,        {"inputs","outputs","locktime","options","bip32derivs"} },
+    { "wallet",             "walletupdatepstt",                 &walletupdatepstt,              {"pstt","bip32derivs"} },
+    { "wallet",             "walletsignpstt",                   &walletsignpstt,                {"pstt","sighashtype","sigscheme"} },
+    { "wallet",             "walletprocesspstt",                &walletprocesspstt,             {"pstt","sign","sighashtype","bip32derivs","sigscheme"} },
     { "hidden",             "resendwallettransactions",         &resendwallettransactions,      {} },
     { "wallet",             "abandontransaction",               &abandontransaction,            {"txid"} },
     { "wallet",             "abortrescan",                      &abortrescan,                   {} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4217,7 +4217,7 @@ UniValue walletsignpstt(const JSONRPCRequest& request)
         PSTTInput& input = pstt.inputs.at(i);
         if (!input.final_script_sig.empty()) continue; // already finalized
 
-        if (input.sighash_type > 0 && input.sighash_type != sighash) {
+        if (input.sighash_type && *input.sighash_type != sighash) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Specified Sighash and sighash in PSTT do not match.");
         }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3182,9 +3182,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
 
-    SignatureScheme sigScheme(SignatureScheme::ECDSA);
-    if(!request.params[3].isNull() && request.params[3].get_str() == "SCHNORR")
-        sigScheme = SignatureScheme::SCHNORR;
+    SignatureScheme sigScheme = ParseSigSchemeString(request.params[3]);
 
     // Sign the transaction
     LOCK2(cs_main, pwallet->cs_wallet);
@@ -4110,12 +4108,6 @@ UniValue walletprocesspsbt(const JSONRPCRequest& request)
     return result;
 }
 
-static SignatureScheme ParseSigSchemeParam(const UniValue& param)
-{
-    if (!param.isNull() && param.get_str() == "SCHNORR") return SignatureScheme::SCHNORR;
-    return SignatureScheme::ECDSA;
-}
-
 UniValue walletupdatepstt(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -4145,7 +4137,7 @@ UniValue walletupdatepstt(const JSONRPCRequest& request)
             + HelpExampleCli("walletupdatepstt", "\"pstt\"")
         );
 
-    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL});
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL}, true);
 
     PartiallySignedTapyrusTransaction pstt;
     std::string error;
@@ -4154,7 +4146,7 @@ UniValue walletupdatepstt(const JSONRPCRequest& request)
     }
 
     bool bip32derivs = request.params[1].isNull() ? false : request.params[1].get_bool();
-    bool complete = FillPSTT(pwallet, pstt, 1, /*sign=*/false, bip32derivs);
+    bool complete = FillPSTT(pwallet, pstt, SIGHASH_ALL, /*sign=*/false, bip32derivs);
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("pstt", EncodePSTT(pstt));
@@ -4200,7 +4192,7 @@ UniValue walletsignpstt(const JSONRPCRequest& request)
             + HelpExampleCli("walletsignpstt", "\"pstt\"")
         );
 
-    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR});
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR}, true);
 
     PartiallySignedTapyrusTransaction pstt;
     std::string error;
@@ -4209,7 +4201,7 @@ UniValue walletsignpstt(const JSONRPCRequest& request)
     }
 
     int sighash = ParseSighashString(request.params[1]);
-    SignatureScheme sigScheme = ParseSigSchemeParam(request.params[2]);
+    SignatureScheme sigScheme = ParseSigSchemeString(request.params[2]);
 
     LOCK(pwallet->cs_wallet);
     bool complete = true;
@@ -4281,7 +4273,7 @@ UniValue walletprocesspstt(const JSONRPCRequest& request)
             + HelpExampleCli("walletprocesspstt", "\"pstt\"")
         );
 
-    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL, UniValue::VSTR, UniValue::VBOOL, UniValue::VSTR});
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL, UniValue::VSTR, UniValue::VBOOL, UniValue::VSTR}, true);
 
     PartiallySignedTapyrusTransaction pstt;
     std::string error;
@@ -4292,7 +4284,7 @@ UniValue walletprocesspstt(const JSONRPCRequest& request)
     int sighash = ParseSighashString(request.params[2]);
     bool sign = request.params[1].isNull() ? true : request.params[1].get_bool();
     bool bip32derivs = request.params[3].isNull() ? false : request.params[3].get_bool();
-    SignatureScheme sigScheme = ParseSigSchemeParam(request.params[4]);
+    SignatureScheme sigScheme = ParseSigSchemeString(request.params[4]);
     bool complete = FillPSTT(pwallet, pstt, sighash, sign, bip32derivs, sigScheme);
 
     UniValue result(UniValue::VOBJ);

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -8,7 +8,12 @@
 #include <amount.h>
 #include <coloridentifier.h>
 #include <primitives/transaction.h>
+#include <pubkey.h>
+
+#include <cstdint>
+#include <map>
 #include <string>
+#include <vector>
 
 class CRPCTable;
 class CWallet;
@@ -35,6 +40,10 @@ bool EnsureWalletIsAvailable(CWallet *, bool avoidException);
 UniValue getaddressinfo(const JSONRPCRequest& request);
 UniValue signrawtransactionwithwallet(const JSONRPCRequest& request);
 bool FillPSBT(const CWallet* pwallet, PartiallySignedTransaction& psbtx, const CTransaction* txConst, int sighash_type = 1, bool sign = true, bool bip32derivs = false);
+
+// Shared by FillPSBT (rpcwallet.cpp) and FillPSTT (wallet/pstt.cpp): looks up a
+// key's HD derivation metadata in the wallet and, if found, records it.
+void AddKeypathToMap(const CWallet* pwallet, const CKeyID& keyID, std::map<CPubKey, std::vector<uint32_t>>& hd_keypaths);
 
 // Token operation helpers — also called from interfaces/wallet.cpp (GUI layer).
 UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& script, CAmount tokenValue, CCoinControl& coin_control);

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -41,10 +41,6 @@ UniValue getaddressinfo(const JSONRPCRequest& request);
 UniValue signrawtransactionwithwallet(const JSONRPCRequest& request);
 bool FillPSBT(const CWallet* pwallet, PartiallySignedTransaction& psbtx, const CTransaction* txConst, int sighash_type = 1, bool sign = true, bool bip32derivs = false);
 
-// Shared by FillPSBT (rpcwallet.cpp) and FillPSTT (wallet/pstt.cpp): looks up a
-// key's HD derivation metadata in the wallet and, if found, records it.
-void AddKeypathToMap(const CWallet* pwallet, const CKeyID& keyID, std::map<CPubKey, std::vector<uint32_t>>& hd_keypaths);
-
 // Token operation helpers — also called from interfaces/wallet.cpp (GUI layer).
 UniValue IssueReissuableToken(CWallet* const pwallet, const std::string& script, CAmount tokenValue, CCoinControl& coin_control);
 UniValue IssueToken(CWallet* const pwallet, CAmount tokenValue, CCoinControl& coin_control);

--- a/src/wallet/test/pstt_wallet_tests.cpp
+++ b/src/wallet/test/pstt_wallet_tests.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <amount.h>
+#include <core_io.h>
+#include <pstt.h>
+#include <rpc/server.h>
+#include <script/sign.h>
+#include <script/standard.h>
+#include <txmempool.h>
+#include <validation.h>
+#include <wallet/rpcwallet.h>
+#include <wallet/test/test_tapyrus_wallet.h>
+#include <wallet/wallet.h>
+
+#include <boost/test/unit_test.hpp>
+
+// -----------------------------------------------------------------------
+// RPC-dispatch-level tests for the wallet's PSTT RPCs (walletupdatepstt,
+// walletsignpstt, walletprocesspstt) -- these go through the real
+// registered actors (tableRPC), the same way pstt_tests.cpp's
+// pstt_rpc_* cases exercise the wallet-independent PSTT RPCs, so argument
+// parsing and JSON result shape are covered, not just FillPSTT/
+// SignPSTTInput underneath them.
+//
+// GetWalletForJSONRPCRequest() resolves the request's wallet via the
+// process-wide vpwallets list (AddWallet/GetWallets), not via the fixture's
+// own `wallet` member directly, so it must be registered there for
+// dispatch to find it. TestWalletSetup owns `wallet` as a unique_ptr and
+// isn't itself RPC-dispatch-ready, so this derives from it (per house
+// style: inherit and extend, don't edit the shared fixture) instead of
+// duplicating its chain/wallet setup.
+// -----------------------------------------------------------------------
+
+struct PsttWalletTestingSetup : public TestWalletSetup
+{
+    // No-op deleter: sharedWallet is a second handle onto the object the
+    // base class's `wallet` unique_ptr already owns and destroys.
+    PsttWalletTestingSetup() : TestWalletSetup(), sharedWallet(wallet.get(), [](CWallet*) {})
+    {
+        AddWallet(sharedWallet);
+        RegisterWalletRPCCommands(tableRPC);
+    }
+
+    ~PsttWalletTestingSetup()
+    {
+        RemoveWallet(sharedWallet);
+    }
+
+    std::shared_ptr<CWallet> sharedWallet;
+};
+
+BOOST_AUTO_TEST_SUITE(pstt_wallet_tests)
+
+static UniValue CallPsttWalletRPC(const std::string& method, const UniValue& params)
+{
+    BOOST_REQUIRE(tableRPC[method]);
+    JSONRPCRequest request;
+    request.strMethod = method;
+    request.params = params;
+    request.fHelp = false;
+    rpcfn_type fn = tableRPC[method]->actor;
+    return (*fn)(request);
+}
+
+// Funds `setup`'s wallet with a spendable P2PKH coin (confirmed on chain,
+// scanned into the wallet) by spending its first coinbase output. Returns
+// the funding transaction so callers can build a PSTT input against it.
+static CTransactionRef FundWalletWithP2PKHCoin(TestWalletSetup& setup, CAmount amount)
+{
+    CPubKey pubkey;
+    BOOST_REQUIRE(setup.wallet->GetKeyFromPool(pubkey, false));
+
+    const CTransactionRef& coinbaseTx = setup.m_coinbase_txns[0];
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = coinbaseTx->GetHashMalFix();
+    input.prev_out_index = 0;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    input.utxo = coinbaseTx;
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = amount;
+    output.script = GetScriptForDestination(pubkey.GetID());
+    pstt.outputs.push_back(output);
+
+    FlatSigningProvider provider;
+    provider.keys[setup.coinbaseKey.GetPubKey().GetID()] = setup.coinbaseKey;
+    SignatureData sigdata;
+    BOOST_REQUIRE(SignPSTTInput(provider, pstt, 0, sigdata, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    pstt.inputs[0].FromSignatureData(sigdata);
+    BOOST_REQUIRE(sigdata.complete);
+
+    CTransactionRef tx = MakeTransactionRef(ExtractPSTT(pstt));
+    BOOST_REQUIRE(setup.AddToWalletAndMempool(tx));
+    BOOST_REQUIRE(setup.ProcessBlockAndScanForWalletTxns(tx));
+    return tx;
+}
+
+// Builds an unsigned, single-input PSTT spending `fundingTx`'s only output
+// to a fresh, wallet-unrelated destination -- no UTXO attached yet, exactly
+// what a Creator/Constructor step would hand to the Updater.
+static PartiallySignedTapyrusTransaction MakeUnsignedSpendPstt(const CTransactionRef& fundingTx)
+{
+    CKey destKey;
+    destKey.MakeNewKey(true);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = fundingTx->GetHashMalFix();
+    input.prev_out_index = 0;
+    input.previous_txid_set = true;
+    input.prev_out_index_set = true;
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = fundingTx->vout[0].nValue - CENT;
+    output.script = GetScriptForDestination(destKey.GetPubKey().GetID());
+    pstt.outputs.push_back(output);
+
+    return pstt;
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_walletupdatepstt_fills_utxo, PsttWalletTestingSetup)
+{
+    CTransactionRef fundingTx = FundWalletWithP2PKHCoin(*this, 1 * COIN);
+    PartiallySignedTapyrusTransaction pstt = MakeUnsignedSpendPstt(fundingTx);
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue result = CallPsttWalletRPC("walletupdatepstt", params);
+    BOOST_REQUIRE(result.isObject());
+    BOOST_CHECK(!result.find_value("complete").get_bool()); // Updater role only -- never signs
+
+    PartiallySignedTapyrusTransaction updated;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(updated, result.find_value("pstt").get_str(), decodeError));
+    BOOST_REQUIRE(updated.inputs[0].utxo);
+    BOOST_CHECK(updated.inputs[0].utxo->GetHashMalFix() == fundingTx->GetHashMalFix());
+    BOOST_CHECK(updated.inputs[0].final_script_sig.empty());
+    BOOST_CHECK(updated.inputs[0].partial_sigs.empty());
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_walletsignpstt_completes_after_update, PsttWalletTestingSetup)
+{
+    CTransactionRef fundingTx = FundWalletWithP2PKHCoin(*this, 1 * COIN);
+    PartiallySignedTapyrusTransaction pstt = MakeUnsignedSpendPstt(fundingTx);
+
+    UniValue updateParams(UniValue::VARR);
+    updateParams.push_back(EncodePSTT(pstt));
+    UniValue updateResult = CallPsttWalletRPC("walletupdatepstt", updateParams);
+
+    UniValue signParams(UniValue::VARR);
+    signParams.push_back(updateResult.find_value("pstt").get_str());
+    UniValue signResult = CallPsttWalletRPC("walletsignpstt", signParams);
+    BOOST_REQUIRE(signResult.isObject());
+    BOOST_CHECK(signResult.find_value("complete").get_bool());
+
+    PartiallySignedTapyrusTransaction signedPstt;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(signedPstt, signResult.find_value("pstt").get_str(), decodeError));
+    BOOST_REQUIRE(!signedPstt.inputs[0].final_script_sig.empty());
+
+    CTransactionRef finalTx = MakeTransactionRef(ExtractPSTT(signedPstt));
+    CTxMempoolAcceptanceOptions opt;
+    opt.flags = MempoolAcceptanceFlags::BYPASSS_LIMITS;
+    LOCK(cs_main);
+    BOOST_CHECK(AcceptToMemoryPool(finalTx, opt));
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_walletprocesspstt_updates_and_signs_in_one_call, PsttWalletTestingSetup)
+{
+    // No prior walletupdatepstt call -- walletprocesspstt must perform both
+    // the Updater and Signer roles itself in a single pass.
+    CTransactionRef fundingTx = FundWalletWithP2PKHCoin(*this, 1 * COIN);
+    PartiallySignedTapyrusTransaction pstt = MakeUnsignedSpendPstt(fundingTx);
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue result = CallPsttWalletRPC("walletprocesspstt", params);
+    BOOST_REQUIRE(result.isObject());
+    BOOST_CHECK(result.find_value("complete").get_bool());
+
+    PartiallySignedTapyrusTransaction processed;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(processed, result.find_value("pstt").get_str(), decodeError));
+    BOOST_CHECK(!processed.inputs[0].final_script_sig.empty());
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_walletprocesspstt_sign_false_only_updates, PsttWalletTestingSetup)
+{
+    // sign=false must behave like walletupdatepstt: fill in the UTXO, but
+    // leave the input unsigned.
+    CTransactionRef fundingTx = FundWalletWithP2PKHCoin(*this, 1 * COIN);
+    PartiallySignedTapyrusTransaction pstt = MakeUnsignedSpendPstt(fundingTx);
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    params.push_back(UniValue(false)); // sign=false
+    UniValue result = CallPsttWalletRPC("walletprocesspstt", params);
+    BOOST_REQUIRE(result.isObject());
+    BOOST_CHECK(!result.find_value("complete").get_bool());
+
+    PartiallySignedTapyrusTransaction processed;
+    std::string decodeError;
+    BOOST_REQUIRE(DecodePSTT(processed, result.find_value("pstt").get_str(), decodeError));
+    BOOST_REQUIRE(processed.inputs[0].utxo);
+    BOOST_CHECK(processed.inputs[0].final_script_sig.empty());
+    BOOST_CHECK(processed.inputs[0].partial_sigs.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Phase 2 — Signer RPCs:
  - decodepstt (full JSON breakdown, including computed locktime and identification_txid) and signpsttwithkey (signs with an explicit key list via FlatSigningProvider), plus DecodePSTT/EncodePSTT in core_io/core_read/core_write, mirroring the existing PSBT equivalents.
  - Wallet-side FillPSTT (src/wallet/pstt.{h,cpp}): combined Updater+Signer pass — attaches PSTT_IN_UTXO from mapWallet where missing, signs via SignPSTTInput against the real wallet or a PublicOnlySigningProvider (for redeem-script/BIP32-path discovery without producing signatures), fills output BIP32 keypaths via a throwaway dummy transaction (PSTT has no embedded global tx to piggyback on, unlike PSBT). Also adds ComputePsttColorBalances.
  - New wallet RPCs: walletupdatepstt (Updater only), walletsignpstt (Signer only), walletprocesspstt (combined, mirrors walletprocesspsbt).
- Phase 3 — Combiner, Finalizer, Extractor:
  - New public ExtractPSTT(): requires PSTT_IN_FINAL_SCRIPTSIG on every input (throws naming the first one missing it), computes the final locktime, materializes the signed transaction.
  - combinepstt (decodes all inputs, verifies pairwise HasSameIdentifierAs(), merges via Merge(), checks IsSane() on the result), finalizepstt (refuses while either modifiable flag is set; derives sighash/scheme from what each input already carries rather than hardcoding, so SignPSTTInput's conflict checks are structurally unreachable here; strips signing-only fields on success; extracts to hex when complete), and extractpstt (thin wrapper over ExtractPSTT).
- Test coverage: removed the Phase-1 ExtractForTest stand-in now that a real ExtractPSTT exists; added Merge()'s refuse-tier (conflicting partial sig) and pick-first-tier (sighash conflict) coverage; a full end-to-end 2-of-2 P2SH multisig test (fund → two parties sign independently → Merge() → completeness check → ExtractPSTT → mempool/mined); and a new RPC-dispatch layer (CallPsttRPC helper via tableRPC, mirroring rpc_tests.cpp's CallRPC) exercising combinepstt/finalizepstt/extractpstt through their real registered actors rather than just the underlying pstt.cpp calls.