### PR TITLE
PSTT - Implement RPC gaps identified during a review comparing with Bitcoin Core's PSBT RPC surface

### DIFF
--- a/doc/tapyrus/pstt.md
+++ b/doc/tapyrus/pstt.md
@@ -227,18 +227,22 @@ construction across separate parties, not a single call).
 Inspecting a PSTT
 -----------------
 
-`decodepstt` reports, alongside the raw field breakdown, which role above
-should run next for this PSTT (`"next"`: `constructor`/`updater`/`signer`/
-`finalizer`/`extractor`), determined by the same completeness check
-`finalizepstt` itself uses (a dry-run `SignPSTTInput` against a keyless
-provider — this can only ever confirm signatures *already collected* are
-enough, never fabricate new ones). Once every input carries `PSTT_IN_UTXO`,
-it also reports `"estimated_size"` (bytes) and `"estimated_fee"` (TPC only,
-per the Fee Provider note above) for the transaction this PSTT would
-currently extract to — using each unfinalized input's already-known redeem
+`decodepstt` reports, alongside the raw field breakdown, `"next"`: a JSON
+array of every role above that could act on this PSTT right now, in ladder
+order (`constructor`/`updater`/`signer`/`finalizer`/`extractor`) — these are
+independent, not mutually exclusive, e.g. a still-modifiable but
+already-fully-funded PSTT reports both `constructor` and `signer`. Role
+completeness is determined by the same check `finalizepstt` itself uses (a
+dry-run `SignPSTTInput` against a keyless provider — this can only ever
+confirm signatures *already collected* are enough, never fabricate new
+ones). Once every input carries `PSTT_IN_UTXO`, it also reports
+`"estimated_size"` (bytes) for the transaction this PSTT would currently
+extract to — using each unfinalized input's already-known redeem
 script/public keys to size a plausible completion, real
-`PSTT_IN_FINAL_SCRIPTSIG` where already present. Both estimates can still
-change while `"next"` is `constructor` or `signer`.
+`PSTT_IN_FINAL_SCRIPTSIG` where already present — and `"estimated_fee"`
+(TPC only, per the Fee Provider note above) alongside it, unless it would be
+negative, which just means this PSTT is still gathering inputs. Both can
+still change while `"next"` contains `constructor` or `signer`.
 
 ---
 

--- a/doc/tapyrus/pstt.md
+++ b/doc/tapyrus/pstt.md
@@ -90,7 +90,7 @@ Reserved and must be rejected, not silently treated as unknown: `0x01`
 from BIP-371 (`0x13`-`0x18`) — none have a Tapyrus counterpart.
 
 `PSTT_IN_PREVIOUS_TXID`/`PSTT_IN_OUTPUT_INDEX` are this wire format's own
-field names (mirrored by `PSTTInput`'s `previous_txid`/`prev_out_index`
+field names (mirrored by `PSTTInput`'s `previous_txid`/`prevout_index`
 members in C++), distinct from the RPC surface: every PSTT RPC that takes
 this pair as a user-facing argument (`createpstt`, `walletcreatefundedpstt`,
 `addinputtopstt`, `addinputoutputpairtopstt`) uses `txid`/`vout` uniformly,
@@ -161,9 +161,26 @@ construction across separate parties, not a single call).
 * **Constructor** — appends inputs/outputs to an existing PSTT. Only ever
   appends; never removes or reorders what is already present. Refuses to
   add an input whose required locktime would make the PSTT's already-signed
-  content locktime-invalid.
+  content locktime-invalid. `addinputtopstt`/`addoutputtopstt`/
+  `addinputoutputpairtopstt` do this one input/output at a time;
+  `joinpstt` instead concatenates the inputs and outputs of several
+  independently-built PSTTs in one call, for assembling a large PSTT (e.g.
+  one filling most of a block) out of pieces built separately without a
+  single caller having to drive every individual `addinputtopstt` call.
+  Every joined PSTT must still have both Inputs/Outputs Modifiable set, must
+  not have Has-`SIGHASH_SINGLE` set, and must carry no signature on any
+  input — joining shifts every subsequent piece's input/output positions,
+  which would silently invalidate a `SIGHASH_SINGLE` commitment to a
+  specific position; join first, add any `SIGHASH_SINGLE` input/output pair
+  afterwards. The same outpoint may not be spent by more than one of the
+  joined PSTTs.
 * **Updater** — attaches externally known data (UTXOs, redeem scripts,
-  BIP32 derivation paths) without altering which inputs/outputs exist. Must
+  BIP32 derivation paths) without altering which inputs/outputs exist.
+  `walletupdatepstt` sources this from a loaded wallet (also discovering
+  redeem scripts/BIP32 paths from it); `updatepstt` instead takes
+  caller-supplied raw transactions directly and only ever attaches
+  `PSTT_IN_UTXO` (no wallet, so no redeem script/BIP32 discovery), for
+  contexts with no wallet loaded at all. Must
   not change an input's sequence number once that input carries a
   signature, or once any other input carries a `SIGHASH_ALL`-without-
   `SIGHASH_ANYONECANPAY` signature (either case would silently invalidate
@@ -184,7 +201,10 @@ construction across separate parties, not a single call).
   inputs and outputs together, never one without the other. This only ever
   clears Inputs/Outputs Modifiable or sets Has-`SIGHASH_SINGLE` — it never
   reopens a bit an earlier signing round already closed.
-* **Combiner** — merges two or more PSTTs that share an identifier.
+* **Combiner** — merges two or more PSTTs that share an identifier (i.e.
+  alternate signing progress on the *same* underlying transaction — not to
+  be confused with `joinpstt`, which assembles *different* inputs/outputs
+  from multiple PSTTs into one new, larger transaction).
   Per-field conflict policy on a mismatch: `PSTT_IN_PARTIAL_SIG`,
   `PSTT_IN_FINAL_SCRIPTSIG`, and `PSTT_IN_UTXO` refuse (signature/UTXO
   disagreements are exactly the disagreements that must not be silently
@@ -201,6 +221,24 @@ construction across separate parties, not a single call).
   either modifiable flag is still set.
 * **Transaction Extractor** — once every input is finalized, assembles and
   returns the network-serialized transaction.
+
+---
+
+Inspecting a PSTT
+-----------------
+
+`decodepstt` reports, alongside the raw field breakdown, which role above
+should run next for this PSTT (`"next"`: `constructor`/`updater`/`signer`/
+`finalizer`/`extractor`), determined by the same completeness check
+`finalizepstt` itself uses (a dry-run `SignPSTTInput` against a keyless
+provider — this can only ever confirm signatures *already collected* are
+enough, never fabricate new ones). Once every input carries `PSTT_IN_UTXO`,
+it also reports `"estimated_size"` (bytes) and `"estimated_fee"` (TPC only,
+per the Fee Provider note above) for the transaction this PSTT would
+currently extract to — using each unfinalized input's already-known redeem
+script/public keys to size a plausible completion, real
+`PSTT_IN_FINAL_SCRIPTSIG` where already present. Both estimates can still
+change while `"next"` is `constructor` or `signer`.
 
 ---
 

--- a/src/pstt.cpp
+++ b/src/pstt.cpp
@@ -54,7 +54,7 @@ CExtPubKey ParseXpubKeyData(const std::vector<unsigned char>& keydata)
 
 bool PSTTInput::IsNull() const
 {
-    return !previous_txid_set && !prev_out_index_set && !utxo && partial_sigs.empty() &&
+    return !previous_txid_set && !prevout_index_set && !utxo && partial_sigs.empty() &&
            unknown.empty() && hd_keypaths.empty() && redeem_script.empty() && final_script_sig.empty();
 }
 
