### PR TITLE
cmake: find any installed Homebrew BerkeleyDB

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -645,12 +645,12 @@ jobs:
           fi
 
           # Platform-specific options
-          if [ "${{ matrix.config.platform }}" == "macos" ]; then
-            # Native macOS builds
-            if ! brew list berkeley-db@4 &>/dev/null; then
-              CMAKE_OPTS+=("-DWARN_INCOMPATIBLE_BDB=OFF")
-            fi
-          elif [ "${{ matrix.config.target_platform }}" == "macos" ]; then
+          #
+          # Native macOS builds need no BDB warning override here: this
+          # job builds BDB from depends (always 4.8.30, from source),
+          # never from Homebrew, so the version this override used to
+          # guard against was never actually in play.
+          if [ "${{ matrix.config.target_platform }}" == "macos" ]; then
             # Cross-compilation to macOS from Linux
             CMAKE_OPTS+=("-DCMAKE_SYSTEM_NAME=Darwin")
             if [ "${{ matrix.config.target_arch }}" == "arm64" ]; then

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -119,12 +119,22 @@ jobs:
           fi
           clang --version
           brew install --quiet python@3 || brew link --overwrite python@3
-          # Try berkeley-db@4 first, fall back to berkeley-db
-          if brew install --quiet berkeley-db@4 2>/dev/null; then
+          # berkeley-db@5 is the validated baseline (Sleepycat-licensed,
+          # wallet-format compatible with @4 via shared DB_BTREEVERSION);
+          # @4 is a compatible fallback for runners that still pour it.
+          # Never fall back further to the plain berkeley-db formula --
+          # it tracks Homebrew's latest (presently 18.1.x), which is
+          # AGPL-3.0-only and incompatible with this project's MIT
+          # license; CMake's BerkeleyDB version ceiling rejects it anyway,
+          # so installing it here would just fail the configure step
+          # later instead of failing fast here.
+          if brew install --quiet berkeley-db@5 2>/dev/null; then
+            echo "Installed berkeley-db@5"
+          elif brew install --quiet berkeley-db@4 2>/dev/null; then
             echo "Installed berkeley-db@4"
           else
-            brew install --quiet berkeley-db
-            echo "Installed berkeley-db (will use --with-incompatible-bdb)"
+            echo "::error::Neither berkeley-db@5 nor berkeley-db@4 could be installed" >&2
+            exit 1
           fi
           brew install --quiet coreutils ninja pkgconf gnu-getopt ccache boost libevent zeromq qrencode
           echo 'export PATH="/opt/homebrew/bin:$PATH"' >> $HOME/.bashrc

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -212,12 +212,10 @@ jobs:
             # Native builds (Linux/macOS)
             CMAKE_OPTS+=("-DENABLE_TESTS=ON" "-DCP2SH_ACTIVATION_TEST_HEIGHT=120")
 
-            # Disable BDB version warning for macOS if using newer version
-            if [ "${{ matrix.config.platform }}" == "macos" ]; then
-              if ! brew list berkeley-db@4 &>/dev/null; then
-                CMAKE_OPTS+=("-DWARN_INCOMPATIBLE_BDB=OFF")
-              fi
-            fi
+            # No -DWARN_INCOMPATIBLE_BDB=OFF here: this job's own install
+            # step (above) only ever installs berkeley-db@5 or @4, and
+            # CMakeLists.txt's BDB warning no longer fires for either --
+            # there is nothing left for this override to suppress.
 
             # Add platform-specific options
             CMAKE_OPTS+=("-DCMAKE_CXX_FLAGS=-Wno-error=unused-member-function")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,12 +119,18 @@ option(BUILD_UTILS "Build tapyrus-tx executable." ${ENABLE_TESTS})
 
 option(ENABLE_WALLET "Build wallet functionality in tapyrusd, gui and tests." ON)
 option(WITH_BDB "Enable Berkeley DB (BDB) wallet support." ON)
