### PR TITLE
Upgrade upload artefact GitHub action

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -957,7 +957,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: daily-test-results-${{ matrix.config.name }}-${{ github.run_id }}
           path: |
@@ -969,7 +969,7 @@ jobs:
 
       - name: Upload coverage data
         if: matrix.config.build_type == 'Debug'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-data-${{ matrix.config.name }}-${{ github.run_id }}
           path: |
@@ -979,7 +979,7 @@ jobs:
 
       - name: Upload Windows binaries
         if: matrix.config.target_platform == 'windows' && always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: tapyrus-windows-${{ matrix.config.target_arch }}-binaries-${{ github.run_id }}
           path: |
@@ -1041,7 +1041,7 @@ jobs:
 
       - name: Upload Core Dumps
         if: failure() && matrix.config.target_platform != 'windows'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: daily-core-dumps-${{ matrix.config.name }}-${{ github.run_id }}
           path: ${{ github.workspace }}/core_dumps/

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -278,7 +278,7 @@ jobs:
 
       - name: Upload Windows binaries
         if: matrix.config.platform == 'windows' && always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: tapyrus-windows-${{ matrix.config.arch }}-binaries
           path: |
@@ -288,7 +288,7 @@ jobs:
 
       - name: Upload test results
         if: matrix.config.platform != 'windows' && always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: smoke-test-results-${{ matrix.config.name }}
           path: |
@@ -333,7 +333,7 @@ jobs:
 
       - name: Upload Core Dumps
         if: failure() && matrix.config.platform != 'windows'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: smoke-core-dumps-${{ matrix.config.name }}
           path: ${{ github.workspace }}/core_dumps/

--- a/.github/workflows/weekly-heavy-tests.yml
+++ b/.github/workflows/weekly-heavy-tests.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Upload combined logs (on failure)
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: heavy-combined-logs-${{ matrix.config.name }}-${{ github.run_id }}
           path: ${{ github.workspace }}/combined_logs/
@@ -321,7 +321,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: heavy-test-results-${{ matrix.config.name }}-${{ github.run_id }}
           path: ${{ github.workspace }}/tapyrus_test
@@ -377,7 +377,7 @@ jobs:
 
       - name: Upload core dumps (on failure)
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: heavy-core-dumps-${{ matrix.config.name }}-${{ github.run_id }}
           path: ${{ github.workspace }}/core_dumps/


### PR DESCRIPTION
Upgrade upload artefact actions in the CI from v5 to v6 to fix the CI deprecated warnings.