@@ -102,7 +102,7 @@ void PSTTInput::FromSignatureData(const SignatureData& sigdata)
 //  - everything else (incl. unknown/proprietary)      -> pick-first, no throw
 void PSTTInput::Merge(const PSTTInput& input)
 {
-    // previous_txid / prev_out_index are required-and-identical by construction
+    // previous_txid / prevout_index are required-and-identical by construction
     // (both sides must already agree, or they wouldn't share a PSTT identifier --
     // HasSameIdentifierAs() is checked by the Combiner before Merge() is ever
     // called). Nothing to merge for these two fields.
@@ -173,7 +173,7 @@ void PSTTInput::Merge(const PSTTInput& input)
 bool PSTTInput::IsSane() const
 {
     // previous_txid / output_index are required.
-    if (!previous_txid_set || !prev_out_index_set) return false;
+    if (!previous_txid_set || !prevout_index_set) return false;
 
     // No mixed ECDSA/Schnorr signatures on one input. Mirrors interpreter.cpp's
     // SCRIPT_ERR_MIXED_SCHEME_MULTISIG classification rule exactly: a 65-byte
@@ -198,9 +198,9 @@ void PSTTInput::Serialize(Stream& s) const
         SerializeToVector(s, PSTT_IN_PREVIOUS_TXID);
         SerializeToVector(s, previous_txid);
     }
-    if (prev_out_index_set) {
+    if (prevout_index_set) {
         SerializeToVector(s, PSTT_IN_OUTPUT_INDEX);
-        SerializeToVector(s, prev_out_index);
+        SerializeToVector(s, prevout_index);
     }
     if (utxo) {
         SerializeToVector(s, PSTT_IN_UTXO);
@@ -362,10 +362,10 @@ void PSTTInput::Unserialize(Stream& s)
                 previous_txid_set = true;
                 break;
             case PSTT_IN_OUTPUT_INDEX:
-                if (prev_out_index_set) throw std::ios_base::failure("Duplicate Key, PSTT_IN_OUTPUT_INDEX already provided");
+                if (prevout_index_set) throw std::ios_base::failure("Duplicate Key, PSTT_IN_OUTPUT_INDEX already provided");
                 if (key.size() != 1) throw std::ios_base::failure("PSTT_IN_OUTPUT_INDEX key is more than one byte type");
-                UnserializeFromVector(s, prev_out_index);
-                prev_out_index_set = true;
+                UnserializeFromVector(s, prevout_index);
+                prevout_index_set = true;
                 break;
             case PSTT_IN_SEQUENCE:
                 if (sequence) throw std::ios_base::failure("Duplicate Key, PSTT_IN_SEQUENCE already provided");
@@ -602,7 +602,7 @@ bool PartiallySignedTapyrusTransaction::IsSane() const
 {
     for (const PSTTInput& input : inputs) {
         if (!input.IsSane()) return false;
-        if (input.utxo && input.prev_out_index_set && input.prev_out_index >= input.utxo->vout.size()) {
+        if (input.utxo && input.prevout_index_set && input.prevout_index >= input.utxo->vout.size()) {
             return false;
         }
         // Deliberately NOT checked here: input.utxo->GetHashMalFix() ==
@@ -904,7 +904,7 @@ CMutableTransaction MaterializeTransaction(const PartiallySignedTapyrusTransacti
 
     for (const PSTTInput& input : pstt.inputs) {
         CTxIn txin;
-        txin.prevout = COutPoint(input.previous_txid, input.prev_out_index);
+        txin.prevout = COutPoint(input.previous_txid, input.prevout_index);
         if (force_zero_sequence) {
             txin.nSequence = 0;
         } else {
@@ -961,7 +961,7 @@ std::string PSTTSignResultToString(PSTTSignResult result)
         case PSTTSignResult::OK: return "OK";
         case PSTTSignResult::MISSING_UTXO: return "input has no PSTT_IN_UTXO";
         case PSTTSignResult::UTXO_TXID_MISMATCH: return "PSTT_IN_UTXO txid does not match PSTT_IN_PREVIOUS_TXID";
-        case PSTTSignResult::PREV_OUT_INDEX_OOB: return "PSTT_IN_OUTPUT_INDEX is out of range for PSTT_IN_UTXO";
+        case PSTTSignResult::PREVOUT_INDEX_OOB: return "PSTT_IN_OUTPUT_INDEX is out of range for PSTT_IN_UTXO";
         case PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH: return "redeem script does not hash to the committed value";
         case PSTTSignResult::SIGHASH_CONFLICT: return "requested sighash type conflicts with PSTT_IN_SIGHASH_TYPE";
         case PSTTSignResult::SCHEME_CONFLICT: return "signature scheme conflicts with an existing signature on this input";
@@ -1011,17 +1011,17 @@ PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySig
     if (input.utxo->GetHashMalFix() != input.previous_txid) {
         return PSTTSignResult::UTXO_TXID_MISMATCH;
     }
-    if (input.prev_out_index >= input.utxo->vout.size()) {
-        return PSTTSignResult::PREV_OUT_INDEX_OOB;
+    if (input.prevout_index >= input.utxo->vout.size()) {
+        return PSTTSignResult::PREVOUT_INDEX_OOB;
     }
 
-    const CTxOut& utxo_out = input.utxo->vout[input.prev_out_index];
+    const CTxOut& utxo = input.utxo->vout[input.prevout_index];
 
     // Must verify the redeem script hashes to the value committed in the
     // scriptPubKey, accounting for CP2SH's color-id prefix.
     if (!input.redeem_script.empty()) {
         uint160 expected_hash;
-        if (!ExtractRedeemScriptHash(utxo_out.scriptPubKey, expected_hash)) {
+        if (!ExtractRedeemScriptHash(utxo.scriptPubKey, expected_hash)) {
             return PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH;
         }
         if (CScriptID(input.redeem_script) != CScriptID(expected_hash)) {
@@ -1061,8 +1061,8 @@ PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySig
     input.FillSignatureData(sigdata);
 
     CMutableTransaction mtx_view = MaterializeTransaction(pstt, locktime, /*force_zero_sequence=*/false, /*use_final_scriptsig=*/false);
-    MutableTransactionSignatureCreator creator(&mtx_view, index, utxo_out.nValue, sighash, sigScheme);
-    ProduceSignature(provider, creator, utxo_out.scriptPubKey, sigdata);
+    MutableTransactionSignatureCreator creator(&mtx_view, index, utxo.nValue, sighash, sigScheme);
+    ProduceSignature(provider, creator, utxo.scriptPubKey, sigdata);
 
     // pstt is taken by const reference (MaterializeTransaction needs the whole
     // PSTT, not just this input, so the signature intentionally doesn't take a

--- a/src/pstt.cpp
+++ b/src/pstt.cpp
@@ -560,7 +560,7 @@ bool PartiallySignedTapyrusTransaction::IsNull() const
 // byte form (78-byte xpub + derivation path), built just for the duration
 // of this call, so appending stays close to linear rather than O(n^2) for
 // large xpub counts.
-static std::vector<unsigned char> XpubEntryCanonicalBytes(const std::pair<CExtPubKey, std::vector<uint32_t>>& entry)
+std::vector<unsigned char> XpubEntryCanonicalBytes(const std::pair<CExtPubKey, std::vector<uint32_t>>& entry)
 {
     std::vector<unsigned char> out = SerializeXpubKeyData(entry.first);
     for (uint32_t v : entry.second) {
@@ -1015,13 +1015,13 @@ PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySig
         return PSTTSignResult::PREVOUT_INDEX_OOB;
     }
 
-    const CTxOut& utxo = input.utxo->vout[input.prevout_index];
+    const CTxOut& utxo_out = input.utxo->vout[input.prevout_index];
 
     // Must verify the redeem script hashes to the value committed in the
     // scriptPubKey, accounting for CP2SH's color-id prefix.
     if (!input.redeem_script.empty()) {
         uint160 expected_hash;
-        if (!ExtractRedeemScriptHash(utxo.scriptPubKey, expected_hash)) {
+        if (!ExtractRedeemScriptHash(utxo_out.scriptPubKey, expected_hash)) {
             return PSTTSignResult::REDEEM_SCRIPT_HASH_MISMATCH;
         }
         if (CScriptID(input.redeem_script) != CScriptID(expected_hash)) {
@@ -1061,8 +1061,8 @@ PSTTSignResult SignPSTTInput(const SigningProvider& provider, const PartiallySig
     input.FillSignatureData(sigdata);
 
     CMutableTransaction mtx_view = MaterializeTransaction(pstt, locktime, /*force_zero_sequence=*/false, /*use_final_scriptsig=*/false);
-    MutableTransactionSignatureCreator creator(&mtx_view, index, utxo.nValue, sighash, sigScheme);
-    ProduceSignature(provider, creator, utxo.scriptPubKey, sigdata);
+    MutableTransactionSignatureCreator creator(&mtx_view, index, utxo_out.nValue, sighash, sigScheme);
+    ProduceSignature(provider, creator, utxo_out.scriptPubKey, sigdata);
 
     // pstt is taken by const reference (MaterializeTransaction needs the whole
     // PSTT, not just this input, so the signature intentionally doesn't take a

--- a/src/pstt.h
+++ b/src/pstt.h
@@ -112,6 +112,11 @@ std::vector<unsigned char> SerializeXpubKeyData(const CExtPubKey& xpub);
  *  the 4-byte prefix isn't exactly Params().Base58Prefix(EXT_PUBLIC_KEY). */
 CExtPubKey ParseXpubKeyData(const std::vector<unsigned char>& keydata);
 
+/** Canonical dedup key for a PSTT_GLOBAL_XPUB entry: keydata bytes followed
+ *  by the derivation path. Used by Merge() and joinpstt to avoid emitting
+ *  duplicate PSTT_GLOBAL_XPUB entries, which Unserialize() rejects. */
+std::vector<unsigned char> XpubEntryCanonicalBytes(const std::pair<CExtPubKey, std::vector<uint32_t>>& entry);
+
 // ---------------------------------------------------------------------
 // PSTTInput
 // ---------------------------------------------------------------------

--- a/src/pstt.h
+++ b/src/pstt.h
@@ -121,9 +121,9 @@ struct PSTTInput
     // Required -- these have no natural "empty" sentinel, hence explicit
     // presence flags rather than e.g. treating an all-zero txid as absent.
     uint256  previous_txid;
-    uint32_t prev_out_index = 0;
+    uint32_t prevout_index = 0;
     bool     previous_txid_set = false;
-    bool     prev_out_index_set = false;
+    bool     prevout_index_set = false;
 
     // Optional, absence is the natural "empty"
     CTransactionRef utxo;             // PSTT_IN_UTXO -- full previous tx only
@@ -234,7 +234,7 @@ enum class PSTTSignResult
     OK,
     MISSING_UTXO,
     UTXO_TXID_MISMATCH,
-    PREV_OUT_INDEX_OOB,
+    PREVOUT_INDEX_OOB,
     REDEEM_SCRIPT_HASH_MISMATCH,
     SIGHASH_CONFLICT,
     SCHEME_CONFLICT,

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -108,6 +108,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "finalizepsttconstruction", 1, "clear_inputs_modifiable" },
     { "finalizepsttconstruction", 2, "clear_outputs_modifiable" },
     { "combinepstt", 0, "txs" },
+    { "joinpstt", 0, "txs" },
+    { "updatepstt", 1, "txs" },
     { "finalizepstt", 1, "extract" },
     { "signpsttwithkey", 1, "privkeys" },
     { "walletcreatefundedpstt", 0, "inputs" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1266,14 +1266,14 @@ static void PushTokenAmount(const CScript& script, CAmount amount, UniValue& ent
 static void PsttInputToUniv(const PSTTInput& input, UniValue& in)
 {
     in.pushKV("txid", input.previous_txid.GetHex());
-    in.pushKV("vout", (uint64_t)input.prev_out_index);
+    in.pushKV("vout", (uint64_t)input.prevout_index);
 
     if (input.utxo) {
         UniValue utxo_univ(UniValue::VOBJ);
         TxToUniv(*input.utxo, uint256(), utxo_univ, false);
         in.pushKV("utxo", utxo_univ);
-        if (input.prev_out_index < input.utxo->vout.size()) {
-            const CTxOut& out = input.utxo->vout[input.prev_out_index];
+        if (input.prevout_index < input.utxo->vout.size()) {
+            const CTxOut& out = input.utxo->vout[input.prevout_index];
             PushTokenAmount(out.scriptPubKey, out.nValue, in);
         }
     }
@@ -1480,9 +1480,9 @@ UniValue createpstt(const JSONRPCRequest& request)
     for (const CTxIn& txin : rawTx.vin) {
         PSTTInput input;
         input.previous_txid = txin.prevout.hashMalFix;
-        input.prev_out_index = txin.prevout.n;
+        input.prevout_index = txin.prevout.n;
         input.previous_txid_set = true;
-        input.prev_out_index_set = true;
+        input.prevout_index_set = true;
         if (txin.nSequence != CTxIn::SEQUENCE_FINAL) input.sequence = txin.nSequence;
         pstt.inputs.push_back(std::move(input));
     }
@@ -1549,9 +1549,9 @@ UniValue converttopstt(const JSONRPCRequest& request)
     for (const CTxIn& txin : tx.vin) {
         PSTTInput input;
         input.previous_txid = txin.prevout.hashMalFix;
-        input.prev_out_index = txin.prevout.n;
+        input.prevout_index = txin.prevout.n;
         input.previous_txid_set = true;
-        input.prev_out_index_set = true;
+        input.prevout_index_set = true;
         if (txin.nSequence != CTxIn::SEQUENCE_FINAL) input.sequence = txin.nSequence;
         pstt.inputs.push_back(std::move(input));
     }
@@ -1615,9 +1615,9 @@ UniValue addinputtopstt(const JSONRPCRequest& request)
     if (nOutput < 0) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
     }
-    input.prev_out_index = (uint32_t)nOutput;
+    input.prevout_index = (uint32_t)nOutput;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     if (!request.params[3].isNull()) {
         int64_t seq = request.params[3].get_int64();
         if (seq < 0 || seq > std::numeric_limits<uint32_t>::max()) {
@@ -1717,9 +1717,9 @@ UniValue addinputoutputpairtopstt(const JSONRPCRequest& request)
     if (nOutput < 0) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
     }
-    input.prev_out_index = (uint32_t)nOutput;
+    input.prevout_index = (uint32_t)nOutput;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     if (!request.params[4].isNull()) {
         int64_t seq = request.params[4].get_int64();
         if (seq < 0 || seq > std::numeric_limits<uint32_t>::max()) {
@@ -1779,6 +1779,237 @@ UniValue finalizepsttconstruction(const JSONRPCRequest& request)
     return EncodePSTT(pstt);
 }
 
+// =======================================================================
+// PSTT introspection helpers (decodepstt's next-role/estimated_size/
+// estimated_fee fields; also used by finalizepstt below).
+// =======================================================================
+
+// The dummy provider's per-input sighash/scheme is derived from what the
+// input itself already carries, not hardcoded: this makes SignPSTTInput's
+// sighash-conflict and scheme-conflict pre-checks unreachable here by
+// construction (they can only ever fire against a mismatch with what we
+// pass in), so a dry run only ever fails for a genuine structural reason
+// (missing/mismatched UTXO, bad redeem script, contradictory locktime, an
+// out-of-range SIGHASH_SINGLE), never a spurious conflict against our own
+// derivation.
+static int FinalizeSighashFor(const PSTTInput& input)
+{
+    return input.sighash_type ? *input.sighash_type : SIGHASH_ALL;
+}
+
+static SignatureScheme FinalizeSigSchemeFor(const PSTTInput& input)
+{
+    if (input.partial_sigs.empty()) return SignatureScheme::ECDSA;
+    const std::vector<unsigned char>& sig = input.partial_sigs.begin()->second.second;
+    return sig.size() == CPubKey::COMPACT_SIGNATURE_SIZE ? SignatureScheme::SCHNORR : SignatureScheme::ECDSA;
+}
+
+// Dry-run of what finalizepstt would do to this one input, without mutating
+// anything: true iff the input's already-collected data (partial sigs/
+// redeem script) is enough to finalize right now. Reuses the same
+// DUMMY_SIGNING_PROVIDER technique finalizepstt itself uses (a keyless
+// provider can't add anything new, so ProduceSignature can only ever report
+// "complete" here if what's already in the PSTT already satisfies the
+// script).
+static bool CanFinalizeInputNow(const PartiallySignedTapyrusTransaction& pstt, unsigned int i)
+{
+    const PSTTInput& input = pstt.inputs.at(i);
+    if (!input.final_script_sig.empty()) return true;
+    if (!input.utxo) return false;
+
+    SignatureData sigdata;
+    PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, i, sigdata,
+                                           FinalizeSighashFor(input), FinalizeSigSchemeFor(input));
+    return result == PSTTSignResult::OK && sigdata.complete;
+}
+
+// Which role should run next, in the same rough ladder as Bitcoin Core's
+// analyzepsbt: constructor (inputs/outputs still modifiable) -> updater (an
+// input has no PSTT_IN_UTXO yet) -> signer (some input's collected data
+// isn't enough to finalize) -> finalizer (every input could finalize now,
+// but hasn't) -> extractor (every input already carries
+// PSTT_IN_FINAL_SCRIPTSIG). A PSTT with zero inputs trivially falls through
+// to "extractor" -- there is nothing left for any earlier role to do.
+static std::string PsttNextRole(const PartiallySignedTapyrusTransaction& pstt)
+{
+    if (pstt.tx_modifiable && (*pstt.tx_modifiable & (PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE)) != 0) {
+        return "constructor";
+    }
+
+    bool any_missing_utxo = false;
+    bool any_needs_signer = false;
+    bool any_not_final = false;
+    for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
+        const PSTTInput& input = pstt.inputs.at(i);
+        if (!input.final_script_sig.empty()) continue;
+        any_not_final = true;
+        if (!input.utxo) {
+            any_missing_utxo = true;
+            continue;
+        }
+        if (!CanFinalizeInputNow(pstt, i)) any_needs_signer = true;
+    }
+
+    if (any_missing_utxo) return "updater";
+    if (any_needs_signer) return "signer";
+    if (any_not_final) return "finalizer";
+    return "extractor";
+}
+
+static bool AllInputsHaveUtxo(const PartiallySignedTapyrusTransaction& pstt)
+{
+    for (const PSTTInput& input : pstt.inputs) {
+        if (!input.utxo) return false;
+    }
+    return true;
+}
+
+// The scriptSig this input would contribute: the real
+// PSTT_IN_FINAL_SCRIPTSIG if already finalized, otherwise a same-size dummy
+// completion of whatever's already known about it (redeem script, any
+// already-collected pubkeys), via a throwaway keystore that holds no real
+// private keys -- DUMMY_SIGNATURE_CREATOR fabricates a plausibly-sized fake
+// signature for every public key the keystore claims to know, the same
+// technique CWallet::CalculateMaximumSignedTxSize uses for fee estimation,
+// just without needing a wallet. Purely a local size probe; never mutates
+// the real PSTT. Caller must have already confirmed input.utxo is set.
+static CScript EstimateInputScriptSig(const PartiallySignedTapyrusTransaction& pstt, unsigned int i)
+{
+    const PSTTInput& input = pstt.inputs.at(i);
+    if (!input.final_script_sig.empty()) return input.final_script_sig;
+
+    CBasicKeyStore keystore;
+    if (!input.redeem_script.empty()) keystore.AddCScript(input.redeem_script);
+    for (const auto& kv : input.hd_keypaths) keystore.AddWatchOnly(GetScriptForRawPubKey(kv.first));
+    for (const auto& kv : input.partial_sigs) keystore.AddWatchOnly(GetScriptForRawPubKey(kv.second.first));
+
+    SignatureData sigdata;
+    input.FillSignatureData(sigdata);
+    const CTxOut& utxo = input.utxo->vout.at(input.prevout_index);
+    ProduceSignature(keystore, DUMMY_SIGNATURE_CREATOR, utxo.scriptPubKey, sigdata);
+    return sigdata.scriptSig;
+}
+
+// Estimated size in bytes of the transaction this PSTT would extract to,
+// using EstimateInputScriptSig for any input not yet finalized. Caller must
+// have already confirmed every input has a UTXO attached (AllInputsHaveUtxo)
+// -- without that there's no scriptPubKey to size a dummy completion
+// against for at least one input, so no estimate is possible at all.
+static int64_t EstimatePsttSize(const PartiallySignedTapyrusTransaction& pstt)
+{
+    uint32_t locktime = 0;
+    ComputeLocktime(pstt, locktime); // best-effort; 0 if inconsistent -- size estimate only, not used for anything consensus-relevant
+
+    CMutableTransaction mtx;
+    mtx.nFeatures = pstt.tx_features.value_or(CTransaction::CURRENT_FEATURES);
+    mtx.nLockTime = locktime;
+    for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
+        const PSTTInput& input = pstt.inputs.at(i);
+        CTxIn txin(COutPoint(input.previous_txid, input.prevout_index), EstimateInputScriptSig(pstt, i),
+                   input.sequence.value_or(CTxIn::SEQUENCE_FINAL));
+        mtx.vin.push_back(std::move(txin));
+    }
+    for (const PSTTOutput& output : pstt.outputs) {
+        mtx.vout.emplace_back(output.amount.value_or(0), output.script);
+    }
+    return ::GetSerializeSize(CTransaction(mtx), SER_NETWORK, PROTOCOL_VERSION);
+}
+
+// Net TPC moved by this PSTT (inputs minus outputs) -- the fee, since fees
+// are payable only in TPC (doc/tapyrus/pstt.md, Fee Provider workflow) and
+// every Colored Coin transfer nets to zero for its own color by consensus
+// rule. Caller must have already confirmed every input has a UTXO attached.
+static CAmount EstimatePsttFee(const PartiallySignedTapyrusTransaction& pstt)
+{
+    CAmount in_tpc = 0;
+    for (const PSTTInput& input : pstt.inputs) {
+        const CTxOut& utxo = input.utxo->vout.at(input.prevout_index);
+        if (GetColorIdFromScript(utxo.scriptPubKey).type == TokenTypes::NONE) in_tpc += utxo.nValue;
+    }
+    CAmount out_tpc = 0;
+    for (const PSTTOutput& output : pstt.outputs) {
+        if (GetColorIdFromScript(output.script).type == TokenTypes::NONE) out_tpc += *output.amount;
+    }
+    return in_tpc - out_tpc;
+}
+
+UniValue updatepstt(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 2)
+        throw std::runtime_error(
+            "updatepstt \"pstt\" [\"hexstring\",...]\n"
+            "\nAttaches PSTT_IN_UTXO to any input that doesn't already have one, by\n"
+            "matching each supplied raw transaction's malfix txid against the PSTT's own\n"
+            "input previous_txids. Implements the Updater role without needing a loaded\n"
+            "wallet -- unlike walletupdatepstt, the previous transactions come from the\n"
+            "caller, not mapWallet, and no redeem script / BIP32 derivation discovery is\n"
+            "attempted (there is no wallet here to discover them from). Never adds,\n"
+            "removes, or reorders inputs/outputs -- only ever attaches PSTT_IN_UTXO to\n"
+            "what's already there. A supplied transaction whose txid doesn't match any\n"
+            "input is silently ignored, not an error -- the caller may not know in\n"
+            "advance which of several candidates a given PSTT actually needs.\n"
+
+            "\nArguments:\n"
+            "1. \"pstt\"                 (string, required) A base64 string of a PSTT\n"
+            "2. \"txs\"                  (array, required) A json array of hex-encoded raw transactions\n"
+            "    [\n"
+            "      \"hexstring\"        (string) A previous transaction this PSTT may spend from\n"
+            "      ,...\n"
+            "    ]\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"pstt\" : \"value\",                (string)  The base64-encoded partially signed transaction\n"
+            "  \"all_utxos_attached\" : true|false, (boolean) Whether every input now has a PSTT_IN_UTXO\n"
+            "}\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("updatepstt", "\"pstt\" \"[\\\"myhex1\\\",\\\"myhex2\\\"]\"")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR});
+
+    PartiallySignedTapyrusTransaction pstt;
+    std::string error;
+    if (!DecodePSTT(pstt, request.params[0].get_str(), error)) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+    }
+
+    UniValue txs = request.params[1].get_array();
+    std::map<uint256, CTransactionRef> known_txs;
+    for (unsigned int idx = 0; idx < txs.size(); ++idx) {
+        CMutableTransaction mtx;
+        if (!DecodeHexTx(mtx, txs[idx].get_str())) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed for tx %d", idx));
+        }
+        CTransactionRef txref = MakeTransactionRef(std::move(mtx));
+        known_txs[txref->GetHashMalFix()] = txref;
+    }
+
+    for (PSTTInput& input : pstt.inputs) {
+        if (input.utxo || !input.previous_txid_set) continue; // already attached, or this input isn't even valid yet
+        auto it = known_txs.find(input.previous_txid);
+        if (it == known_txs.end()) continue; // not among the supplied txs -- leave for a later Updater round
+        if (input.prevout_index_set && input.prevout_index >= it->second->vout.size()) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Input prevout index out of range");
+        }
+        input.utxo = it->second;
+    }
+
+    bool all_attached = true;
+    for (const PSTTInput& input : pstt.inputs) {
+        if (!input.utxo) {
+            all_attached = false;
+            break;
+        }
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("pstt", EncodePSTT(pstt));
+    result.pushKV("all_utxos_attached", all_attached);
+    return result;
+}
+
 UniValue decodepstt(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
@@ -1786,6 +2017,11 @@ UniValue decodepstt(const JSONRPCRequest& request)
             "decodepstt \"pstt\"\n"
             "\nReturn a JSON object representing the serialized, base64-encoded "
             "Partially Signed Tapyrus Transaction (see doc/tapyrus/pstt.md).\n"
+            "\nAlso reports \"next\" (which role should run next: constructor, updater,\n"
+            "signer, finalizer, or extractor) and, once every input has a UTXO attached,\n"
+            "\"estimated_size\"/\"estimated_fee\" for the transaction this PSTT would\n"
+            "currently extract to -- both are estimates only and can still change while\n"
+            "\"next\" is \"constructor\" or \"signer\".\n"
 
             "\nArguments:\n"
             "1. \"pstt\"            (string, required) The PSTT base64 string\n"
@@ -1875,6 +2111,12 @@ UniValue decodepstt(const JSONRPCRequest& request)
     }
     result.pushKV("outputs", outputs);
 
+    result.pushKV("next", PsttNextRole(pstt));
+    if (AllInputsHaveUtxo(pstt)) {
+        result.pushKV("estimated_size", EstimatePsttSize(pstt));
+        result.pushKV("estimated_fee", ValueFromAmount(EstimatePsttFee(pstt)));
+    }
+
     return result;
 }
 
@@ -1935,24 +2177,105 @@ UniValue combinepstt(const JSONRPCRequest& request)
     return EncodePSTT(merged_pstt);
 }
 
-// The dummy provider's per-input sighash/scheme is derived from what the
-// input itself already carries, not hardcoded: this makes SignPSTTInput's
-// sighash-conflict and scheme-conflict pre-checks unreachable here by
-// construction (they can only ever fire against a mismatch with what we
-// pass in), so finalization only ever fails for a genuine structural reason
-// (missing/mismatched UTXO, bad redeem script, contradictory locktime, an
-// out-of-range SIGHASH_SINGLE), never a spurious conflict against our own
-// derivation.
-static int FinalizeSighashFor(const PSTTInput& input)
+UniValue joinpstt(const JSONRPCRequest& request)
 {
-    return input.sighash_type ? *input.sighash_type : SIGHASH_ALL;
-}
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "joinpstt [\"pstt\",...]\n"
+            "\nJoin multiple distinct, still-under-construction PSTTs -- each with its own\n"
+            "inputs and outputs -- into one larger PSTT, by concatenating their inputs and\n"
+            "outputs in the order supplied. Lets a large PSTT be built up as several\n"
+            "independently-constructed pieces (e.g. contributed by different parties, or\n"
+            "built in parallel) and then combined, rather than requiring every input/output\n"
+            "to be added one at a time to a single PSTT via addinputtopstt/addoutputtopstt.\n"
+            "Implements the Constructor role. This is not the Combiner (see combinepstt):\n"
+            "combinepstt merges alternate signing progress on the *same* underlying\n"
+            "transaction, while joinpstt assembles *different* inputs/outputs from\n"
+            "multiple PSTTs into a new, larger transaction.\n"
+            "\nEvery supplied PSTT must still have both its Inputs-Modifiable and\n"
+            "Outputs-Modifiable flags set (call finalizepsttconstruction only after\n"
+            "joining, never before), must not have its Has-SIGHASH_SINGLE flag set, and\n"
+            "none of its inputs may carry a partial signature -- a SIGHASH_SINGLE\n"
+            "signature (partial or final) commits to its own input's position matching a\n"
+            "specific output position, an invariant joining would silently break by\n"
+            "shifting every position after the first PSTT. Join first, add any\n"
+            "SIGHASH_SINGLE input/output pair afterwards. The same previous output may not\n"
+            "be spent by more than one of the supplied PSTTs.\n"
 
-static SignatureScheme FinalizeSigSchemeFor(const PSTTInput& input)
-{
-    if (input.partial_sigs.empty()) return SignatureScheme::ECDSA;
-    const std::vector<unsigned char>& sig = input.partial_sigs.begin()->second.second;
-    return sig.size() == CPubKey::COMPACT_SIGNATURE_SIZE ? SignatureScheme::SCHNORR : SignatureScheme::ECDSA;
+            "\nArguments:\n"
+            "1. \"txs\"                   (string) A json array of base64 strings of PSTTs to join\n"
+            "    [\n"
+            "      \"pstt\"             (string) A base64 string of a PSTT\n"
+            "      ,...\n"
+            "    ]\n"
+
+            "\nResult:\n"
+            "  \"pstt\"          (string) The base64-encoded joined partially signed transaction\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("joinpstt", "[\"mybase64_1\", \"mybase64_2\", \"mybase64_3\"]")
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VARR}, true);
+
+    UniValue txs = request.params[0].get_array();
+    if (txs.size() < 2) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "joinpstt requires at least two PSTTs");
+    }
+
+    std::vector<PartiallySignedTapyrusTransaction> psttxs;
+    for (unsigned int i = 0; i < txs.size(); ++i) {
+        PartiallySignedTapyrusTransaction pstt;
+        std::string error;
+        if (!DecodePSTT(pstt, txs[i].get_str(), error)) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
+        }
+        psttxs.push_back(std::move(pstt));
+    }
+
+    PartiallySignedTapyrusTransaction joined;
+    joined.tx_features = CTransaction::CURRENT_FEATURES;
+    std::set<COutPoint> seen_outpoints;
+    for (unsigned int i = 0; i < psttxs.size(); ++i) {
+        const PartiallySignedTapyrusTransaction& pstt = psttxs[i];
+        uint8_t modifiable = pstt.tx_modifiable.value_or(0);
+        if (!(modifiable & PSTT_TXMOD_INPUTS_MODIFIABLE) || !(modifiable & PSTT_TXMOD_OUTPUTS_MODIFIABLE)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("PSTT %d is not still under construction (Inputs/Outputs-Modifiable must both be set)", i));
+        }
+        if (modifiable & PSTT_TXMOD_HAS_SIGHASH_SINGLE) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("PSTT %d has its Has-SIGHASH_SINGLE flag set; join it after joinpstt instead", i));
+        }
+        for (unsigned int j = 0; j < pstt.inputs.size(); ++j) {
+            const PSTTInput& input = pstt.inputs[j];
+            if (!input.partial_sigs.empty() || !input.final_script_sig.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("PSTT %d input %d is already signed; only unsigned PSTTs may be joined", i, j));
+            }
+            if (input.previous_txid_set && input.prevout_index_set) {
+                if (!seen_outpoints.insert(COutPoint(input.previous_txid, input.prevout_index)).second) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("PSTT %d input %d spends an outpoint already spent by another joined PSTT", i, j));
+                }
+            }
+        }
+
+        if (pstt.tx_features && *pstt.tx_features > *joined.tx_features) joined.tx_features = pstt.tx_features;
+        if (!joined.fallback_locktime) joined.fallback_locktime = pstt.fallback_locktime;
+        for (const auto& entry : pstt.xpubs) joined.xpubs.push_back(entry);
+        for (const auto& kv : pstt.unknown) joined.unknown.insert(kv); // pick-first tier, same as combinepstt's Merge()
+
+        joined.inputs.insert(joined.inputs.end(), pstt.inputs.begin(), pstt.inputs.end());
+        joined.outputs.insert(joined.outputs.end(), pstt.outputs.begin(), pstt.outputs.end());
+    }
+    joined.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE;
+
+    uint32_t locktime;
+    if (!ComputeLocktime(joined, locktime)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Joining these PSTTs would make the resulting locktime unsatisfiable");
+    }
+    if (!joined.IsSane()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Joined PSTT is inconsistent");
+    }
+
+    return EncodePSTT(joined);
 }
 
 UniValue finalizepstt(const JSONRPCRequest& request)
@@ -2189,8 +2512,10 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "addoutputtopstt",              &addoutputtopstt,           {"pstt","output"} },
     { "rawtransactions",    "addinputoutputpairtopstt",     &addinputoutputpairtopstt,  {"pstt","txid","vout","output","sequence"} },
     { "rawtransactions",    "finalizepsttconstruction",     &finalizepsttconstruction,  {"pstt","clear_inputs_modifiable","clear_outputs_modifiable"} },