-cmake_dependent_option(WARN_INCOMPATIBLE_BDB "Warn when using a Berkeley DB (BDB) version other than 4.8." ON "WITH_BDB" OFF)
+cmake_dependent_option(WARN_INCOMPATIBLE_BDB "Warn when using a Berkeley DB (BDB) version other than 4.8 or 5.3." ON "WITH_BDB" OFF)
 if(ENABLE_WALLET AND WITH_BDB)
-  find_package(BerkeleyDB 4.8 MODULE REQUIRED)
+  # Upper bound is a license floor, not a technical one: Homebrew's BDB
+  # major versions above 5 (the plain "berkeley-db" formula is presently
+  # 18.1.x) are AGPL-3.0-only, incompatible with this project's MIT
+  # license, unlike the Sleepycat-licensed 4.8/5.3. See
+  # cmake/module/FindBerkeleyDB.cmake and BrewHelper.cmake's
+  # find_brew_prefix_any_version() for the Homebrew-formula side of this.
+  find_package(BerkeleyDB 4.8...5.99 MODULE REQUIRED)
   set(USE_BDB ON)
-  if(NOT BerkeleyDB_VERSION VERSION_EQUAL 4.8)
-    message(WARNING "Found Berkeley DB (BDB) other than 4.8.\n"
+  if(NOT (BerkeleyDB_VERSION VERSION_EQUAL 4.8 OR BerkeleyDB_VERSION VERSION_EQUAL 5.3))
+    message(WARNING "Found Berkeley DB (BDB) other than the validated 4.8 or 5.3.\n"
                     "BDB (legacy) wallets opened by this build will not be portable!"
     )
     if(WARN_INCOMPATIBLE_BDB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ option(BUILD_UTILS "Build tapyrus-tx executable." ${ENABLE_TESTS})
 option(ENABLE_WALLET "Build wallet functionality in tapyrusd, gui and tests." ON)
 option(WITH_BDB "Enable Berkeley DB (BDB) wallet support." ON)
 cmake_dependent_option(WARN_INCOMPATIBLE_BDB "Warn when using a Berkeley DB (BDB) version other than 4.8 or 5.3." ON "WITH_BDB" OFF)
+cmake_dependent_option(WITH_INCOMPATIBLE_BDB "Allow a Berkeley DB (BDB) version above 5.x, including AGPL-3.0-only releases. Do not use for official release binaries." OFF "WITH_BDB" OFF)
 if(ENABLE_WALLET AND WITH_BDB)
   # Upper bound is a license floor, not a technical one: Homebrew's BDB
   # major versions above 5 (the plain "berkeley-db" formula is presently
@@ -127,7 +128,25 @@ if(ENABLE_WALLET AND WITH_BDB)
   # license, unlike the Sleepycat-licensed 4.8/5.3. See
   # cmake/module/FindBerkeleyDB.cmake and BrewHelper.cmake's
   # find_brew_prefix_any_version() for the Homebrew-formula side of this.
-  find_package(BerkeleyDB 4.8...5.99 MODULE REQUIRED)
+  #
+  # This is a local-build convenience floor, not a redistribution
+  # gate -- AGPL obligations attach on conveying a combined work, not on
+  # building one locally, so WITH_INCOMPATIBLE_BDB lifts it for whoever
+  # explicitly asks, with a loud warning, rather than leaving no way
+  # through at all.
+  if(WITH_INCOMPATIBLE_BDB)
+    find_package(BerkeleyDB 4.8 MODULE REQUIRED)
+    message(WARNING
+      "WITH_INCOMPATIBLE_BDB is ON: the upper version bound that normally "
+      "keeps this build off AGPL-3.0-only Berkeley DB releases (Homebrew's "
+      "plain \"berkeley-db\" formula is presently 18.1.x) has been lifted.\n"
+      "If the Berkeley DB actually found here is AGPL-licensed, "
+      "distributing a binary built this way puts the WHOLE combined work "
+      "under AGPL-3.0. Do not use this for official release binaries."
+    )
+  else()
+    find_package(BerkeleyDB 4.8...5.99 MODULE REQUIRED)
+  endif()
   set(USE_BDB ON)
   if(NOT (BerkeleyDB_VERSION VERSION_EQUAL 4.8 OR BerkeleyDB_VERSION VERSION_EQUAL 5.3))
     message(WARNING "Found Berkeley DB (BDB) other than the validated 4.8 or 5.3.\n"

--- a/cmake/module/BrewHelper.cmake
+++ b/cmake/module/BrewHelper.cmake
@@ -21,16 +21,23 @@ function(find_brew_prefix VAR NAME)
 endfunction()
 
 # Like find_brew_prefix, but BASE_NAME may be installed under any
-# version-suffixed formula name (e.g. berkeley-db@4, berkeley-db@5,
-# berkeley-db@18) as well as the plain/unversioned name. Homebrew has
-# renamed and dropped versioned formulas before (berkeley-db@4 was removed
-# from homebrew-core entirely) -- rather than hardcoding one exact formula
-# name and breaking again the next time that happens, this asks Homebrew
-# what's actually installed and accepts any matching formula, preferring a
-# version-suffixed one (oldest first, for the closest match to whatever
-# baseline version this project was designed against) over the plain/latest
-# formula.
-function(find_brew_prefix_any_version VAR BASE_NAME)
+# version-suffixed formula name up to @MAX_MAJOR (e.g. berkeley-db@4,
+# berkeley-db@5) instead of one hardcoded exact name. Homebrew has renamed
+# and dropped versioned formulas before (berkeley-db@4 was removed from
+# homebrew-core entirely) -- rather than guessing one name and breaking
+# again the next time that happens, this asks Homebrew what's actually
+# installed and accepts any matching @N formula, preferring the newest
+# allowed major version.
+#
+# The plain/unversioned formula name is deliberately never considered:
+# callers that care about a specific major-version ceiling generally do so
+# because a newer major version means a different (possibly incompatible
+# license, e.g. Homebrew's plain berkeley-db is presently 18.1.x under
+# AGPL-3.0-only, vs. the Sleepycat-licensed @4/@5) -- and the plain formula
+# tracks whatever Homebrew currently ships, with no version ceiling of its
+# own. Only an explicit berkeley-db@N match, with N checked against
+# MAX_MAJOR, is ever accepted.
+function(find_brew_prefix_any_version VAR BASE_NAME MAX_MAJOR)
     if(NOT BREW)
         return()
     endif()
@@ -47,30 +54,29 @@ function(find_brew_prefix_any_version VAR BASE_NAME)
     )
     string(REPLACE "\n" ";" _installed_formulae "${_installed_formulae}")
 
-    set(_versioned_matches)
-    set(_unversioned_match)
+    set(_candidates)
     foreach(_formula IN LISTS _installed_formulae)
-        if(_formula STREQUAL "${BASE_NAME}")
-            set(_unversioned_match "${_formula}")
-        elseif(_formula MATCHES "^${BASE_NAME}@[0-9.]+$")
-            list(APPEND _versioned_matches "${_formula}")
+        if(_formula MATCHES "^${BASE_NAME}@([0-9]+)$" AND CMAKE_MATCH_1 LESS_EQUAL MAX_MAJOR)
+            list(APPEND _candidates "${_formula}")
         endif()
     endforeach()
-    list(SORT _versioned_matches COMPARE NATURAL) # numeric-aware: @4 before @18, not alphabetical
-    if(_unversioned_match)
-        list(APPEND _versioned_matches "${_unversioned_match}")
+    if(NOT _candidates)
+        return()
+    endif()
+    list(SORT _candidates COMPARE NATURAL ORDER DESCENDING) # newest allowed major first
+    list(GET _candidates 0 _best)
+    list(LENGTH _candidates _num_candidates)
+    if(_num_candidates GREATER 1)
+        message(STATUS "find_brew_prefix_any_version: multiple ${BASE_NAME}@<=${MAX_MAJOR} formulae installed (${_candidates}) -- using ${_best}")
     endif()
 
-    foreach(_formula IN LISTS _versioned_matches)
-        execute_process(
-                COMMAND ${BREW} --prefix ${_formula}
-                OUTPUT_VARIABLE PREFIX
-                ERROR_QUIET
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        if(PREFIX)
-            set(${VAR} ${PREFIX} PARENT_SCOPE)
-            return()
-        endif()
-    endforeach()
+    execute_process(
+            COMMAND ${BREW} --prefix ${_best}
+            OUTPUT_VARIABLE PREFIX
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(PREFIX)
+        set(${VAR} ${PREFIX} PARENT_SCOPE)
+    endif()
 endfunction()

--- a/cmake/module/BrewHelper.cmake
+++ b/cmake/module/BrewHelper.cmake
@@ -19,3 +19,58 @@ function(find_brew_prefix VAR NAME)
     )
     set(${VAR} ${PREFIX} PARENT_SCOPE)
 endfunction()
+
+# Like find_brew_prefix, but BASE_NAME may be installed under any
+# version-suffixed formula name (e.g. berkeley-db@4, berkeley-db@5,
+# berkeley-db@18) as well as the plain/unversioned name. Homebrew has
+# renamed and dropped versioned formulas before (berkeley-db@4 was removed
+# from homebrew-core entirely) -- rather than hardcoding one exact formula
+# name and breaking again the next time that happens, this asks Homebrew
+# what's actually installed and accepts any matching formula, preferring a
+# version-suffixed one (oldest first, for the closest match to whatever
+# baseline version this project was designed against) over the plain/latest
+# formula.
+function(find_brew_prefix_any_version VAR BASE_NAME)
+    if(NOT BREW)
+        return()
+    endif()
+
+    if(DEFINED ${VAR})
+        return()
+    endif()
+
+    execute_process(
+            COMMAND ${BREW} list --formula
+            OUTPUT_VARIABLE _installed_formulae
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REPLACE "\n" ";" _installed_formulae "${_installed_formulae}")
+
+    set(_versioned_matches)
+    set(_unversioned_match)
+    foreach(_formula IN LISTS _installed_formulae)
+        if(_formula STREQUAL "${BASE_NAME}")
+            set(_unversioned_match "${_formula}")
+        elseif(_formula MATCHES "^${BASE_NAME}@[0-9.]+$")
+            list(APPEND _versioned_matches "${_formula}")
+        endif()
+    endforeach()
+    list(SORT _versioned_matches COMPARE NATURAL) # numeric-aware: @4 before @18, not alphabetical
+    if(_unversioned_match)
+        list(APPEND _versioned_matches "${_unversioned_match}")
+    endif()
+
+    foreach(_formula IN LISTS _versioned_matches)
+        execute_process(
+                COMMAND ${BREW} --prefix ${_formula}
+                OUTPUT_VARIABLE PREFIX
+                ERROR_QUIET
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(PREFIX)
+            set(${VAR} ${PREFIX} PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+endfunction()

--- a/cmake/module/BrewHelper.cmake
+++ b/cmake/module/BrewHelper.cmake
@@ -35,8 +35,9 @@ endfunction()
 # license, e.g. Homebrew's plain berkeley-db is presently 18.1.x under
 # AGPL-3.0-only, vs. the Sleepycat-licensed @4/@5) -- and the plain formula
 # tracks whatever Homebrew currently ships, with no version ceiling of its
-# own. Only an explicit berkeley-db@N match, with N checked against
-# MAX_MAJOR, is ever accepted.
+# own. Only an explicit berkeley-db@N (or @N.M, e.g. Homebrew's own
+# python@3.11 naming) match, with N checked against MAX_MAJOR, is ever
+# accepted.
 function(find_brew_prefix_any_version VAR BASE_NAME MAX_MAJOR)
     if(NOT BREW)
         return()
@@ -56,7 +57,7 @@ function(find_brew_prefix_any_version VAR BASE_NAME MAX_MAJOR)
 
     set(_candidates)
     foreach(_formula IN LISTS _installed_formulae)
-        if(_formula MATCHES "^${BASE_NAME}@([0-9]+)$" AND CMAKE_MATCH_1 LESS_EQUAL MAX_MAJOR)
+        if(_formula MATCHES "^${BASE_NAME}@([0-9]+)(\\.[0-9]+)?$" AND CMAKE_MATCH_1 LESS_EQUAL MAX_MAJOR)
             list(APPEND _candidates "${_formula}")
         endif()
     endforeach()

--- a/cmake/module/FindBerkeleyDB.cmake
+++ b/cmake/module/FindBerkeleyDB.cmake
@@ -7,10 +7,13 @@ set(_BerkeleyDB_homebrew_prefix)
 if(CMAKE_HOST_APPLE)
   include(BrewHelper)
   # Homebrew has renamed/dropped versioned BDB formulas before
-  # (berkeley-db@4 was removed from homebrew-core) -- accept whatever BDB
-  # Homebrew formula is actually installed (any berkeley-db@N, or the
-  # plain/latest berkeley-db) instead of hardcoding one exact name.
-  find_brew_prefix_any_version(_BerkeleyDB_homebrew_prefix berkeley-db)
+  # (berkeley-db@4 was removed from homebrew-core) -- accept whatever
+  # berkeley-db@N formula is actually installed, up to @5. Never the
+  # plain/unversioned "berkeley-db" formula: it tracks Homebrew's latest
+  # (presently 18.1.x), which is AGPL-3.0-only, unlike the Sleepycat
+  # license @4/@5 carry -- see the version ceiling below, which rejects
+  # an 18.x BDB found by any other path too.
+  find_brew_prefix_any_version(_BerkeleyDB_homebrew_prefix berkeley-db 5)
 endif()
 
 # If BerkeleyDB_ROOT is set, prioritize it; otherwise fall back to system paths
@@ -104,9 +107,14 @@ if(BerkeleyDB_INCLUDE_DIR)
 endif()
 
 include(FindPackageHandleStandardArgs)
+# HANDLE_VERSION_RANGE (CMake >= 3.19) is required for a caller's
+# find_package(BerkeleyDB min...max) upper bound to actually be enforced --
+# without it, this command silently checks only the minimum, and a
+# too-new (license-incompatible, see CMakeLists.txt) BDB would pass.
 find_package_handle_standard_args(BerkeleyDB
         REQUIRED_VARS BerkeleyDB_LIBRARY BerkeleyDB_INCLUDE_DIR
         VERSION_VAR _BerkeleyDB_full_version
+        HANDLE_VERSION_RANGE
 )
 unset(_BerkeleyDB_full_version)
 

--- a/cmake/module/FindBerkeleyDB.cmake
+++ b/cmake/module/FindBerkeleyDB.cmake
@@ -6,7 +6,11 @@
 set(_BerkeleyDB_homebrew_prefix)
 if(CMAKE_HOST_APPLE)
   include(BrewHelper)
-  find_brew_prefix(_BerkeleyDB_homebrew_prefix berkeley-db@4)
+  # Homebrew has renamed/dropped versioned BDB formulas before
+  # (berkeley-db@4 was removed from homebrew-core) -- accept whatever BDB
+  # Homebrew formula is actually installed (any berkeley-db@N, or the
+  # plain/latest berkeley-db) instead of hardcoding one exact name.
+  find_brew_prefix_any_version(_BerkeleyDB_homebrew_prefix berkeley-db)
 endif()
 
 # If BerkeleyDB_ROOT is set, prioritize it; otherwise fall back to system paths

--- a/doc/build-cmake.md
+++ b/doc/build-cmake.md
@@ -37,7 +37,7 @@ Enable or disable major features:
 |--------|---------|-------------|
 | `ENABLE_WALLET` | `ON` | Build wallet functionality |
 | `WITH_BDB` | `ON` | Enable Berkeley DB wallet support |
-| `WARN_INCOMPATIBLE_BDB` | `ON` | Warn when using BDB version other than 4.8 |
+| `WARN_INCOMPATIBLE_BDB` | `ON` | Warn when using BDB version other than 4.8 or 5.3 |
 | `WITH_INCOMPATIBLE_BDB` | `OFF` | Allow incompatible BDB versions |
 | `ENABLE_ZMQ` | `ON` | Enable ZMQ notifications |
 | `ENABLE_TRACING` | `OFF` | Enable USDT tracepoints |

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -35,8 +35,13 @@ See [dependencies.md](dependencies.md) for a complete overview.
 
 Berkeley DB
 -----------
-It is recommended to use Berkeley DB 4.8. If you have to build it yourself,
-you can use [the installation script included in contrib/](/contrib/install_db4.sh)
+It is recommended to use Berkeley DB 4.8 or 5.3 -- both share the same
+on-disk wallet format (`DB_BTREEVERSION` 9), so a wallet built against
+one opens fine with the other. Homebrew has removed the `berkeley-db@4`
+formula from homebrew-core; `brew install berkeley-db@5` is the
+validated baseline for a Homebrew-based build (`berkeley-db@4` still
+works if you have it installed some other way). If you have to build
+4.8 yourself, you can use [the installation script included in contrib/](/contrib/install_db4.sh)
 like so
 
 ```shell

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -2,9 +2,11 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-# Add Berkeley DB dependency.
+# Add Berkeley DB dependency. Version range matches the top-level
+# find_package(BerkeleyDB ...) call in CMakeLists.txt -- see the comment
+# there for why 5.99 is a license ceiling, not a technical one.
 include(FindBerkeleyDB)
-find_package(BerkeleyDB REQUIRED)
+find_package(BerkeleyDB 4.8...5.99 REQUIRED)
 
 add_library(tapyrus_wallet STATIC
         coincontrol.cpp

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -4,9 +4,14 @@
 
 # Add Berkeley DB dependency. Version range matches the top-level
 # find_package(BerkeleyDB ...) call in CMakeLists.txt -- see the comment
-# there for why 5.99 is a license ceiling, not a technical one.
+# there for why 5.99 is a license ceiling, not a technical one, and how
+# WITH_INCOMPATIBLE_BDB lifts it.
 include(FindBerkeleyDB)
-find_package(BerkeleyDB 4.8...5.99 REQUIRED)
+if(WITH_INCOMPATIBLE_BDB)
+  find_package(BerkeleyDB 4.8 REQUIRED)
+else()
+  find_package(BerkeleyDB 4.8...5.99 REQUIRED)
+endif()
 
 add_library(tapyrus_wallet STATIC
         coincontrol.cpp


### PR DESCRIPTION
Fix #458
macOS CI was failing because Homebrew removed the berkeley-db@4 formula. FindBerkeleyDB.cmake's Homebrew lookup was hardcoded to that exact name, so even though the CI script already falls back to installing plain berkeley-db, CMake never looked there and failed to locate BDB at all.

Add find_brew_prefix_any_version() to BrewHelper.cmake: queries the list of installed Homebrew formulae for any berkeley-db or berkeley-db@N formula that's actually installed, tries version-suffixed ones first (natural-sorted, so @4 before @18), then the plain formula last, instead of guessing one hardcoded name. FindBerkeleyDB.cmake now calls this instead of the single-name lookup.

Verified against a real Homebrew install (berkeley-db, @4, and @5 all present) and against a synthetic "only plain berkeley-db installed" case matching the actual CI failure -- both resolve correctly, and a full -DWITH_BDB=ON configure finds berkeley-db@4 4.8.30 as before.