### PR TITLE
Fix intermittent CI failure:  Harden functional-test CLI/JSON parsing

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -85,10 +85,13 @@ class PruneStallDetector(StallDetector):
     def progress(self):
         try:
             return calc_usage(self.blockdir)
-        except FileNotFoundError:
+        except OSError:
             # calc_usage's listdir/isfile/getsize sequence isn't atomic; a
-            # block file can be unlinked mid-scan while pruning is actively
-            # running. Retry rather than treating a benign race as a stall.
+            # block file can be unlinked (or briefly inaccessible) mid-scan
+            # while pruning is actively running. Retry rather than treating
+            # a benign race as a stall. Any exception other than OSError is
+            # not a known race and is left to propagate as an unexpected
+            # failure (see StallDetector.run()/describe_failure()).
             raise TransientProgressError()
 
     def on_stall(self, usage):
@@ -98,6 +101,14 @@ class PruneStallDetector(StallDetector):
 
     def log_progress(self, usage):
         self.log.info("wait_for_prune: usage=%d, %s still present" % (usage, self.filename))
+
+    def describe_failure(self):
+        try:
+            entries = sorted(os.listdir(self.blockdir))
+        except OSError as e:
+            entries = "<failed to list %s: %s>" % (self.blockdir, e)
+        return "blockdir=%s target=%s target_present=%s entries=%s" % (
+            self.blockdir, self.filename, os.path.isfile(self.target_path), entries)
 
 class PruneTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -32,8 +32,22 @@ from .util import (
 )
 from .timeout_config import TAPYRUSD_PROC_TIMEOUT, TAPYRUSD_IMMEDIATE_TIMEOUT
 
-# For Python 3.4 compatibility
-JSONDecodeError = getattr(json, "JSONDecodeError", ValueError)
+def _parse_float_decimal(value):
+    """
+    parse_float for json.loads() that raises ValueError (like the rest of
+    json's scalar parsing) instead of decimal.InvalidOperation on a
+    malformed literal. json.loads's number scanner matches greedily on a
+    regex before checking whether the full input was consumed, so a bare,
+    unquoted non-JSON string (e.g. a txid tapyrus-cli prints without quotes)
+    can be misread as a number with a bogus, out-of-range exponent if it
+    contains a hex 'e' followed by a long digit run -- decimal.Decimal
+    rejects that with InvalidOperation, a non-ValueError exception that
+    would otherwise bypass json.loads's normal "invalid JSON" handling.
+    """
+    try:
+        return decimal.Decimal(value)
+    except decimal.InvalidOperation as e:
+        raise ValueError("invalid decimal literal: %r" % (value,)) from e
 
 class FailedToStartError(Exception):
     """Raised when a node fails to start correctly."""
@@ -447,13 +461,27 @@ class TestNodeCLI():
             match = re.match(r'error code: ([-0-9]+)\nerror message:\n(.*)', cli_stderr)
             if match:
                 code, message = match.groups()
+                self.log.debug("send_cli: command=%r args=%r kwargs=%r returned RPC error code=%s message=%r" % (
+                    command, args, kwargs, code, message))
                 raise JSONRPCException(dict(code=int(code), message=message))
             #if stop command could not be delivered its not an error.
             if command == 'stop' and re.match(r'error: Could not connect to the server\n(.*)', cli_stderr):
                 return 0
             # Ignore cli_stdout, raise with cli_stderr
+            self.log.error("send_cli: command=%r args=%r kwargs=%r exited with returncode=%d stderr=%r stdout=%r" % (
+                command, args, kwargs, returncode, cli_stderr, cli_stdout))
             raise subprocess.CalledProcessError(returncode, self.binary, output=cli_stderr)
         try:
-            return json.loads(cli_stdout, parse_float=decimal.Decimal)
-        except JSONDecodeError:
+            return json.loads(cli_stdout, parse_float=_parse_float_decimal)
+        except ValueError as e:
+            # Expected for any RPC that returns a plain (non-JSON) string --
+            # tapyrus-cli prints those unquoted (see CommandLineRPC in
+            # tapyrus-cli.cpp), so json.loads() always fails to parse them.
+            # Logged at debug level since this is the routine path for most
+            # string-returning RPCs, not a real failure; the raw output is
+            # included so a *genuine* malformed-response case is still
+            # diagnosable from the log instead of just silently passing
+            # through as text.
+            self.log.debug("send_cli: command=%r args=%r kwargs=%r: %s: %s; stdout=%r treated as plain string" % (
+                command, args, kwargs, type(e).__name__, e, cli_stdout))
             return cli_stdout.rstrip("\n")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -440,13 +440,22 @@ class StallDetector:
     current progress value every progress_log_interval seconds so a
     long-running wait isn't silent in CI.
 