+    { "rawtransactions",    "updatepstt",                   &updatepstt,                {"pstt","txs"} },
     { "rawtransactions",    "decodepstt",                   &decodepstt,                {"pstt"} },
     { "rawtransactions",    "combinepstt",                  &combinepstt,               {"txs"} },
+    { "rawtransactions",    "joinpstt",                     &joinpstt,                  {"txs"} },
     { "rawtransactions",    "finalizepstt",                 &finalizepstt,              {"pstt", "extract"} },
     { "rawtransactions",    "extractpstt",                  &extractpstt,               {"pstt"} },
     { "rawtransactions",    "signpsttwithkey",               &signpsttwithkey,           {"pstt","privkeys","sighashtype","sigscheme"} },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1823,43 +1823,53 @@ static bool CanFinalizeInputNow(const PartiallySignedTapyrusTransaction& pstt, u
     return result == PSTTSignResult::OK && sigdata.complete;
 }
 
-// Which role should run next, in the same rough ladder as Bitcoin Core's
-// analyzepsbt: constructor (inputs/outputs still modifiable) -> updater (an
-// input has no PSTT_IN_UTXO yet) -> signer (some input's collected data
-// isn't enough to finalize) -> finalizer (every input could finalize now,
-// but hasn't) -> extractor (every input already carries
-// PSTT_IN_FINAL_SCRIPTSIG). A PSTT with zero inputs trivially falls through
-// to "extractor" -- there is nothing left for any earlier role to do.
-static std::string PsttNextRole(const PartiallySignedTapyrusTransaction& pstt)
+// Every role that could act on this PSTT right now, in the same rough
+// ladder as Bitcoin Core's analyzepsbt: constructor (inputs/outputs still
+// modifiable), updater (some input has no PSTT_IN_UTXO yet), signer (some
+// input has a UTXO but its collected data isn't enough to finalize),
+// finalizer (some input could finalize now but hasn't), extractor (every
+// input already carries PSTT_IN_FINAL_SCRIPTSIG, or there are no inputs).
+// These are independent, not mutually exclusive -- e.g. a freshly
+// wallet-funded, still-modifiable, unsigned PSTT is both "constructor" (more
+// inputs/outputs could still be added) and "signer" (its attached UTXOs
+// already make it signable); the caller decides whether to sign now or wait
+// for construction to close. Returned in this canonical ladder order,
+// filtered to only the roles that currently apply.
+static std::vector<std::string> PsttNextRoles(const PartiallySignedTapyrusTransaction& pstt)
 {
+    std::vector<std::string> roles;
     if (pstt.tx_modifiable && (*pstt.tx_modifiable & (PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE)) != 0) {
-        return "constructor";
+        roles.push_back("constructor");
     }
 
     bool any_missing_utxo = false;
     bool any_needs_signer = false;
-    bool any_not_final = false;
+    bool any_ready_to_finalize = false;
     for (unsigned int i = 0; i < pstt.inputs.size(); ++i) {
         const PSTTInput& input = pstt.inputs.at(i);
         if (!input.final_script_sig.empty()) continue;
-        any_not_final = true;
         if (!input.utxo) {
             any_missing_utxo = true;
             continue;
         }
-        if (!CanFinalizeInputNow(pstt, i)) any_needs_signer = true;
+        if (CanFinalizeInputNow(pstt, i)) {
+            any_ready_to_finalize = true;
+        } else {
+            any_needs_signer = true;
+        }
     }
 
-    if (any_missing_utxo) return "updater";
-    if (any_needs_signer) return "signer";
-    if (any_not_final) return "finalizer";
-    return "extractor";
+    if (any_missing_utxo) roles.push_back("updater");
+    if (any_needs_signer) roles.push_back("signer");
+    if (any_ready_to_finalize) roles.push_back("finalizer");
+    if (!any_missing_utxo && !any_needs_signer && !any_ready_to_finalize) roles.push_back("extractor");
+    return roles;
 }
 
 static bool AllInputsHaveUtxo(const PartiallySignedTapyrusTransaction& pstt)
 {
     for (const PSTTInput& input : pstt.inputs) {
-        if (!input.utxo) return false;
+        if (!input.utxo || !input.prevout_index_set || input.prevout_index >= input.utxo->vout.size()) return false;
     }
     return true;
 }
@@ -1885,16 +1895,21 @@ static CScript EstimateInputScriptSig(const PartiallySignedTapyrusTransaction& p
 
     SignatureData sigdata;
     input.FillSignatureData(sigdata);
-    const CTxOut& utxo = input.utxo->vout.at(input.prevout_index);
-    ProduceSignature(keystore, DUMMY_SIGNATURE_CREATOR, utxo.scriptPubKey, sigdata);
+    const CTxOut& utxo_out = input.utxo->vout.at(input.prevout_index);
+    ProduceSignature(keystore, DUMMY_SIGNATURE_CREATOR, utxo_out.scriptPubKey, sigdata);
     return sigdata.scriptSig;
 }
 
 // Estimated size in bytes of the transaction this PSTT would extract to,
 // using EstimateInputScriptSig for any input not yet finalized. Caller must
-// have already confirmed every input has a UTXO attached (AllInputsHaveUtxo)
-// -- without that there's no scriptPubKey to size a dummy completion
-// against for at least one input, so no estimate is possible at all.
+// have already confirmed every input has a usable, in-range UTXO attached
+// (AllInputsHaveUtxo) -- without that there's no scriptPubKey to size a
+// dummy completion against for at least one input, so no estimate is
+// possible at all. Fidelity depends on what key material happens to be
+// attached: with BIP32 derivation paths or partial sigs already collected,
+// the dummy completion approximates a real signature's size well; with
+// none (e.g. a createpstt+updatepstt PSTT built without a wallet), the
+// keystore stays empty and this is essentially the unsigned size.
 static int64_t EstimatePsttSize(const PartiallySignedTapyrusTransaction& pstt)
 {
     uint32_t locktime = 0;
@@ -1918,17 +1933,18 @@ static int64_t EstimatePsttSize(const PartiallySignedTapyrusTransaction& pstt)
 // Net TPC moved by this PSTT (inputs minus outputs) -- the fee, since fees
 // are payable only in TPC (doc/tapyrus/pstt.md, Fee Provider workflow) and
 // every Colored Coin transfer nets to zero for its own color by consensus
-// rule. Caller must have already confirmed every input has a UTXO attached.
+// rule. Caller must have already confirmed every input has a usable,
+// in-range UTXO attached.
 static CAmount EstimatePsttFee(const PartiallySignedTapyrusTransaction& pstt)
 {
     CAmount in_tpc = 0;
     for (const PSTTInput& input : pstt.inputs) {
-        const CTxOut& utxo = input.utxo->vout.at(input.prevout_index);
-        if (GetColorIdFromScript(utxo.scriptPubKey).type == TokenTypes::NONE) in_tpc += utxo.nValue;
+        const CTxOut& utxo_out = input.utxo->vout.at(input.prevout_index);
+        if (GetColorIdFromScript(utxo_out.scriptPubKey).type == TokenTypes::NONE) in_tpc += utxo_out.nValue;
     }
     CAmount out_tpc = 0;
     for (const PSTTOutput& output : pstt.outputs) {
-        if (GetColorIdFromScript(output.script).type == TokenTypes::NONE) out_tpc += *output.amount;
+        if (GetColorIdFromScript(output.script).type == TokenTypes::NONE) out_tpc += output.amount.value_or(0);
     }
     return in_tpc - out_tpc;
 }
@@ -2017,11 +2033,19 @@ UniValue decodepstt(const JSONRPCRequest& request)
             "decodepstt \"pstt\"\n"
             "\nReturn a JSON object representing the serialized, base64-encoded "
             "Partially Signed Tapyrus Transaction (see doc/tapyrus/pstt.md).\n"
-            "\nAlso reports \"next\" (which role should run next: constructor, updater,\n"
-            "signer, finalizer, or extractor) and, once every input has a UTXO attached,\n"
-            "\"estimated_size\"/\"estimated_fee\" for the transaction this PSTT would\n"
-            "currently extract to -- both are estimates only and can still change while\n"
-            "\"next\" is \"constructor\" or \"signer\".\n"
+            "\nAlso reports \"next\" (a JSON array of every role that could act on this PSTT\n"
+            "right now, in ladder order: constructor, updater, signer, finalizer,\n"
+            "extractor -- these are independent, not mutually exclusive, e.g. a\n"
+            "still-modifiable but already-fully-funded PSTT reports both \"constructor\"\n"
+            "and \"signer\") and, once every input has a UTXO attached, \"estimated_size\"\n"
+            "for the transaction this PSTT would currently extract to -- an estimate only,\n"
+            "using whatever BIP32 derivation/partial-signature data happens to be attached\n"
+            "right now to size a dummy completion of each unfinalized input (with none\n"
+            "attached, e.g. a createpstt+updatepstt PSTT built without a wallet, this is\n"
+            "essentially the unsigned size), and can still change while \"next\" contains\n"
+            "\"constructor\" or \"signer\". \"estimated_fee\" (inputs minus outputs, in TPC)\n"
+            "is included alongside it unless it would be negative, which just means this\n"
+            "PSTT is still gathering inputs.\n"
 
             "\nArguments:\n"
             "1. \"pstt\"            (string, required) The PSTT base64 string\n"
@@ -2111,10 +2135,13 @@ UniValue decodepstt(const JSONRPCRequest& request)
     }
     result.pushKV("outputs", outputs);
 
-    result.pushKV("next", PsttNextRole(pstt));
+    UniValue next(UniValue::VARR);
+    for (const std::string& role : PsttNextRoles(pstt)) next.push_back(role);
+    result.pushKV("next", next);
     if (AllInputsHaveUtxo(pstt)) {
         result.pushKV("estimated_size", EstimatePsttSize(pstt));
-        result.pushKV("estimated_fee", ValueFromAmount(EstimatePsttFee(pstt)));
+        CAmount fee = EstimatePsttFee(pstt);
+        if (fee >= 0) result.pushKV("estimated_fee", ValueFromAmount(fee)); // negative just means still gathering inputs
     }
 
     return result;
@@ -2201,6 +2228,8 @@ UniValue joinpstt(const JSONRPCRequest& request)
             "shifting every position after the first PSTT. Join first, add any\n"
             "SIGHASH_SINGLE input/output pair afterwards. The same previous output may not\n"
             "be spent by more than one of the supplied PSTTs.\n"
+            "\nfallback_locktime becomes the maximum of the joined PSTTs' fallback_locktime\n"
+            "values. PSTT_GLOBAL_VERSION is not carried over from any input PSTT.\n"
 
             "\nArguments:\n"
             "1. \"txs\"                   (string) A json array of base64 strings of PSTTs to join\n"
@@ -2236,6 +2265,7 @@ UniValue joinpstt(const JSONRPCRequest& request)
     PartiallySignedTapyrusTransaction joined;
     joined.tx_features = CTransaction::CURRENT_FEATURES;
     std::set<COutPoint> seen_outpoints;
+    std::set<std::vector<unsigned char>> seen_xpubs;
     for (unsigned int i = 0; i < psttxs.size(); ++i) {
         const PartiallySignedTapyrusTransaction& pstt = psttxs[i];
         uint8_t modifiable = pstt.tx_modifiable.value_or(0);
@@ -2258,8 +2288,14 @@ UniValue joinpstt(const JSONRPCRequest& request)
         }
 
         if (pstt.tx_features && *pstt.tx_features > *joined.tx_features) joined.tx_features = pstt.tx_features;
-        if (!joined.fallback_locktime) joined.fallback_locktime = pstt.fallback_locktime;
-        for (const auto& entry : pstt.xpubs) joined.xpubs.push_back(entry);
+        if (pstt.fallback_locktime && (!joined.fallback_locktime || *pstt.fallback_locktime > *joined.fallback_locktime)) {
+            joined.fallback_locktime = pstt.fallback_locktime;
+        }
+        for (const auto& entry : pstt.xpubs) {
+            if (seen_xpubs.insert(XpubEntryCanonicalBytes(entry)).second) {
+                joined.xpubs.push_back(entry);
+            }
+        }
         for (const auto& kv : pstt.unknown) joined.unknown.insert(kv); // pick-first tier, same as combinepstt's Merge()
 
         joined.inputs.insert(joined.inputs.end(), pstt.inputs.begin(), pstt.inputs.end());

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -1454,9 +1454,10 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_shape, TestChainSetup)
 
 BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_constructor, TestingSetup)
 {
-    // Still under construction (an Inputs/Outputs-Modifiable bit set) takes
-    // priority over every other state -- irrelevant here whether the lone
-    // input is even signable yet.
+    // Still under construction (an Inputs/Outputs-Modifiable bit set) and
+    // already signable (UTXO attached, no signature yet) -- both roles are
+    // reported, since they're independent: the caller may still add more
+    // inputs/outputs, or may choose to sign what's already there now.
     PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
     pstt.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE;
 
@@ -1464,7 +1465,12 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_constructor, TestingSetup)
     params.push_back(EncodePSTT(pstt));
     UniValue decoded = CallPsttRPC("decodepstt", params);
 
-    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "constructor");
+    BOOST_REQUIRE(decoded.exists("next"));
+    const UniValue& next = decoded.find_value("next");
+    BOOST_REQUIRE(next.isArray());
+    BOOST_REQUIRE_EQUAL(next.size(), 2U);
+    BOOST_CHECK_EQUAL(next[0].get_str(), "constructor");
+    BOOST_CHECK_EQUAL(next[1].get_str(), "signer");
     // Estimates are still offered even mid-construction -- a running
     // estimate is useful to a caller building up a PSTT incrementally --
     // just documented as subject to change (see decodepstt's help text).
@@ -1484,7 +1490,11 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_updater, TestingSetup)
     params.push_back(EncodePSTT(pstt));
     UniValue decoded = CallPsttRPC("decodepstt", params);
 
-    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "updater");
+    BOOST_REQUIRE(decoded.exists("next"));
+    const UniValue& next = decoded.find_value("next");
+    BOOST_REQUIRE(next.isArray());
+    BOOST_REQUIRE_EQUAL(next.size(), 1U);
+    BOOST_CHECK_EQUAL(next[0].get_str(), "updater");
     BOOST_CHECK(!decoded.exists("estimated_size"));
     BOOST_CHECK(!decoded.exists("estimated_fee"));
 }
@@ -1503,7 +1513,11 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_signer_and_estimates, Test
     params.push_back(EncodePSTT(pstt));
     UniValue decoded = CallPsttRPC("decodepstt", params);
 
-    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "signer");
+    BOOST_REQUIRE(decoded.exists("next"));
+    const UniValue& next = decoded.find_value("next");
+    BOOST_REQUIRE(next.isArray());
+    BOOST_REQUIRE_EQUAL(next.size(), 1U);
+    BOOST_CHECK_EQUAL(next[0].get_str(), "signer");
     BOOST_REQUIRE(decoded.exists("estimated_fee"));
     BOOST_CHECK_EQUAL(ValueFromAmount(10000).write(), decoded.find_value("estimated_fee").write());
     BOOST_REQUIRE(decoded.exists("estimated_size"));
@@ -1525,7 +1539,11 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_finalizer, TestChainSetup)
     params.push_back(EncodePSTT(merged));
     UniValue decoded = CallPsttRPC("decodepstt", params);
 
-    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "finalizer");
+    BOOST_REQUIRE(decoded.exists("next"));
+    const UniValue& next = decoded.find_value("next");
+    BOOST_REQUIRE(next.isArray());
+    BOOST_REQUIRE_EQUAL(next.size(), 1U);
+    BOOST_CHECK_EQUAL(next[0].get_str(), "finalizer");
     BOOST_CHECK(decoded.exists("estimated_size"));
     BOOST_CHECK(decoded.exists("estimated_fee"));
 }
@@ -1552,8 +1570,113 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_extractor, TestChainSetup)
     params.push_back(EncodePSTT(merged));
     UniValue decoded = CallPsttRPC("decodepstt", params);
 
-    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "extractor");
+    BOOST_REQUIRE(decoded.exists("next"));
+    const UniValue& next = decoded.find_value("next");
+    BOOST_REQUIRE(next.isArray());
+    BOOST_REQUIRE_EQUAL(next.size(), 1U);
+    BOOST_CHECK_EQUAL(next[0].get_str(), "extractor");
     BOOST_CHECK_EQUAL(decoded.find_value("estimated_size").get_int64(), actual_size);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_roles_updater_and_signer_together, TestingSetup)
+{
+    // Two inputs in different states -- one missing its UTXO (needs
+    // Updater), the other has a UTXO but no signature yet (needs Signer).
+    // Both roles are independently actionable on this PSTT right now, so
+    // both must be reported -- the old short-circuiting ladder could never
+    // report this combination, since it stopped at the first category it
+    // found.
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt(); // input[0]: utxo attached, unsigned
+    CTransactionRef otherUtxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 50000);
+    PSTTInput secondInput;
+    secondInput.previous_txid = otherUtxo->GetHashMalFix();
+    secondInput.prevout_index = 0;
+    secondInput.previous_txid_set = true;
+    secondInput.prevout_index_set = true; // utxo left unattached
+    pstt.inputs.push_back(secondInput);
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_REQUIRE(decoded.exists("next"));
+    const UniValue& next = decoded.find_value("next");
+    BOOST_REQUIRE(next.isArray());
+    BOOST_REQUIRE_EQUAL(next.size(), 2U);
+    BOOST_CHECK_EQUAL(next[0].get_str(), "updater");
+    BOOST_CHECK_EQUAL(next[1].get_str(), "signer");
+    // AllInputsHaveUtxo requires every input, not just some -- no estimate
+    // at all while one input still lacks a UTXO.
+    BOOST_CHECK(!decoded.exists("estimated_size"));
+    BOOST_CHECK(!decoded.exists("estimated_fee"));
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_omits_negative_estimated_fee, TestingSetup)
+{
+    // Still under construction (an Inputs-Modifiable bit set, more inputs
+    // may yet be added) with an output total that already exceeds the one
+    // attached input's value -- in_tpc - out_tpc would be negative, which
+    // is never a meaningful fee. decodepstt must omit estimated_fee rather
+    // than report a negative number, while still offering estimated_size.
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt(); // in=100000, out=90000
+    pstt.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE;
+    pstt.outputs[0].amount = 500000; // out (500000) now exceeds in (100000)
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_CHECK(decoded.exists("estimated_size"));
+    BOOST_CHECK(!decoded.exists("estimated_fee"));
+}
+
+BOOST_AUTO_TEST_CASE(pstt_output_with_no_amount_fails_is_sane_and_unserialize)
+{
+    // An output with a script but no PSTT_OUT_AMOUNT is rejected by
+    // PSTTOutput::IsSane(), and PartiallySignedTapyrusTransaction::
+    // Unserialize() enforces IsSane() unconditionally at the end of parsing
+    // ("if (!IsSane()) throw ... PSTT is not sane.", pstt.cpp). So this
+    // shape can never actually reach decodepstt's body in the first place:
+    // DecodePSTT() -- the only way a base64 string becomes a PSTT object --
+    // already rejects it. EstimatePsttFee's output.amount.value_or(0) guard
+    // (rawtransaction.cpp) is still correct defensive coding, just not
+    // reachable through any real RPC call.
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    PSTTOutput noAmountOutput;
+    noAmountOutput.script = RandomP2PKHScript(); // amount left unset
+    pstt.outputs.push_back(noAmountOutput);
+
+    BOOST_CHECK(!pstt.IsSane());
+
+    std::vector<unsigned char> data = SerializeObj(pstt);
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(pstt_out_of_range_prevout_index_fails_is_sane_and_unserialize)
+{
+    // A UTXO-attached input whose prevout_index is out of range for that
+    // UTXO's own vout list is rejected by PartiallySignedTapyrusTransaction
+    // ::IsSane() directly, and Unserialize() enforces IsSane()
+    // unconditionally -- so, like the no-amount-output case above, this
+    // shape can never actually reach decodepstt's body through any real
+    // call. AllInputsHaveUtxo()'s range check (rawtransaction.cpp) is still
+    // correct defense in depth.
+    CTransactionRef utxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 100000); // single-output tx
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input = MakeBasicInput(utxo->GetHashMalFix(), 0, utxo);
+    input.prevout_index = 5; // out of range: utxo only has one output (index 0)
+    pstt.inputs.push_back(input);
+
+    PSTTOutput output;
+    output.amount = 90000;
+    output.script = RandomP2PKHScript();
+    pstt.outputs.push_back(output);
+
+    BOOST_CHECK(!pstt.IsSane());
+
+    std::vector<unsigned char> data = SerializeObj(pstt);
+    BOOST_CHECK_THROW(UnserializeObj<PartiallySignedTapyrusTransaction>(data), std::ios_base::failure);
 }
 
 // -----------------------------------------------------------------------
@@ -1756,6 +1879,86 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_rejects_duplicate_outpoint, TestingSet
     params.push_back(txs);
 
     BOOST_CHECK_THROW(CallPsttRPC("joinpstt", params), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_dedups_shared_xpub, TestingSetup)