-    Subclasses implement is_done(), progress() and on_stall(); before_check()
-    and log_progress() are optional hooks.
+    progress() may raise TransientProgressError for a benign, retryable read
+    failure (e.g. a TOCTOU race); that is retried without affecting the
+    stall timer, logging each occurrence. Any other exception progress()
+    raises is treated as a genuine, unexpected failure: it is logged
+    together with describe_failure()'s diagnostic context and then
+    re-raised immediately, rather than retried, so an unforeseen error
+    can't turn into a silent, undiagnosable hang.
+
+    Subclasses implement is_done(), progress() and on_stall(); before_check(),
+    log_progress() and describe_failure() are optional hooks.
     """
-    def __init__(self, *, wait=1, stall_timeout, progress_log_interval):
+    def __init__(self, *, wait=1, stall_timeout, progress_log_interval, log=None):
         self.wait = wait
         self.stall_timeout = stall_timeout
         self.progress_log_interval = progress_log_interval
+        self.log = log or logger
 
     def before_check(self):
         pass
@@ -463,6 +472,14 @@ class StallDetector:
     def log_progress(self, progress):
         pass
 
+    def describe_failure(self):
+        """
+        Optional hook: return a string with extra diagnostic context (e.g.
+        current filesystem or node state) to log alongside an unexpected
+        exception raised from progress(). Default: no extra context.
+        """
+        return None
+
     def run(self):
         last_progress = None
         last_progress_time = time.time()
@@ -473,9 +490,17 @@ class StallDetector:
                 return
             try:
                 progress = self.progress()
-            except TransientProgressError:
+            except TransientProgressError as e:
+                self.log.info("%s: retrying after transient progress error: %s" % (
+                    type(self).__name__, e))
                 time.sleep(self.wait)
                 continue
+            except Exception as e:
+                detail = self.describe_failure()
+                self.log.error("%s: progress() raised unexpected %s: %s%s" % (
+                    type(self).__name__, type(e).__name__, e,
+                    " | " + detail if detail else ""))
+                raise
             now = time.time()
             if progress != last_progress:
                 last_progress = progress
@@ -508,7 +533,10 @@ class _BlockSyncStallDetector(StallDetector):
                 "".join("\n  {!r}".format(b) for b in self.last_best_hash)))
 
     def log_progress(self, heights):
-        logger.info("sync_blocks_with_stall_detection: heights={}".format(heights))
+        self.log.info("sync_blocks_with_stall_detection: heights={}".format(heights))
+
+    def describe_failure(self):
+        return "last_best_hash=%r" % (self.last_best_hash,)
 
 class Node3SyncStallDetector(StallDetector):
     """
@@ -518,8 +546,7 @@ class Node3SyncStallDetector(StallDetector):
     retried unpredictably, so a fixed wall-clock budget doesn't fit well.
     """
     def __init__(self, log, target_node, reference_node, reconnect, *, min_peers, min_height, **kwargs):
-        super().__init__(**kwargs)
-        self.log = log
+        super().__init__(log=log, **kwargs)
         self.target_node = target_node
         self.reference_node = reference_node
         self.reconnect = reconnect
@@ -544,6 +571,10 @@ class Node3SyncStallDetector(StallDetector):
 
     def log_progress(self, height):
         self.log.info("node3 sync progress: height=%d" % height)
+
+    def describe_failure(self):
+        return "last_height=%r min_peers=%r min_height=%r" % (
+            self.last_height, self.min_peers, self.min_height)
 
 def sync_blocks_with_stall_detection(rpc_connections, *, wait=1, stall_timeout=TAPYRUSD_SYNC_TIMEOUT, progress_log_interval=TAPYRUSD_MESSAGE_TIMEOUT):
     """


### PR DESCRIPTION
Two related test-harness robustness fixes surfaced while chasing an
intermittent weekly smoke-test failure in `wallet_coloredcoin.py --usecli`:

1. **`send_cli()` could crash on a perfectly valid CLI response.**
   `tapyrus-cli` prints top-level string RPC results (txids, block hashes,
   raw tx hex, ...) unquoted, so `TestNodeCLI.send_cli()` already expected
   `json.loads()` to fail and fell back to returning the raw text. But
   Python's JSON scanner matches numbers via a greedy regex *before*
   checking whether the whole input was consumed, so a bare hex string
   containing a lowercase `e` followed by a long run of digits (e.g.
   `525e14327405958332449931adabd...`) gets misread as a JSON float with a
   bogus, out-of-range exponent. `decimal.Decimal()` then raises
   `decimal.InvalidOperation` — a non-`ValueError` exception that bypassed
   the existing `except JSONDecodeError` fallback and crashed the test with
   an unhandled traceback.

2. **`StallDetector.progress()` (introduced in a prior commit to replace
   fixed-timeout polling with stall detection) only guarded against one
   specific race.** `PruneStallDetector.progress()` caught `FileNotFoundError`
   from `calc_usage()` scanning the block directory concurrently with
   pruning, but any other exception — expected or not — propagated with no
   diagnostic context about what state caused it.

### Fixes

**`test/functional/test_framework/test_node.py`**
- Added `_parse_float_decimal()`, a `parse_float` wrapper for `json.loads()`
  that normalizes `decimal.InvalidOperation` into a plain `ValueError`, so
  it's always a `ValueError` subclass — same family as `JSONDecodeError` —
  reaching `send_cli()`'s except clause. Collapsed the two failure paths
  into a single `except ValueError:`, removing the now-dead
  `JSONDecodeError` Python-3.4-compat shim.
- Added debug/error logging at every failure branch in `send_cli()`
  (RPC error responses, non-zero CLI exit, and the JSON-parse fallback),
  each including the command, args, and raw stdout/stderr, so a future
  failure is diagnosable straight from the log instead of requiring a
  repro.

**`test/functional/test_framework/util.py` / `feature_pruning.py`**
- `StallDetector.run()` now distinguishes two exception categories from
  `progress()`: `TransientProgressError` (benign, retried, now logged per
  occurrence) vs. any other exception (logged with a new
  `describe_failure()` diagnostic hook, then re-raised immediately instead
  of ever retrying silently).
- `PruneStallDetector` broadened its retry guard from `FileNotFoundError`
  to `OSError` (covers other TOCTOU-adjacent races from the same
  non-atomic `listdir`/`isfile`/`getsize` scan) and implemented
  `describe_failure()` to log the block directory, target filename, and a
  fresh directory listing on genuine failure.
- Unified logging across `StallDetector` subclasses via a shared
  `self.log` (defaults to the module logger), and added `describe_failure()`
  to `Node3SyncStallDetector` / `_BlockSyncStallDetector` for consistency.