+{
+    // Two PSTTs both carrying the same global xpub (same key, same
+    // derivation path) -- joinpstt must dedup, not concatenate, or the
+    // joined result carries two PSTT_GLOBAL_XPUB entries with the same
+    // keydata and fails to decode (Unserialize rejects a repeated
+    // PSTT_GLOBAL_XPUB keydata outright).
+    CExtPubKey xpub;
+    CKey key;
+    key.MakeNewKey(true);
+    xpub.pubkey = key.GetPubKey();
+    xpub.nDepth = 1;
+    xpub.nChild = 0;
+    xpub.chaincode.SetNull();
+
+    PartiallySignedTapyrusTransaction a = MakeJoinableConstructorPstt();
+    PartiallySignedTapyrusTransaction b = MakeJoinableConstructorPstt();
+    a.xpubs.emplace_back(xpub, std::vector<uint32_t>{0});
+    b.xpubs.emplace_back(xpub, std::vector<uint32_t>{0}); // same xpub, same path
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(a));
+    txs.push_back(EncodePSTT(b));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+    UniValue result = CallPsttRPC("joinpstt", params);
+
+    PartiallySignedTapyrusTransaction joined;
+    std::string err;
+    BOOST_REQUIRE(DecodePSTT(joined, result.get_str(), err)); // must still decode
+    BOOST_REQUIRE_EQUAL(joined.xpubs.size(), 1U); // deduped, not doubled
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_fallback_locktime_takes_max, TestingSetup)
+{
+    // joinpstt takes the maximum of the joined PSTTs' fallback_locktime
+    // values, rather than silently keeping only the first one.
+    PartiallySignedTapyrusTransaction a = MakeJoinableConstructorPstt();
+    PartiallySignedTapyrusTransaction b = MakeJoinableConstructorPstt();
+    a.fallback_locktime = 500;
+    b.fallback_locktime = 900;
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(a));
+    txs.push_back(EncodePSTT(b));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+    UniValue result = CallPsttRPC("joinpstt", params);
+
+    PartiallySignedTapyrusTransaction joined;
+    std::string err;
+    BOOST_REQUIRE(DecodePSTT(joined, result.get_str(), err));
+    BOOST_REQUIRE(joined.fallback_locktime);
+    BOOST_CHECK_EQUAL(*joined.fallback_locktime, 900U);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_fallback_locktime_takes_max_regardless_of_order, TestingSetup)
+{
+    // Same rule regardless of which PSTT (first or second) carries the
+    // higher value -- guards against a comparison that only takes the max
+    // when the larger value happens to arrive second.
+    PartiallySignedTapyrusTransaction a = MakeJoinableConstructorPstt();
+    PartiallySignedTapyrusTransaction b = MakeJoinableConstructorPstt();
+    a.fallback_locktime = 900;
+    b.fallback_locktime = 500;
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(a));
+    txs.push_back(EncodePSTT(b));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+    UniValue result = CallPsttRPC("joinpstt", params);
+
+    PartiallySignedTapyrusTransaction joined;
+    std::string err;
+    BOOST_REQUIRE(DecodePSTT(joined, result.get_str(), err));
+    BOOST_REQUIRE(joined.fallback_locktime);
+    BOOST_CHECK_EQUAL(*joined.fallback_locktime, 900U);
 }
 
 // -----------------------------------------------------------------------

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -1452,7 +1452,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_shape, TestChainSetup)
 // decodepstt's "next" role hint / estimated_size / estimated_fee
 // -----------------------------------------------------------------------
 
-BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_constructor)
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_constructor, TestingSetup)
 {
     // Still under construction (an Inputs/Outputs-Modifiable bit set) takes
     // priority over every other state -- irrelevant here whether the lone
@@ -1472,7 +1472,7 @@ BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_constructor)
     BOOST_CHECK(decoded.exists("estimated_fee"));
 }
 
-BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_updater)
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_updater, TestingSetup)
 {
     // No PSTT_IN_UTXO attached yet -- ahead of Signer in the ladder, and
     // means no fee/size estimate is even possible (an input's value/type
@@ -1489,7 +1489,7 @@ BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_updater)
     BOOST_CHECK(!decoded.exists("estimated_fee"));
 }
 
-BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_signer_and_estimates)
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_signer_and_estimates, TestingSetup)
 {
     // Construction finished, UTXO attached, no signature yet -- Signer is
     // next. The 100000/90000 split from MakeBasicPstt() gives an exact,

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -58,9 +58,9 @@ static PSTTInput MakeBasicInput(const uint256& prev_txid, uint32_t vout, const C
 {
     PSTTInput input;
     input.previous_txid = prev_txid;
-    input.prev_out_index = vout;
+    input.prevout_index = vout;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     input.utxo = utxo;
     return input;
 }
@@ -99,6 +99,13 @@ static T UnserializeObj(const std::vector<unsigned char>& data)
     return obj;
 }
 
+static std::string EncodeHexTxForTest(const CMutableTransaction& mtx)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << mtx;
+    return HexStr(ss.begin(), ss.end());
+}
+
 // -----------------------------------------------------------------------
 // Round-trip serialize/deserialize
 // -----------------------------------------------------------------------
@@ -114,7 +121,7 @@ BOOST_AUTO_TEST_CASE(pstt_roundtrip_basic)
     BOOST_CHECK_EQUAL(parsed.outputs.size(), 1U);
     BOOST_CHECK(parsed.inputs[0].previous_txid_set);
     BOOST_CHECK(parsed.inputs[0].previous_txid == pstt.inputs[0].previous_txid);
-    BOOST_CHECK_EQUAL(parsed.inputs[0].prev_out_index, pstt.inputs[0].prev_out_index);
+    BOOST_CHECK_EQUAL(parsed.inputs[0].prevout_index, pstt.inputs[0].prevout_index);
     BOOST_CHECK(parsed.inputs[0].utxo->GetHashMalFix() == pstt.inputs[0].utxo->GetHashMalFix());
     BOOST_CHECK_EQUAL(*parsed.outputs[0].amount, *pstt.outputs[0].amount);
     BOOST_CHECK(parsed.outputs[0].script == pstt.outputs[0].script);
@@ -541,9 +548,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_p2pk_coinbase_spend, TestChainSetup)
     pstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput input;
     input.previous_txid = prevTx->GetHashMalFix();
-    input.prev_out_index = 0;
+    input.prevout_index = 0;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     input.utxo = prevTx;
     pstt.inputs.push_back(input);
 
@@ -572,9 +579,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_schnorr_spend, TestChainSetup)
     pstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput input;
     input.previous_txid = prevTx->GetHashMalFix();
-    input.prev_out_index = 0;
+    input.prevout_index = 0;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     input.utxo = prevTx;
     pstt.inputs.push_back(input);
 
@@ -606,9 +613,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_wrong_key, TestChainSetup)
     pstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput input;
     input.previous_txid = prevTx->GetHashMalFix();
-    input.prev_out_index = 0;
+    input.prevout_index = 0;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     input.utxo = prevTx;
     pstt.inputs.push_back(input);
 
@@ -638,9 +645,9 @@ static std::pair<CTransactionRef, CKey> MakeConfirmedP2PKHCoin(TestChainSetup& s
     pstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput input;
     input.previous_txid = coinbaseTx->GetHashMalFix();
-    input.prev_out_index = 0;
+    input.prevout_index = 0;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     input.utxo = coinbaseTx;
     pstt.inputs.push_back(input);
 
@@ -676,9 +683,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_colored_issue_and_transfer, TestChain
     issuePstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput issueInput;
     issueInput.previous_txid = p2pkhTx->GetHashMalFix();
-    issueInput.prev_out_index = 0;
+    issueInput.prevout_index = 0;
     issueInput.previous_txid_set = true;
-    issueInput.prev_out_index_set = true;
+    issueInput.prevout_index_set = true;
     issueInput.utxo = p2pkhTx;
     issuePstt.inputs.push_back(issueInput);
 
@@ -713,17 +720,17 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_valid_colored_issue_and_transfer, TestChain
 
     PSTTInput coloredInput;
     coloredInput.previous_txid = issueTx->GetHashMalFix();
-    coloredInput.prev_out_index = 0;
+    coloredInput.prevout_index = 0;
     coloredInput.previous_txid_set = true;
-    coloredInput.prev_out_index_set = true;
+    coloredInput.prevout_index_set = true;
     coloredInput.utxo = issueTx;
     transferPstt.inputs.push_back(coloredInput);
 
     PSTTInput feeInput;
     feeInput.previous_txid = feeTx->GetHashMalFix();
-    feeInput.prev_out_index = 0;
+    feeInput.prevout_index = 0;
     feeInput.previous_txid_set = true;
-    feeInput.prev_out_index_set = true;
+    feeInput.prevout_index_set = true;
     feeInput.utxo = feeTx;
     transferPstt.inputs.push_back(feeInput);
 
@@ -764,9 +771,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_token_without_fee, TestChainSetup)
     issuePstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput issueInput;
     issueInput.previous_txid = p2pkhTx->GetHashMalFix();
-    issueInput.prev_out_index = 0;
+    issueInput.prevout_index = 0;
     issueInput.previous_txid_set = true;
-    issueInput.prev_out_index_set = true;
+    issueInput.prevout_index_set = true;
     issueInput.utxo = p2pkhTx;
     issuePstt.inputs.push_back(issueInput);
 
@@ -793,9 +800,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_extract_invalid_token_without_fee, TestChainSetup)
     transferPstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput coloredInput;
     coloredInput.previous_txid = issueTx->GetHashMalFix();
-    coloredInput.prev_out_index = 0;
+    coloredInput.prevout_index = 0;
     coloredInput.previous_txid_set = true;
-    coloredInput.prev_out_index_set = true;
+    coloredInput.prevout_index_set = true;
     coloredInput.utxo = issueTx;
     transferPstt.inputs.push_back(coloredInput);
 
@@ -886,9 +893,9 @@ static MultisigSpendPair MakeUnmergedMultisigSpendPair(TestChainSetup& setup)
     fundingPstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput fundingInput;
     fundingInput.previous_txid = coinbaseTx->GetHashMalFix();
-    fundingInput.prev_out_index = 0;
+    fundingInput.prevout_index = 0;
     fundingInput.previous_txid_set = true;
-    fundingInput.prev_out_index_set = true;
+    fundingInput.prevout_index_set = true;
     fundingInput.utxo = coinbaseTx;
     fundingPstt.inputs.push_back(fundingInput);
     PSTTOutput fundingOutput;
@@ -911,9 +918,9 @@ static MultisigSpendPair MakeUnmergedMultisigSpendPair(TestChainSetup& setup)
         pstt.tx_features = CTransaction::CURRENT_FEATURES;
         PSTTInput input;
         input.previous_txid = multisigUtxo->GetHashMalFix();
-        input.prev_out_index = 0;
+        input.prevout_index = 0;
         input.previous_txid_set = true;
-        input.prev_out_index_set = true;
+        input.prevout_index_set = true;
         input.utxo = multisigUtxo;
         input.redeem_script = redeemScript;
         pstt.inputs.push_back(input);
@@ -992,9 +999,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_mixed_scheme_rejected_construction_and_execution_ag
     fundingPstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput fundingInput;
     fundingInput.previous_txid = coinbaseTx->GetHashMalFix();
-    fundingInput.prev_out_index = 0;
+    fundingInput.prevout_index = 0;
     fundingInput.previous_txid_set = true;
-    fundingInput.prev_out_index_set = true;
+    fundingInput.prevout_index_set = true;
     fundingInput.utxo = coinbaseTx;
     fundingPstt.inputs.push_back(fundingInput);
     PSTTOutput fundingOutput;
@@ -1014,9 +1021,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_mixed_scheme_rejected_construction_and_execution_ag
         pstt.tx_features = CTransaction::CURRENT_FEATURES;
         PSTTInput input;
         input.previous_txid = multisigUtxo->GetHashMalFix();
-        input.prev_out_index = 0;
+        input.prevout_index = 0;
         input.previous_txid_set = true;
-        input.prev_out_index_set = true;
+        input.prevout_index_set = true;
         input.utxo = multisigUtxo;
         input.redeem_script = redeemScript;
         pstt.inputs.push_back(input);
@@ -1207,9 +1214,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_signpsttwithkey_p2pk_coinbase_spend, TestChainS
     pstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput input;
     input.previous_txid = prevTx->GetHashMalFix();
-    input.prev_out_index = 0;
+    input.prevout_index = 0;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     input.utxo = prevTx;
     pstt.inputs.push_back(input);
 
@@ -1296,7 +1303,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_strips_signing_only_fields, TestCh
 BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_partial_completion_mixed_missing_utxo, TestChainSetup)
 {
     // Input 0 has both required multisig partial sigs already (finalizepstt
-    // can complete it). Input 1 has a previous_txid/prev_out_index but no
+    // can complete it). Input 1 has a previous_txid/prevout_index but no
     // attached UTXO at all -- as if a co-signer's Constructor/Updater step
     // hasn't happened yet. finalizepstt must finalize what it can and
     // report complete=false for the whole PSTT, not throw.
@@ -1317,9 +1324,9 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_partial_completion_mixed_missing_u
     fundingPstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput fundingInput;
     fundingInput.previous_txid = coinbaseTx->GetHashMalFix();
-    fundingInput.prev_out_index = 0;
+    fundingInput.prevout_index = 0;
     fundingInput.previous_txid_set = true;
-    fundingInput.prev_out_index_set = true;
+    fundingInput.prevout_index_set = true;
     fundingInput.utxo = coinbaseTx;
     fundingPstt.inputs.push_back(fundingInput);
     PSTTOutput fundingOutput;
@@ -1342,18 +1349,18 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_finalizepstt_partial_completion_mixed_missing_u
 
         PSTTInput multisigInput;
         multisigInput.previous_txid = multisigUtxo->GetHashMalFix();
-        multisigInput.prev_out_index = 0;
+        multisigInput.prevout_index = 0;
         multisigInput.previous_txid_set = true;
-        multisigInput.prev_out_index_set = true;
+        multisigInput.prevout_index_set = true;
         multisigInput.utxo = multisigUtxo;
         multisigInput.redeem_script = redeemScript;
         pstt.inputs.push_back(multisigInput);
 
         PSTTInput missingUtxoInput;
         missingUtxoInput.previous_txid = missingUtxoTxid;
-        missingUtxoInput.prev_out_index = 0;
+        missingUtxoInput.prevout_index = 0;
         missingUtxoInput.previous_txid_set = true;
-        missingUtxoInput.prev_out_index_set = true;
+        missingUtxoInput.prevout_index_set = true;
         pstt.inputs.push_back(missingUtxoInput);
 
         PSTTOutput output;
@@ -1439,6 +1446,316 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_shape, TestChainSetup)
     const UniValue& out0 = outputs[0];
     BOOST_CHECK(out0.exists("amount_raw"));
     BOOST_CHECK(out0.exists("script"));
+}
+
+// -----------------------------------------------------------------------
+// decodepstt's "next" role hint / estimated_size / estimated_fee
+// -----------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_constructor)
+{
+    // Still under construction (an Inputs/Outputs-Modifiable bit set) takes
+    // priority over every other state -- irrelevant here whether the lone
+    // input is even signable yet.
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE;
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "constructor");
+    // Estimates are still offered even mid-construction -- a running
+    // estimate is useful to a caller building up a PSTT incrementally --
+    // just documented as subject to change (see decodepstt's help text).
+    BOOST_CHECK(decoded.exists("estimated_size"));
+    BOOST_CHECK(decoded.exists("estimated_fee"));
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_updater)
+{
+    // No PSTT_IN_UTXO attached yet -- ahead of Signer in the ladder, and
+    // means no fee/size estimate is even possible (an input's value/type
+    // isn't knowable without it).
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.inputs[0].utxo.reset();
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "updater");
+    BOOST_CHECK(!decoded.exists("estimated_size"));
+    BOOST_CHECK(!decoded.exists("estimated_fee"));
+}
+
+BOOST_AUTO_TEST_CASE(pstt_rpc_decodepstt_next_role_signer_and_estimates)
+{
+    // Construction finished, UTXO attached, no signature yet -- Signer is
+    // next. The 100000/90000 split from MakeBasicPstt() gives an exact,
+    // known 10000 fee to check the estimate against; estimated_size only
+    // needs to be in a sane P2PKH-with-one-dummy-signature ballpark, not an
+    // exact byte count (EstimateInputScriptSig's dummy signature length can
+    // legitimately vary by a byte or two).
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "signer");
+    BOOST_REQUIRE(decoded.exists("estimated_fee"));
+    BOOST_CHECK_EQUAL(ValueFromAmount(10000).write(), decoded.find_value("estimated_fee").write());
+    BOOST_REQUIRE(decoded.exists("estimated_size"));
+    int64_t size = decoded.find_value("estimated_size").get_int64();
+    BOOST_CHECK(size > 100 && size < 400);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_finalizer, TestChainSetup)
+{
+    // Every required signature already collected (via Combiner), but
+    // nothing finalized yet -- Finalizer is next, not Signer.
+    MultisigSpendPair fx = MakeUnmergedMultisigSpendPair(*this);
+    PartiallySignedTapyrusTransaction merged = fx.signedByA;
+    merged.Merge(fx.signedByB);
+    BOOST_REQUIRE_EQUAL(merged.inputs[0].partial_sigs.size(), 2U);
+    BOOST_REQUIRE(merged.inputs[0].final_script_sig.empty());
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(merged));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "finalizer");
+    BOOST_CHECK(decoded.exists("estimated_size"));
+    BOOST_CHECK(decoded.exists("estimated_fee"));
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_decodepstt_next_role_extractor, TestChainSetup)
+{
+    // Fully finalized -- Extractor is next, and estimated_size should match
+    // the real extracted transaction's actual size exactly (not just be "in
+    // range"): every input already carries its real final_script_sig, so
+    // EstimatePsttSize takes the "already finalized" branch for all of them,
+    // no dummy signatures involved.
+    MultisigSpendPair fx = MakeUnmergedMultisigSpendPair(*this);
+    PartiallySignedTapyrusTransaction merged = fx.signedByA;
+    merged.Merge(fx.signedByB);
+    SignatureData finalSigdata;
+    BOOST_REQUIRE(SignPSTTInput(DUMMY_SIGNING_PROVIDER, merged, 0, finalSigdata, SIGHASH_ALL, SignatureScheme::ECDSA) == PSTTSignResult::OK);
+    merged.inputs[0].FromSignatureData(finalSigdata);
+    BOOST_REQUIRE(!merged.inputs[0].final_script_sig.empty());
+
+    CMutableTransaction extracted = ExtractPSTT(merged);
+    int64_t actual_size = ::GetSerializeSize(CTransaction(extracted), SER_NETWORK, PROTOCOL_VERSION);
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(merged));
+    UniValue decoded = CallPsttRPC("decodepstt", params);
+
+    BOOST_CHECK_EQUAL(decoded.find_value("next").get_str(), "extractor");
+    BOOST_CHECK_EQUAL(decoded.find_value("estimated_size").get_int64(), actual_size);
+}
+
+// -----------------------------------------------------------------------
+// updatepstt: the non-wallet Updater (caller-supplied previous transactions,
+// no loaded wallet needed).
+// -----------------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_updatepstt_attaches_matching_utxo, TestingSetup)
+{
+    CScript scriptPubKey = RandomP2PKHScript();
+    CTransactionRef utxo = MakeSimpleUtxoTx(scriptPubKey, 100000);
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = utxo->GetHashMalFix();
+    input.prevout_index = 0;
+    input.previous_txid_set = true;
+    input.prevout_index_set = true;
+    // Deliberately no utxo attached yet -- that's updatepstt's job.
+    pstt.inputs.push_back(input);
+    PSTTOutput output;
+    output.amount = 90000;
+    output.script = RandomP2PKHScript();
+    pstt.outputs.push_back(output);
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodeHexTxForTest(CMutableTransaction(*utxo)));
+    // An unrelated tx too, to prove a non-matching supplied tx is silently
+    // ignored rather than erroring.
+    txs.push_back(EncodeHexTxForTest(CMutableTransaction(*MakeSimpleUtxoTx(RandomP2PKHScript(), 555))));
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    params.push_back(txs);
+    UniValue result = CallPsttRPC("updatepstt", params);
+
+    BOOST_CHECK(result.find_value("all_utxos_attached").get_bool());
+    PartiallySignedTapyrusTransaction updated;
+    std::string err;
+    BOOST_REQUIRE(DecodePSTT(updated, result.find_value("pstt").get_str(), err));
+    BOOST_REQUIRE(updated.inputs[0].utxo);
+    BOOST_CHECK_EQUAL(updated.inputs[0].utxo->GetHashMalFix(), utxo->GetHashMalFix());
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_updatepstt_rejects_out_of_range_prevout, TestingSetup)
+{
+    CScript scriptPubKey = RandomP2PKHScript();
+    CTransactionRef utxo = MakeSimpleUtxoTx(scriptPubKey, 100000); // exactly one vout
+
+    PartiallySignedTapyrusTransaction pstt;
+    pstt.tx_features = CTransaction::CURRENT_FEATURES;
+    PSTTInput input;
+    input.previous_txid = utxo->GetHashMalFix();
+    input.prevout_index = 5; // out of range for a one-vout tx
+    input.previous_txid_set = true;
+    input.prevout_index_set = true;
+    pstt.inputs.push_back(input);
+    PSTTOutput output;
+    output.amount = 90000;
+    output.script = RandomP2PKHScript();
+    pstt.outputs.push_back(output);
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodeHexTxForTest(CMutableTransaction(*utxo)));
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    params.push_back(txs);
+    BOOST_CHECK_THROW(CallPsttRPC("updatepstt", params), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_updatepstt_leaves_unmatched_input_for_later_round, TestingSetup)
+{
+    // First input already has a utxo (MakeBasicPstt) -- confirms updatepstt
+    // never overwrites what's already attached. Second input has neither a
+    // utxo nor a matching supplied tx -- confirms it's left alone, not
+    // treated as an error, for a later Updater round to resolve.
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    CTransactionRef otherUtxo = MakeSimpleUtxoTx(RandomP2PKHScript(), 50000);
+    PSTTInput secondInput;
+    secondInput.previous_txid = otherUtxo->GetHashMalFix();
+    secondInput.prevout_index = 0;
+    secondInput.previous_txid_set = true;
+    secondInput.prevout_index_set = true;
+    pstt.inputs.push_back(secondInput);
+
+    UniValue txs(UniValue::VARR); // nothing supplied for the second input
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodePSTT(pstt));
+    params.push_back(txs);
+    UniValue result = CallPsttRPC("updatepstt", params);
+
+    BOOST_CHECK(!result.find_value("all_utxos_attached").get_bool());
+    PartiallySignedTapyrusTransaction updated;
+    std::string err;
+    BOOST_REQUIRE(DecodePSTT(updated, result.find_value("pstt").get_str(), err));
+    BOOST_REQUIRE(updated.inputs[0].utxo); // first input's existing utxo preserved
+    BOOST_CHECK(!updated.inputs[1].utxo);  // second input still unattached
+}
+
+// -----------------------------------------------------------------------
+// joinpstt RPC-dispatch tests, via the real registered actor (tableRPC).
+// -----------------------------------------------------------------------
+
+static PartiallySignedTapyrusTransaction MakeJoinableConstructorPstt()
+{
+    PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
+    pstt.tx_modifiable = PSTT_TXMOD_INPUTS_MODIFIABLE | PSTT_TXMOD_OUTPUTS_MODIFIABLE;
+    return pstt;
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_concatenates_inputs_and_outputs, TestingSetup)
+{
+    PartiallySignedTapyrusTransaction a = MakeJoinableConstructorPstt();
+    PartiallySignedTapyrusTransaction b = MakeJoinableConstructorPstt();
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(a));
+    txs.push_back(EncodePSTT(b));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+    UniValue result = CallPsttRPC("joinpstt", params);
+
+    PartiallySignedTapyrusTransaction joined;
+    std::string err;
+    BOOST_REQUIRE(DecodePSTT(joined, result.get_str(), err));
+    BOOST_CHECK_EQUAL(joined.inputs.size(), a.inputs.size() + b.inputs.size());
+    BOOST_CHECK_EQUAL(joined.outputs.size(), a.outputs.size() + b.outputs.size());
+    uint8_t modifiable = joined.tx_modifiable.value_or(0);
+    BOOST_CHECK(modifiable & PSTT_TXMOD_INPUTS_MODIFIABLE);
+    BOOST_CHECK(modifiable & PSTT_TXMOD_OUTPUTS_MODIFIABLE);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_requires_at_least_two, TestingSetup)
+{
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(MakeJoinableConstructorPstt()));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+
+    BOOST_CHECK_THROW(CallPsttRPC("joinpstt", params), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_rejects_pstt_not_under_construction, TestingSetup)
+{
+    // MakeBasicPstt() leaves tx_modifiable absent -- not still under
+    // construction, so it must not be joinable.
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(MakeJoinableConstructorPstt()));
+    txs.push_back(EncodePSTT(MakeBasicPstt()));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+
+    BOOST_CHECK_THROW(CallPsttRPC("joinpstt", params), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_rejects_has_sighash_single_flag, TestingSetup)
+{
+    PartiallySignedTapyrusTransaction withSighashSingle = MakeJoinableConstructorPstt();
+    withSighashSingle.tx_modifiable = *withSighashSingle.tx_modifiable | PSTT_TXMOD_HAS_SIGHASH_SINGLE;
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(MakeJoinableConstructorPstt()));
+    txs.push_back(EncodePSTT(withSighashSingle));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+
+    BOOST_CHECK_THROW(CallPsttRPC("joinpstt", params), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_rejects_already_signed_input, TestingSetup)
+{
+    PartiallySignedTapyrusTransaction signedPstt = MakeJoinableConstructorPstt();
+    CKey key;
+    key.MakeNewKey(true);
+    std::vector<unsigned char> sig(71, 0x11);
+    sig.push_back(SIGHASH_ALL);
+    signedPstt.inputs[0].partial_sigs.emplace(key.GetPubKey().GetID(), SigPair(key.GetPubKey(), sig));
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(MakeJoinableConstructorPstt()));
+    txs.push_back(EncodePSTT(signedPstt));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+
+    BOOST_CHECK_THROW(CallPsttRPC("joinpstt", params), UniValue);
+}
+
+BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_rejects_duplicate_outpoint, TestingSetup)
+{
+    PartiallySignedTapyrusTransaction a = MakeJoinableConstructorPstt();
+    PartiallySignedTapyrusTransaction b = MakeJoinableConstructorPstt();
+    b.inputs[0] = a.inputs[0]; // same previous_txid/prevout_index as a's input
+
+    UniValue txs(UniValue::VARR);
+    txs.push_back(EncodePSTT(a));
+    txs.push_back(EncodePSTT(b));
+    UniValue params(UniValue::VARR);
+    params.push_back(txs);
+
+    BOOST_CHECK_THROW(CallPsttRPC("joinpstt", params), UniValue);
 }
 
 // -----------------------------------------------------------------------
@@ -1629,13 +1946,13 @@ BOOST_AUTO_TEST_CASE(pstt_sign_utxo_txid_mismatch)
     BOOST_CHECK(result == PSTTSignResult::UTXO_TXID_MISMATCH);
 }
 
-BOOST_AUTO_TEST_CASE(pstt_sign_prev_out_index_oob)
+BOOST_AUTO_TEST_CASE(pstt_sign_prevout_index_oob)
 {
     PartiallySignedTapyrusTransaction pstt = MakeBasicPstt();
-    pstt.inputs[0].prev_out_index = 5; // utxo only has a single output (index 0)
+    pstt.inputs[0].prevout_index = 5; // utxo only has a single output (index 0)
     SignatureData sigdata;
     PSTTSignResult result = SignPSTTInput(DUMMY_SIGNING_PROVIDER, pstt, 0, sigdata, SIGHASH_ALL);
-    BOOST_CHECK(result == PSTTSignResult::PREV_OUT_INDEX_OOB);
+    BOOST_CHECK(result == PSTTSignResult::PREVOUT_INDEX_OOB);
 }
 
 BOOST_AUTO_TEST_CASE(pstt_sign_redeem_script_hash_mismatch)
@@ -1761,13 +2078,6 @@ BOOST_AUTO_TEST_CASE(pstt_sign_scheme_conflict)
 // finalizepsttconstruction) RPCs, via the real registered actors (tableRPC).
 // -----------------------------------------------------------------------
 
-static std::string EncodeHexTxForTest(const CMutableTransaction& mtx)
-{
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss << mtx;
-    return HexStr(ss.begin(), ss.end());
-}
-
 static UniValue MakeCreatepsttInputEntry(const uint256& txid, uint32_t vout)
 {
     UniValue input(UniValue::VOBJ);
@@ -1809,7 +2119,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_createpstt_basic_roundtrip, TestingSetup)
     BOOST_CHECK_EQUAL(*pstt.tx_features, CTransaction::CURRENT_FEATURES);
     BOOST_REQUIRE_EQUAL(pstt.inputs.size(), 1U);
     BOOST_CHECK(pstt.inputs[0].previous_txid == utxo->GetHashMalFix());
-    BOOST_CHECK_EQUAL(pstt.inputs[0].prev_out_index, 0U);
+    BOOST_CHECK_EQUAL(pstt.inputs[0].prevout_index, 0U);
     BOOST_REQUIRE_EQUAL(pstt.outputs.size(), 1U);
     BOOST_CHECK_EQUAL(*pstt.outputs[0].amount, 90000);
     // No flags requested -- default createpstt leaves tx_modifiable absent
@@ -1920,7 +2230,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_addinputtopstt_appends_and_increments, TestingS
     BOOST_REQUIRE(DecodePSTT(pstt, added.get_str(), error));
     BOOST_REQUIRE_EQUAL(pstt.inputs.size(), 1U);
     BOOST_CHECK(pstt.inputs[0].previous_txid == utxo->GetHashMalFix());
-    BOOST_CHECK_EQUAL(pstt.inputs[0].prev_out_index, 0U);
+    BOOST_CHECK_EQUAL(pstt.inputs[0].prevout_index, 0U);
     BOOST_REQUIRE(pstt.inputs[0].sequence);
     BOOST_CHECK_EQUAL(*pstt.inputs[0].sequence, 0xFFFFFFFEu);
 }

--- a/src/test/pstt_tests.cpp
+++ b/src/test/pstt_tests.cpp
@@ -418,6 +418,7 @@ BOOST_AUTO_TEST_CASE(pstt_xpub_roundtrip_matching_prefix)
     key.MakeNewKey(true);
     xpub.pubkey = key.GetPubKey();
     xpub.nDepth = 1;
+    memset(xpub.vchFingerprint, 0, sizeof(xpub.vchFingerprint));
     xpub.nChild = 0;
     xpub.chaincode.SetNull();
 
@@ -434,6 +435,7 @@ BOOST_AUTO_TEST_CASE(pstt_xpub_rejects_wrong_network_prefix)
     key.MakeNewKey(true);
     xpub.pubkey = key.GetPubKey();
     xpub.nDepth = 0;
+    memset(xpub.vchFingerprint, 0, sizeof(xpub.vchFingerprint));
     xpub.nChild = 0;
     xpub.chaincode.SetNull();
 
@@ -453,6 +455,7 @@ BOOST_AUTO_TEST_CASE(pstt_xpub_rejects_unknown_prefix)
     key.MakeNewKey(true);
     xpub.pubkey = key.GetPubKey();
     xpub.nDepth = 0;
+    memset(xpub.vchFingerprint, 0, sizeof(xpub.vchFingerprint));
     xpub.nChild = 0;
     xpub.chaincode.SetNull();
 
@@ -1893,6 +1896,7 @@ BOOST_FIXTURE_TEST_CASE(pstt_rpc_joinpstt_dedups_shared_xpub, TestingSetup)
     key.MakeNewKey(true);
     xpub.pubkey = key.GetPubKey();
     xpub.nDepth = 1;
+    memset(xpub.vchFingerprint, 0, sizeof(xpub.vchFingerprint));
     xpub.nChild = 0;
     xpub.chaincode.SetNull();
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(rpc_pstt_params)
     BOOST_REQUIRE(DecodePSTT(populated, r.get_str(), decodeErr));
     BOOST_REQUIRE_EQUAL(populated.inputs.size(), 1U);
     BOOST_CHECK_EQUAL(populated.inputs[0].previous_txid.GetHex(), dummy_txid);
-    BOOST_CHECK_EQUAL(populated.inputs[0].prev_out_index, 0U);
+    BOOST_CHECK_EQUAL(populated.inputs[0].prevout_index, 0U);
 
     // combinepstt: txs(0)=array.
     BOOST_CHECK_NO_THROW(CallRPC(std::string("combinepstt [\"")+pstt+"\"]"));

--- a/src/wallet/pstt.cpp
+++ b/src/wallet/pstt.cpp
@@ -27,7 +27,7 @@ bool FillPSTT(const CWallet* pwallet, PartiallySignedTapyrusTransaction& pstt, i
             const auto it = pwallet->mapWallet.find(input.previous_txid);
             if (it != pwallet->mapWallet.end()) {
                 const CWalletTx& wtx = it->second;
-                if (input.prev_out_index_set && input.prev_out_index >= wtx.tx->vout.size()) {
+                if (input.prevout_index_set && input.prevout_index >= wtx.tx->vout.size()) {
                     throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Input prevout index out of range");
                 }
                 input.utxo = wtx.tx;
@@ -130,12 +130,12 @@ void ComputePsttColorBalances(const PartiallySignedTapyrusTransaction& pstt,
                                TxColoredCoinBalancesMap& in, TxColoredCoinBalancesMap& out)
 {
     for (const PSTTInput& input : pstt.inputs) {
-        if (!input.utxo || !input.prev_out_index_set || input.prev_out_index >= input.utxo->vout.size()) {
+        if (!input.utxo || !input.prevout_index_set || input.prevout_index >= input.utxo->vout.size()) {
             continue; // color/amount not knowable without an attached UTXO
         }
-        const CTxOut& utxo_out = input.utxo->vout[input.prev_out_index];
-        ColorIdentifier colorId = GetColorIdFromScript(utxo_out.scriptPubKey);
-        in[colorId] += utxo_out.nValue;
+        const CTxOut& utxo = input.utxo->vout[input.prevout_index];
+        ColorIdentifier colorId = GetColorIdFromScript(utxo.scriptPubKey);
+        in[colorId] += utxo.nValue;
     }
     for (const PSTTOutput& output : pstt.outputs) {
         if (!output.amount || output.script.empty()) continue;

--- a/src/wallet/pstt.cpp
+++ b/src/wallet/pstt.cpp
@@ -133,9 +133,9 @@ void ComputePsttColorBalances(const PartiallySignedTapyrusTransaction& pstt,
         if (!input.utxo || !input.prevout_index_set || input.prevout_index >= input.utxo->vout.size()) {
             continue; // color/amount not knowable without an attached UTXO
         }
-        const CTxOut& utxo = input.utxo->vout[input.prevout_index];
-        ColorIdentifier colorId = GetColorIdFromScript(utxo.scriptPubKey);
-        in[colorId] += utxo.nValue;
+        const CTxOut& utxo_out = input.utxo->vout[input.prevout_index];
+        ColorIdentifier colorId = GetColorIdFromScript(utxo_out.scriptPubKey);
+        in[colorId] += utxo_out.nValue;
     }
     for (const PSTTOutput& output : pstt.outputs) {
         if (!output.amount || output.script.empty()) continue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4270,9 +4270,9 @@ UniValue walletcreatefundedpstt(const JSONRPCRequest& request)
     for (const CTxIn& txin : rawTx.vin) {
         PSTTInput input;
         input.previous_txid = txin.prevout.hashMalFix;
-        input.prev_out_index = txin.prevout.n;
+        input.prevout_index = txin.prevout.n;
         input.previous_txid_set = true;
-        input.prev_out_index_set = true;
+        input.prevout_index_set = true;
         if (txin.nSequence != CTxIn::SEQUENCE_FINAL) input.sequence = txin.nSequence;
         pstt.inputs.push_back(std::move(input));
     }
@@ -4412,9 +4412,9 @@ UniValue walletfundpsttfee(const JSONRPCRequest& request)
 
         PSTTInput input;
         input.previous_txid = txid;
-        input.prev_out_index = (uint32_t)nOutput;
+        input.prevout_index = (uint32_t)nOutput;
         input.previous_txid_set = true;
-        input.prev_out_index_set = true;
+        input.prevout_index_set = true;
         input.utxo = feeTx;
         pstt.inputs.push_back(std::move(input));
     } else {
@@ -4433,7 +4433,7 @@ UniValue walletfundpsttfee(const JSONRPCRequest& request)
         rawTx.nFeatures = pstt.tx_features.value_or(CTransaction::CURRENT_FEATURES);
         for (const PSTTInput& in : pstt.inputs) {
             CTxIn txin;
-            txin.prevout = COutPoint(in.previous_txid, in.prev_out_index);
+            txin.prevout = COutPoint(in.previous_txid, in.prevout_index);
             txin.nSequence = in.sequence.value_or(CTxIn::SEQUENCE_FINAL);
             rawTx.vin.push_back(txin);
         }
@@ -4476,9 +4476,9 @@ UniValue walletfundpsttfee(const JSONRPCRequest& request)
             const CTxIn& txin = rawTx.vin[i];
             PSTTInput input;
             input.previous_txid = txin.prevout.hashMalFix;
-            input.prev_out_index = txin.prevout.n;
+            input.prevout_index = txin.prevout.n;
             input.previous_txid_set = true;
-            input.prev_out_index_set = true;
+            input.prevout_index_set = true;
             if (txin.nSequence != CTxIn::SEQUENCE_FINAL) input.sequence = txin.nSequence;
             pstt.inputs.push_back(std::move(input));
         }

--- a/src/wallet/test/pstt_wallet_tests.cpp
+++ b/src/wallet/test/pstt_wallet_tests.cpp
@@ -116,9 +116,9 @@ static CTransactionRef FundWalletWithP2PKHCoin(TestWalletSetup& setup, CAmount a
     pstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput input;
     input.previous_txid = coinbaseTx->GetHashMalFix();
-    input.prev_out_index = 0;
+    input.prevout_index = 0;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     input.utxo = coinbaseTx;
     pstt.inputs.push_back(input);
 
@@ -152,9 +152,9 @@ static PartiallySignedTapyrusTransaction MakeUnsignedSpendPstt(const CTransactio
     pstt.tx_features = CTransaction::CURRENT_FEATURES;
     PSTTInput input;
     input.previous_txid = fundingTx->GetHashMalFix();
-    input.prev_out_index = 0;
+    input.prevout_index = 0;
     input.previous_txid_set = true;
-    input.prev_out_index_set = true;
+    input.prevout_index_set = true;
     pstt.inputs.push_back(input);
 
     PSTTOutput output;
@@ -489,17 +489,17 @@ BOOST_FIXTURE_TEST_CASE(pstt_updater_never_mutates_sequence, WalletTestingSetup)
 
     PSTTInput input0;
     input0.previous_txid = prevTx1->GetHashMalFix();
-    input0.prev_out_index = 0;
+    input0.prevout_index = 0;
     input0.previous_txid_set = true;
-    input0.prev_out_index_set = true;
+    input0.prevout_index_set = true;
     input0.sequence = 0xFFFFFFFE;
     pstt.inputs.push_back(input0);
 
     PSTTInput input1;
     input1.previous_txid = prevTx2->GetHashMalFix();
-    input1.prev_out_index = 0;
+    input1.prevout_index = 0;
     input1.previous_txid_set = true;
-    input1.prev_out_index_set = true;
+    input1.prevout_index_set = true;
     input1.sequence = 0xFFFFFFFD;
     pstt.inputs.push_back(input1);
 

--- a/test/functional/feature_large_pstt.py
+++ b/test/functional/feature_large_pstt.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Chaintope Inc.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Stress-test PSTT construction at scale: large and very-large PSTTs (tens
+of inputs each), assembled via joinpstt (see doc/tapyrus/pstt.md's
+Constructor role) rather than one addinputtopstt call per input, then signed,
+finalized, and mined -- checking that multiple such transactions can fill a
+single block, and that a larger batch of them needs to span several blocks.
+
+Runs against a single node with a small -blockmaxsize so this is exercisable
+without building actual near-1MB transactions (which would only make the
+test slower, not exercise anything -blockmaxsize itself doesn't already
+cover) -- only the transaction *count* and relative *size* matter here, not
+real TPC value, so every input below is simply a whole, distinct coinbase
+UTXO from this node's own wallet.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+# Chosen with several hundred bytes of headroom on both sides of the fit/
+# no-fit boundary, since a P2PKH scriptSig's exact size varies by a couple of
+# bytes per input with DER signature encoding -- not a razor-thin fit that
+# would make this test flaky.
+BLOCK_MAX_SIZE = 10000
+
+# Two of these fill one block together (under BLOCK_MAX_SIZE); see
+# test_large_ptts_fill_one_block.
+LARGE_INPUT_COUNT = 28
+
+# Built via joinpstt out of this many separately-constructed pieces; the
+# result is already too big to share a block with another one like it, so
+# several of them each need their own block. See
+# test_very_large_pstts_span_blocks.
+VERY_LARGE_PIECE_COUNT = 3
+VERY_LARGE_INPUTS_PER_PIECE = 15
+VERY_LARGE_INPUT_COUNT = VERY_LARGE_PIECE_COUNT * VERY_LARGE_INPUTS_PER_PIECE
+VERY_LARGE_PSTT_COUNT = 3
+
+FEE = Decimal('0.01')
+
+
+class PSTTLargeScaleTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[f"-blockmaxsize={BLOCK_MAX_SIZE}"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        total_utxos_needed = 2 * LARGE_INPUT_COUNT + VERY_LARGE_PSTT_COUNT * VERY_LARGE_INPUT_COUNT
+        # A distinct coinbase UTXO per block, plus a little headroom.
+        node.generate(total_utxos_needed + 5, self.signblockprivkey_wif)
+
+        self.test_large_ptts_fill_one_block()
+        self.test_very_large_pstts_span_blocks()
+
+    def _spend_utxos_to_one_output(self, utxos):
+        """Builds, signs, and finalizes (but does not broadcast) a PSTT
+        spending every one of the given wallet UTXOs into a single
+        new-address output, via one createpstt call -- its own inputs array
+        already accepts however many are given, no addinputtopstt looping
+        needed for a single-party build like this one."""
+        node = self.nodes[0]
+        total = sum(u['amount'] for u in utxos)
+        pstt = node.createpstt(
+            [{"txid": u['txid'], "vout": u['vout']} for u in utxos],
+            {node.getnewaddress(): total - FEE},
+        )
+        processed = node.walletprocesspstt(pstt)
+        assert_equal(processed['complete'], True)
+        assert_equal(node.decodepstt(processed['pstt'])['next'], 'extractor')  # single-key P2PKH: walletprocesspstt already fully finalizes
+        return node.finalizepstt(processed['pstt'])['hex']
+
+    def _build_very_large_pstt(self, utxos):
+        """Builds one VERY_LARGE_INPUT_COUNT-input PSTT out of
+        VERY_LARGE_PIECE_COUNT separately-constructed pieces via joinpstt --
+        the scenario joinpstt exists for (see doc/tapyrus/pstt.md's
+        Constructor role): assembling a large PSTT without a single caller
+        driving one addinputtopstt call per input. Signs, finalizes, but
+        does not broadcast."""
+        node = self.nodes[0]
+        assert_equal(len(utxos), VERY_LARGE_INPUT_COUNT)
+
+        pieces = []
+        for i in range(VERY_LARGE_PIECE_COUNT):
+            chunk = utxos[i * VERY_LARGE_INPUTS_PER_PIECE:(i + 1) * VERY_LARGE_INPUTS_PER_PIECE]
+            pieces.append(node.createpstt(
+                [{"txid": u['txid'], "vout": u['vout']} for u in chunk],
+                [], 0, True, True,
+            ))
+        joined = node.joinpstt(pieces)
+        decoded_joined = node.decodepstt(joined)
+        assert_equal(len(decoded_joined['inputs']), VERY_LARGE_INPUT_COUNT)
+        assert_equal(len(decoded_joined['outputs']), 0)
+
+        total = sum(u['amount'] for u in utxos)
+        with_output = node.addoutputtopstt(joined, {node.getnewaddress(): total - FEE})
+        finished = node.finalizepsttconstruction(with_output)
+
+        processed = node.walletprocesspstt(finished)
+        assert_equal(processed['complete'], True)
+        assert_equal(node.decodepstt(processed['pstt'])['next'], 'extractor')  # single-key P2PKH: walletprocesspstt already fully finalizes
+        return node.finalizepstt(processed['pstt'])['hex']
+
+    def test_large_ptts_fill_one_block(self):
+        self.log.info("Test: multiple large PSTTs (%d inputs each) filling one block" % LARGE_INPUT_COUNT)
+        node = self.nodes[0]
+        unspent = node.listunspent()
+        assert len(unspent) >= 2 * LARGE_INPUT_COUNT, "not enough spendable UTXOs for this scenario"
+
+        txids = []
+        for i in range(2):
+            chunk = unspent[i * LARGE_INPUT_COUNT:(i + 1) * LARGE_INPUT_COUNT]
+            hex_tx = self._spend_utxos_to_one_output(chunk)
+            txids.append(node.sendrawtransaction(hex_tx, True))
+
+        assert_equal(node.getmempoolinfo()['size'], 2)
+        total_bytes = sum(node.getrawtransaction(t, True)['size'] for t in txids)
+
+        blockhash = node.generate(1, self.signblockprivkey_wif)[0]
+        assert_equal(node.getmempoolinfo()['size'], 0)
+        block = node.getblock(blockhash)
+        for txid in txids:
+            assert txid in block['tx']
+        self.log.info("    both large PSTTs (%d bytes total) confirmed together in one block" % total_bytes)
+
+    def test_very_large_pstts_span_blocks(self):
+        self.log.info("Test: very-large PSTTs (%d inputs each, built via joinpstt) spanning multiple blocks" % VERY_LARGE_INPUT_COUNT)
+        node = self.nodes[0]
+        unspent = node.listunspent()
+        assert len(unspent) >= VERY_LARGE_PSTT_COUNT * VERY_LARGE_INPUT_COUNT, "not enough spendable UTXOs for this scenario"
+
+        txids = []
+        for i in range(VERY_LARGE_PSTT_COUNT):
+            chunk = unspent[i * VERY_LARGE_INPUT_COUNT:(i + 1) * VERY_LARGE_INPUT_COUNT]
+            hex_tx = self._build_very_large_pstt(chunk)
+            txids.append(node.sendrawtransaction(hex_tx, True))
+
+        assert_equal(node.getmempoolinfo()['size'], VERY_LARGE_PSTT_COUNT)
+
+        # Each very-large PSTT was sized (via BLOCK_MAX_SIZE/joinpstt above)
+        # to need its own block, so clearing all of them must take exactly
+        # VERY_LARGE_PSTT_COUNT blocks -- never fewer (would mean two shared
+        # a block, undermining the "very-large" sizing) and never more
+        # (would mean mining stalled on one of them).
+        blocks_mined = 0
+        while node.getmempoolinfo()['size'] > 0:
+            node.generate(1, self.signblockprivkey_wif)
+            blocks_mined += 1
+            assert blocks_mined <= VERY_LARGE_PSTT_COUNT, "mining stalled -- a very-large PSTT should always fit in its own block"
+
+        assert_equal(blocks_mined, VERY_LARGE_PSTT_COUNT)
+        self.log.info("    %d very-large PSTTs required %d separate blocks to confirm" % (VERY_LARGE_PSTT_COUNT, blocks_mined))
+
+
+if __name__ == '__main__':
+    PSTTLargeScaleTest().main()

--- a/test/functional/feature_large_pstt.py
+++ b/test/functional/feature_large_pstt.py
@@ -73,7 +73,7 @@ class PSTTLargeScaleTest(BitcoinTestFramework):
         )
         processed = node.walletprocesspstt(pstt)
         assert_equal(processed['complete'], True)
-        assert_equal(node.decodepstt(processed['pstt'])['next'], 'extractor')  # single-key P2PKH: walletprocesspstt already fully finalizes
+        assert_equal(node.decodepstt(processed['pstt'])['next'], ['extractor'])  # single-key P2PKH: walletprocesspstt already fully finalizes
         return node.finalizepstt(processed['pstt'])['hex']
 
     def _build_very_large_pstt(self, utxos):
@@ -104,7 +104,7 @@ class PSTTLargeScaleTest(BitcoinTestFramework):
 
         processed = node.walletprocesspstt(finished)
         assert_equal(processed['complete'], True)
-        assert_equal(node.decodepstt(processed['pstt'])['next'], 'extractor')  # single-key P2PKH: walletprocesspstt already fully finalizes
+        assert_equal(node.decodepstt(processed['pstt'])['next'], ['extractor'])  # single-key P2PKH: walletprocesspstt already fully finalizes
         return node.finalizepstt(processed['pstt'])['hex']
 
     def test_large_ptts_fill_one_block(self):

--- a/test/functional/p2p_pstt.py
+++ b/test/functional/p2p_pstt.py
@@ -276,7 +276,7 @@ class PSTTNetworkTest(BitcoinTestFramework):
         self.final_reconciliation()
 
         expected_errors = {
-            'MISSING_UTXO', 'UTXO_TXID_MISMATCH', 'PREV_OUT_INDEX_OOB',
+            'MISSING_UTXO', 'UTXO_TXID_MISMATCH', 'PREVOUT_INDEX_OOB',
             'REDEEM_SCRIPT_HASH_MISMATCH', 'SIGHASH_CONFLICT',
             'SIGHASH_SINGLE_OOB', 'LOCKTIME_INVALID', 'SCHEME_CONFLICT',
         }
@@ -634,7 +634,7 @@ class PSTTNetworkTest(BitcoinTestFramework):
         addr_b = node_b.getnewaddress("errsim", color_b)
 
         self._sim_missing_utxo(entry_a, owner_a, addr_a)
-        self._sim_prev_out_index_oob(entry_a, owner_a, addr_a)
+        self._sim_prevout_index_oob(entry_a, owner_a, addr_a)
         self._sim_sighash_single_oob(entry_a, entry_b, addr_a)
         self._sim_utxo_txid_mismatch(entry_a, entry_b, owner_a, addr_a)
         self._sim_sighash_conflict(entry_a, owner_a, addr_a)
@@ -659,12 +659,12 @@ class PSTTNetworkTest(BitcoinTestFramework):
         assert 'final_scriptSig' not in decoded['inputs'][0]
         self.error_coverage.add('MISSING_UTXO')
 
-    def _sim_prev_out_index_oob(self, entry, owner, addr):
+    def _sim_prevout_index_oob(self, entry, owner, addr):
         node = self.nodes[owner]
         pstt = node.createpstt([], {addr: entry['amount']}, 0, True, False)
         pstt = node.addinputtopstt(pstt, entry['txid'], 99)
         assert_raises_rpc_error(None, "prevout index out of range", node.walletupdatepstt, pstt)
-        self.error_coverage.add('PREV_OUT_INDEX_OOB')
+        self.error_coverage.add('PREVOUT_INDEX_OOB')
 
     def _sim_sighash_single_oob(self, entry_a, entry_b, addr_a):
         # 2 inputs, 1 output -- signing input index 1 with SIGHASH_SINGLE

--- a/test/functional/rpc_pstt.py
+++ b/test/functional/rpc_pstt.py
@@ -34,6 +34,7 @@ doc/tapyrus/pstt.md's Constructor role description.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error, find_output, sync_blocks
 from test_framework.blocktools import create_colored_transaction
+from test_framework.messages import CTransaction, CTxOut
 
 from decimal import Decimal
 
@@ -66,6 +67,84 @@ def make_bare_pstt_with_unknown_global_field():
     unknown = lp(bytes([0xFC, 0x01])) + lp(bytes([0x42]))                  # PSTT_GLOBAL_PROPRIETARY, identifier 0x01, payload 0x42
     separator = bytes([0x00])
     return base64.b64encode(magic + tx_features + input_count + output_count + unknown + separator).decode()
+
+
+def make_pstt_output_missing_amount():
+    """Hand-builds a PSTT (zero inputs, one output) whose sole output carries
+    a PSTT_OUT_SCRIPT but no PSTT_OUT_AMOUNT -- the exact malformed shape
+    behind PSTTImplementation5's review finding #2 (EstimatePsttFee
+    dereferencing an unset boost::optional<CAmount>). PSTTOutput::IsSane()
+    requires amount present, and PartiallySignedTapyrusTransaction::
+    Unserialize() enforces IsSane() unconditionally at the end of parsing
+    (src/pstt.cpp), so this must be rejected by decodepstt at decode time,
+    the same as src/test/pstt_tests.cpp's
+    pstt_output_with_no_amount_fails_is_sane_and_unserialize checks at the
+    C++ level -- this is the same shape reaching the RPC boundary instead.
+    """
+    def lp(b):  # length-prefixed byte string (CompactSize len -- values used here are all < 0xfd)
+        return bytes([len(b)]) + b
+
+    magic = bytes([0x70, 0x73, 0x74, 0x74, 0xFF])  # "pstt" + 0xFF
+    tx_features = lp(bytes([0x02])) + lp(struct.pack("<i", 1))  # PSTT_GLOBAL_TX_FEATURES = 1
+    input_count = lp(bytes([0x04])) + lp(bytes([0x00]))         # PSTT_GLOBAL_INPUT_COUNT = 0
+    output_count = lp(bytes([0x05])) + lp(bytes([0x01]))        # PSTT_GLOBAL_OUTPUT_COUNT = 1
+    global_separator = bytes([0x00])
+
+    # The one output map: PSTT_OUT_SCRIPT (0x04) only -- no PSTT_OUT_AMOUNT
+    # (0x03). Script content is irrelevant to IsSane(), just needs to be
+    # non-empty.
+    out_script = lp(bytes([0x04])) + lp(bytes([0x51]))
+    out_separator = bytes([0x00])
+
+    return base64.b64encode(
+        magic + tx_features + input_count + output_count + global_separator
+        + out_script + out_separator
+    ).decode()
+
+
+def make_pstt_out_of_range_prevout_index():
+    """Hand-builds a PSTT with one input carrying a PSTT_IN_UTXO (a real,
+    single-output previous transaction) whose PSTT_IN_OUTPUT_INDEX is out of
+    range for that UTXO's own vout list -- the exact malformed shape behind
+    PSTTImplementation5's review finding #3 (EstimatePsttFee/
+    EstimateInputScriptSig indexing input.utxo->vout.at(prevout_index)
+    unchecked). PartiallySignedTapyrusTransaction::IsSane() range-checks
+    this directly (src/pstt.cpp), and Unserialize() enforces IsSane()
+    unconditionally, so this must be rejected by decodepstt at decode time
+    too -- same shape as pstt_tests.cpp's
+    pstt_out_of_range_prevout_index_fails_is_sane_and_unserialize, reaching
+    the RPC boundary instead of the C++ Unserialize() call directly.
+    """
+    def lp(b):
+        return bytes([len(b)]) + b
+
+    magic = bytes([0x70, 0x73, 0x74, 0x74, 0xFF])
+    tx_features = lp(bytes([0x02])) + lp(struct.pack("<i", 1))
+    input_count = lp(bytes([0x04])) + lp(bytes([0x01]))         # PSTT_GLOBAL_INPUT_COUNT = 1
+    output_count = lp(bytes([0x05])) + lp(bytes([0x01]))        # PSTT_GLOBAL_OUTPUT_COUNT = 1
+    global_separator = bytes([0x00])
+
+    # A real single-output previous transaction, embedded as PSTT_IN_UTXO.
+    utxo_tx = CTransaction()
+    utxo_tx.vout = [CTxOut(100000, bytes([0x51]))]
+    utxo_bytes = utxo_tx.serialize()
+
+    in_txid = lp(bytes([0x0e])) + lp(bytes([0x11]) * 32)        # PSTT_IN_PREVIOUS_TXID, arbitrary
+    in_index = lp(bytes([0x0f])) + lp(struct.pack("<I", 5))     # PSTT_IN_OUTPUT_INDEX = 5, out of range (utxo has only index 0)
+    in_utxo = lp(bytes([0x00])) + lp(utxo_bytes)                # PSTT_IN_UTXO
+    in_separator = bytes([0x00])
+
+    # One valid output, so the only defect anywhere in this PSTT is the
+    # input's out-of-range index.
+    out_amount = lp(bytes([0x03])) + lp(struct.pack("<q", 90000))
+    out_script = lp(bytes([0x04])) + lp(bytes([0x51]))
+    out_separator = bytes([0x00])
+
+    return base64.b64encode(
+        magic + tx_features + input_count + output_count + global_separator
+        + in_txid + in_index + in_utxo + in_separator
+        + out_amount + out_script + out_separator
+    ).decode()
 
 
 class PSTTTest(BitcoinTestFramework):
@@ -300,6 +379,27 @@ class PSTTTest(BitcoinTestFramework):
         unknown_out = self.nodes[0].walletprocesspstt(unknown_pstt)['pstt']
         assert_equal(unknown_pstt, unknown_out)
 
+        # PSTTImplementation5 review findings #2/#3: two malformed-but-
+        # structurally-decodable-looking PSTT shapes (missing output amount,
+        # out-of-range prevout_index on a UTXO-attached input) that were
+        # flagged as reachable, crash-inducing input at the decodepstt RPC
+        # layer. src/test/pstt_tests.cpp already confirms
+        # PartiallySignedTapyrusTransaction::IsSane()/Unserialize() reject
+        # both directly (a C++ std::ios_base::failure). Here, the same wire
+        # bytes reach decodepstt through the real RPC dispatch instead --
+        # the surfaced error is different (a JSON-RPC error object,
+        # RPC_DESERIALIZATION_ERROR, not a raw C++ exception type), so this
+        # closes the loop end to end: neither shape reaches decodepstt's own
+        # body through any real call, it's rejected earlier, at decode time,
+        # with a normal RPC error rather than a crash.
+        self.log.info('Test decodepstt rejects an output with no PSTT_OUT_AMOUNT')
+        assert_raises_rpc_error(-22, "PSTT is not sane",
+                                 self.nodes[0].decodepstt, make_pstt_output_missing_amount())
+
+        self.log.info('Test decodepstt rejects an out-of-range prevout_index on a UTXO-attached input')
+        assert_raises_rpc_error(-22, "PSTT is not sane",
+                                 self.nodes[0].decodepstt, make_pstt_out_of_range_prevout_index())
+
         # Constructor role: addinputtopstt/addoutputtopstt/
         # addinputoutputpairtopstt/finalizepsttconstruction. rpc_psbt.py has
         # no equivalent section -- PSBT's Constructor is folded silently into
@@ -315,6 +415,11 @@ class PSTTTest(BitcoinTestFramework):
         assert_equal(decoded_bare['tx_modifiable']['outputs_modifiable'], True)
         assert_equal(len(decoded_bare['inputs']), 0)
         assert_equal(len(decoded_bare['outputs']), 0)
+        # "next" is a JSON array of every role that could act right now, not
+        # a single string -- still-modifiable and zero inputs are both true
+        # here, so both "constructor" (more could be added) and "extractor"
+        # (there's nothing for an earlier role to do on zero inputs) apply.
+        assert_equal(decoded_bare['next'], ['constructor', 'extractor'])
 
         # Neither Constructor RPC works once construction is not modifiable.
         self.nodes[0].generate(5, self.signblockprivkey_wif)
@@ -341,6 +446,10 @@ class PSTTTest(BitcoinTestFramework):
         assert_equal(len(decoded['inputs']), 1)
         assert_equal(len(decoded['outputs']), 0)
         assert_equal(decoded['inputs'][0]['txid'], unspent_a['txid'])
+        # addinputtopstt only records the outpoint -- no PSTT_IN_UTXO yet --
+        # so both "constructor" (still modifiable) and "updater" (this input
+        # needs a UTXO) are simultaneously actionable.
+        assert_equal(decoded['next'], ['constructor', 'updater'])
 
         pstt_construct = self.nodes[1].addoutputtopstt(pstt_construct, {self.nodes[1].getnewaddress(): 1})
         decoded = self.nodes[0].decodepstt(pstt_construct)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -126,6 +126,7 @@ BASE_SCRIPTS = [
     'rpc_pstt.py --scheme SCHNORR',
     'wallet_pstt.py',
     'wallet_pstt.py --scheme SCHNORR',
+    'feature_large_pstt.py',
     'rpc_users.py',
     'rpc_whitelist.py',
     'feature_proxy.py',


### PR DESCRIPTION
1. No **analyzepsbt** equivalent. Bitcoin's analyzepsbt tells a caller, without them having to reason about it manually: which role should run next, per-input readiness, and — the part Tapyrus genuinely lacks — an estimated fee/vsize once every input has a UTXO attached. decodepstt already exposes tx_modifiable directly (arguably better than Bitcoin's PSBT, which has no wire-level modifiable bit at all and has to infer it), but it computes no size/fee estimate. A wallet UI building on PSTT has no way to ask "what would this cost if extracted right now?" without reconstructing the transaction itself. Suggest: add analyzepstt (or extend decodepstt) with per-input has_utxo/is_final, an overall next role hint, and an estimated-fee/vsize once computable.

2. No **non-wallet Updater** (utxoupdatepsbt equivalent). walletupdatepstt requires a loaded wallet. Since Tapyrus has no witness-UTXO shortcut — every input needs the full previous transaction attached to PSTT_IN_UTXO — this gap arguably matters more here than in Bitcoin: a coordinator, hardware-wallet bridge, or watch-only tool with no wallet loaded has no way to attach known previous transactions to a PSTT at all. Suggest: a updatepstt "pstt" ["rawtx",...] RPC that fills PSTT_IN_UTXO from caller-supplied raw transactions (or the node's own tx index) purely by matching previous_txid, no wallet required.

3. No **joinpsbts** equivalent. Given PSTT's whole point is the constructable (BIP-370) model specifically because it makes composition easier than BIP-174's embedded-global-tx shape, this is a case where PSTT is better positioned to support it than old-style PSBT ever was — and the hard part (locktime-kind intersection across inputs) is already implemented and reusable (ComputeLocktime). Genuinely low-hanging: merge N independent PSTTs' inputs/outputs into one, re-run ComputeLocktime over the union, reject if the intersection is empty. Suggest: joinpstts ["pstt",...].

Suggested test scenarios (regardless of whether the RPC gaps above get filled)

- Fee/size estimation (once added): a PSTT with a subset of inputs UTXO-attached should report "not yet estimable"; fully attached should match extractpstt's actual materialized size within tolerance.
- PSTT_GLOBAL_TX_MODIFIABLE bit-transition races: two independent Signer rounds (different parties) each closing a different bit concurrently, then combinepstt — confirm the merged modifiable state is the intersection/union rule you'd expect, not last-writer-wins.
- Large-PSTT stress: hundreds of inputs/outputs, many-preimage inputs (RIPEMD160/SHA256/HASH160/HASH256 all populated) — confirms the TLV parser doesn't have an accidental O(n²) (the unknown map dedup and xpub canonical-bytes dedup are the two spots I'd specifically check under load).
- combinepstt idempotency: merging a PSTT with itself, or merging A into B then B into A, should be a no-op/order-independent for every field-merge tier (refuse/must-match/pick-first) — currently only tested pairwise-conflict, not commutativity.
- Cross-tool interop: if any other TIP-174 implementation exists (even a reference/test one from the chaintope/tips repo), a round-trip test — decode there, re-encode here, byte-identical — would catch subtle serialization-order assumptions the current test suite can't, since it only ever round-trips through this one implementation.
- Once updatepstt/joinpstts land: the obvious construction/rejection pairs, same style as everything already in pstt_tests.cpp and rpc_pstt.py.