### PR TITLE
Upgrade Berkeley DB dependency from 4.8.30 to 5.3.28 

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -227,6 +227,12 @@ jobs:
           git checkout -- depends/
           git clean -fdx -- depends/patches/ depends/packages/ depends/hosts/ depends/builders/
 
+      - name: Re-checkout depends/packages and depends/patches
+        # A stale restore-keys cache hit (e.g. right after a version bump)
+        # can overwrite these with old content, so make rebuilds the wrong
+        # version. Force them back to HEAD after the cache restore.
+        run: git checkout -- depends/packages depends/patches
+
       - name: Restore Benchmark History cache
         # Benchmarks only run on scheduled/manually-dispatched runs, not on
         # every PR (see the gated benchmark step further down). Gated on the
@@ -417,8 +423,8 @@ jobs:
 
             # Wallet dependencies (Berkeley DB)
             if [ "${{ matrix.config.enable_wallet }}" == "true" ]; then
-              REQUIRED_FILES+=("$DEPENDS_PREFIX/lib/libdb_cxx-4.8.a")
-              REQUIRED_FILES+=("$DEPENDS_PREFIX/lib/libdb-4.8.a")
+              REQUIRED_FILES+=("$DEPENDS_PREFIX/lib/libdb_cxx-5.3.a")
+              REQUIRED_FILES+=("$DEPENDS_PREFIX/lib/libdb-5.3.a")
               REQUIRED_FILES+=("$DEPENDS_PREFIX/include/db_cxx.h")
               REQUIRED_FILES+=("$DEPENDS_PREFIX/include/db.h")
             fi
@@ -686,7 +692,7 @@ jobs:
           # Platform-specific options
           #
           # Native macOS builds need no BDB warning override here: this
-          # job builds BDB from depends (always 4.8.30, from source),
+          # job builds BDB from depends (always 5.3.28, from source),
           # never from Homebrew, so the version this override used to
           # guard against was never actually in play.
           if [ "${{ matrix.config.target_platform }}" == "macos" ]; then
@@ -708,7 +714,7 @@ jobs:
           # but not the specific header/library paths).
           if [ "${{ matrix.config.enable_wallet }}" == "true" ]; then
             CMAKE_OPTS+=("-DBerkeleyDB_INCLUDE_DIR=$DEPENDS_PREFIX/include")
-            CMAKE_OPTS+=("-DBerkeleyDB_LIBRARY=$DEPENDS_PREFIX/lib/libdb_cxx-4.8.a")
+            CMAKE_OPTS+=("-DBerkeleyDB_LIBRARY=$DEPENDS_PREFIX/lib/libdb_cxx-5.3.a")
           fi
 
           # Configure and build

--- a/.github/workflows/weekly-heavy-tests.yml
+++ b/.github/workflows/weekly-heavy-tests.yml
@@ -501,10 +501,11 @@ jobs:
         #
         # The rest of depends/packages/*.mk is left pinned at its current
         # version:
-        #   - Berkeley DB: find_package(BerkeleyDB 4.8 MODULE REQUIRED)
-        #     (CMakeLists.txt:124) is already satisfied by the 4.8.30 pinned in
-        #     bdb.mk (4.8.30 >= 4.8) -- no older, meaningfully-different 4.8.x
-        #     release to fetch instead, so bdb.mk is left as-is.
+        #   - Berkeley DB: find_package(BerkeleyDB 4.8...5.99 MODULE REQUIRED)
+        #     (CMakeLists.txt:149) is already satisfied by the 5.3.28 pinned
+        #     in bdb.mk, and doc/dependencies.md documents no separate
+        #     "Minimum required" for it (Version and Minimum required are
+        #     both 5.3.28), so bdb.mk is left as-is.
         #   - Qt: find_package(Qt 6.0 ...) (CMakeLists.txt:180) is 5+ minor
         #     versions behind the 6.10.1 pinned in qt.mk. Swapping in Qt 6.0.0
         #     isn't a one-line version+hash change the way the five above
@@ -654,7 +655,7 @@ jobs:
             -DZEROMQ_LIBRARY="$DEPENDS_PREFIX/lib/libzmq.a"
             -DBerkeleyDB_ROOT="$DEPENDS_PREFIX"
             -DBerkeleyDB_INCLUDE_DIR="$DEPENDS_PREFIX/include"
-            -DBerkeleyDB_LIBRARY="$DEPENDS_PREFIX/lib/libdb_cxx-4.8.a"
+            -DBerkeleyDB_LIBRARY="$DEPENDS_PREFIX/lib/libdb_cxx-5.3.a"
           )
           if [ "${{ matrix.config.platform }}" == "linux" ]; then
             CMAKE_OPTS+=(-DENABLE_TRACING=ON)

--- a/.github/workflows/weekly-heavy-tests.yml
+++ b/.github/workflows/weekly-heavy-tests.yml
@@ -175,7 +175,7 @@ jobs:
             -DZEROMQ_LIBRARY="$DEPENDS_PREFIX/lib/libzmq.a" \
             -DBerkeleyDB_ROOT="$DEPENDS_PREFIX" \
             -DBerkeleyDB_INCLUDE_DIR="$DEPENDS_PREFIX/include" \
-            -DBerkeleyDB_LIBRARY="$DEPENDS_PREFIX/lib/libdb_cxx-4.8.a"
+            -DBerkeleyDB_LIBRARY="$DEPENDS_PREFIX/lib/libdb_cxx-5.3.a"
 
           cmake --build "$BASE_BUILD_DIR" --parallel -j$(nproc) --target all
 

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -81,7 +81,6 @@ make install
 echo
 echo "db4 build complete."
 echo
-echo 'When compiling tapyrusd, run `./configure` in the following way:'
+echo 'When configuring tapyrus-core with CMake, point it at this prefix:'
 echo
-echo "  export BDB_PREFIX='${BDB_PREFIX}'"
-echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" ...'
+echo "  cmake -S . -B build -DBerkeleyDB_ROOT='${BDB_PREFIX}'"

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -1,11 +1,14 @@
 package=bdb
-$(package)_version=4.8.30
+$(package)_version=5.3.28
 $(package)_download_path=https://download.oracle.com/berkeley-db
 $(package)_file_name=db-$($(package)_version).NC.tar.gz
-$(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef
+$(package)_sha256_hash=76a25560d9e52a198d37a31440fd07632b5f1f8f9f2b6d5438f4bc3e7c9013ef
 $(package)_build_subdir=build_unix
 ifeq ($($(package)_version),4.8.30)
 $(package)_patches=clang_cxx_11.patch
+endif
+ifeq ($($(package)_version),5.3.28)
+$(package)_patches=clang_cxx_11.patch mingw_winioctl_case.patch
 endif
 
 define $(package)_set_vars
@@ -25,7 +28,7 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE) libdb_cxx-4.8.a libdb-4.8.a
+  $(MAKE) libdb_cxx-5.3.a libdb-5.3.a
 endef
 
 define $(package)_stage_cmds

--- a/depends/patches/bdb/5.3.28/clang_cxx_11.patch
+++ b/depends/patches/bdb/5.3.28/clang_cxx_11.patch
@@ -1,0 +1,148 @@
+Fix C++11 compatibility (BDB 5.3.28)
+
+Regenerated against Berkeley DB 5.3.28's own source tree for the 4.8 -> 5.3
+upgrade: 5.3.28 nests every source file one level deeper, under a top-level
+src/ directory that didn't exist in 4.8.30 (e.g. dbinc/atomic.h is now
+src/dbinc/atomic.h) -- the paths below reflect that, everything else is the
+same fix as the original 4.8-targeted patch (commit 3311d68f11d1 upstream):
+atomic_init()/__atomic_compare_exchange() collide with C++11's own
+std::atomic_init/std::atomic_compare_exchange when these headers are
+included from a C++11-or-later translation unit; renamed to
+atomic_init_db()/__atomic_compare_exchange_db() to avoid the collision.
+Verified this file-by-file against the real, official 5.3.28.NC source
+tree (downloaded and hashed directly from download.oracle.com) -- the same
+atomic_init/__atomic_compare_exchange identifiers are still present,
+unpatched, at essentially the same lines, so this is still the correct fix
+for 5.3.28.
+
+diff --git a/src/dbinc/atomic.h b/src/dbinc/atomic.h
+index 0034dcc..7c11d4a 100644
+--- a/src/dbinc/atomic.h
++++ b/src/dbinc/atomic.h
+@@ -70,7 +70,7 @@
+  * These have no memory barriers; the caller must include them when necessary.
+  */
+ #define	atomic_read(p)		((p)->value)
+-#define	atomic_init(p, val)	((p)->value = (val))
++#define	atomic_init_db(p, val)	((p)->value = (val))
+
+ #ifdef HAVE_ATOMIC_SUPPORT
+
+@@ -144,7 +144,7 @@
+ #define	atomic_inc(env, p)	__atomic_inc(p)
+ #define	atomic_dec(env, p)	__atomic_dec(p)
+ #define	atomic_compare_exchange(env, p, o, n)	\
+-	__atomic_compare_exchange((p), (o), (n))
++	__atomic_compare_exchange_db((p), (o), (n))
+ static inline int __atomic_inc(db_atomic_t *p)
+ {
+ 	int	temp;
+@@ -176,7 +176,7 @@
+  * http://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html
+  * which configure could be changed to use.
+  */
+-static inline int __atomic_compare_exchange(
++static inline int __atomic_compare_exchange_db(
+ 	db_atomic_t *p, atomic_value_t oldval, atomic_value_t newval)
+ {
+ 	atomic_value_t was;
+@@ -206,7 +206,7 @@
+ #define	atomic_dec(env, p)	(--(p)->value)
+ #define	atomic_compare_exchange(env, p, oldval, newval)		\
+ 	(DB_ASSERT(env, atomic_read(p) == (oldval)),		\
+-	atomic_init(p, (newval)), 1)
++	atomic_init_db(p, (newval)), 1)
+ #else
+ #define atomic_inc(env, p)	__atomic_inc(env, p)
+ #define atomic_dec(env, p)	__atomic_dec(env, p)
+--- a/src/mp/mp_fget.c
++++ b/src/mp/mp_fget.c
+@@ -649,7 +649,7 @@
+
+ 		/* Initialize enough so we can call __memp_bhfree. */
+ 		alloc_bhp->flags = 0;
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ #ifdef DIAGNOSTIC
+ 		if ((uintptr_t)alloc_bhp->buf & (sizeof(size_t) - 1)) {
+ 			__db_errx(env, DB_STR("3025",
+@@ -955,7 +955,7 @@
+ 			MVCC_MPROTECT(bhp->buf, mfp->pagesize,
+ 			    PROT_READ);
+
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+ 		alloc_bhp->priority = bhp->priority;
+ 		alloc_bhp->pgno = bhp->pgno;
+--- a/src/mp/mp_mvcc.c
++++ b/src/mp/mp_mvcc.c
+@@ -276,7 +276,7 @@
+ #else
+ 	memcpy(frozen_bhp, bhp, SSZA(BH, buf));
+ #endif
+-	atomic_init(&frozen_bhp->ref, 0);
++	atomic_init_db(&frozen_bhp->ref, 0);
+ 	if (mutex != MUTEX_INVALID)
+ 		frozen_bhp->mtx_buf = mutex;
+ 	else if ((ret = __mutex_alloc(env, MTX_MPOOL_BH,
+@@ -428,7 +428,7 @@
+ #endif
+ 		alloc_bhp->mtx_buf = mutex;
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		F_CLR(alloc_bhp, BH_FROZEN);
+ 	}
+
+--- a/src/mp/mp_region.c
++++ b/src/mp/mp_region.c
+@@ -245,7 +245,7 @@
+ 			     MTX_MPOOL_FILE_BUCKET, 0, &htab[i].mtx_hash)) != 0)
+ 				return (ret);
+ 			SH_TAILQ_INIT(&htab[i].hash_bucket);
+-			atomic_init(&htab[i].hash_page_dirty, 0);
++			atomic_init_db(&htab[i].hash_page_dirty, 0);
+ 		}
+
+ 		/*
+@@ -302,7 +302,7 @@
+ 		} else
+ 			hp->mtx_hash = mtx_base + (i % dbenv->mp_mtxcount);
+ 		SH_TAILQ_INIT(&hp->hash_bucket);
+-		atomic_init(&hp->hash_page_dirty, 0);
++		atomic_init_db(&hp->hash_page_dirty, 0);
+ #ifdef HAVE_STATISTICS
+ 		hp->hash_io_wait = 0;
+ 		hp->hash_frozen = hp->hash_thawed = hp->hash_frozen_freed = 0;
+--- a/src/mutex/mut_method.c
++++ b/src/mutex/mut_method.c
+@@ -474,7 +474,7 @@
+ 	MUTEX_LOCK(env, mtx);
+ 	ret = atomic_read(v) == oldval;
+ 	if (ret)
+-		atomic_init(v, newval);
++		atomic_init_db(v, newval);
+ 	MUTEX_UNLOCK(env, mtx);
+
+ 	return (ret);
+--- a/src/mutex/mut_tas.c
++++ b/src/mutex/mut_tas.c
+@@ -47,7 +47,7 @@
+
+ #ifdef HAVE_SHARED_LATCHES
+ 	if (F_ISSET(mutexp, DB_MUTEX_SHARED))
+-		atomic_init(&mutexp->sharecount, 0);
++		atomic_init_db(&mutexp->sharecount, 0);
+ 	else
+ #endif
+ 	if (MUTEX_INIT(&mutexp->tas)) {
+@@ -536,7 +536,7 @@
+ 			F_CLR(mutexp, DB_MUTEX_LOCKED);
+ 			/* Flush flag update before zeroing count */
+ 			MEMBAR_EXIT();
+-			atomic_init(&mutexp->sharecount, 0);
++			atomic_init_db(&mutexp->sharecount, 0);
+ 		} else {
+ 			DB_ASSERT(env, sharecount > 0);
+ 			MEMBAR_EXIT();

--- a/depends/patches/bdb/5.3.28/mingw_winioctl_case.patch
+++ b/depends/patches/bdb/5.3.28/mingw_winioctl_case.patch
@@ -1,0 +1,18 @@
+Fix mingw-w64 cross-compilation: win_db.h includes <WinIoCtl.h> (mixed
+case), but mingw-w64 ships it as lowercase winioctl.h, so this fails to
+resolve on a case-sensitive host. Works natively on Windows only. Not
+present in BDB 4.8.30, introduced in 5.3.28.
+
+diff --git a/src/dbinc/win_db.h b/src/dbinc/win_db.h
+index 1111111..2222222 100644
+--- a/src/dbinc/win_db.h
++++ b/src/dbinc/win_db.h
+@@ -46,7 +46,7 @@
+ #include <windows.h>
+ #include <winsock2.h>
+ #ifndef DB_WINCE
+-#include <WinIoCtl.h>
++#include <winioctl.h>
+ #endif
+
+ #ifdef HAVE_GETADDRINFO

--- a/doc/build-cmake.md
+++ b/doc/build-cmake.md
@@ -194,7 +194,7 @@ Specify custom paths for dependencies:
 ```bash
 cmake -S . -B build \
   -DBoost_ROOT=/opt/boost \
-  -DBerkeleyDB_ROOT=/opt/db4 \
+  -DBerkeleyDB_ROOT=/opt/db5.3 \
   -DLibevent_ROOT=/opt/libevent \
   -DZeroMQ_ROOT=/opt/zeromq
 ```

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -35,12 +35,15 @@ See [dependencies.md](dependencies.md) for a complete overview.
 
 Berkeley DB
 -----------
-It is recommended to use Berkeley DB 4.8 or 5.3 -- both share the same
-`wallet.dat` file format (`DB_BTREEVERSION` 9), but not the BDB
-environment: once a wallet directory has been opened by 5.3, its
-transaction log is a version 4.8 cannot read, and it will not reopen
-under a 4.8-linked build (remove the wallet's `database/` subdirectory,
-or run the old binary with `-salvagewallet`, to go back). Homebrew has
+It is recommended to use Berkeley DB 5.3. A wallet written by an older,
+4.8-linked build opens and upgrades cleanly under 5.3, since both read
+the same `wallet.dat` file format (`DB_BTREEVERSION` 9) -- but this is a
+one-way upgrade, not general compatibility between the two versions: once
+a wallet directory has been opened by 5.3, its transaction log is a
+version 4.8 cannot read, and that wallet directory can no longer be
+opened by a 4.8-linked build afterwards (remove the wallet's `database/`
+subdirectory, or run the old binary with `-salvagewallet`, to go back).
+Homebrew has
 removed the `berkeley-db@4` formula from homebrew-core; `brew install
 berkeley-db@5` is the validated baseline for a Homebrew-based build
 (`berkeley-db@4` still works if you have it installed some other way).

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -36,12 +36,16 @@ See [dependencies.md](dependencies.md) for a complete overview.
 Berkeley DB
 -----------
 It is recommended to use Berkeley DB 4.8 or 5.3 -- both share the same
-on-disk wallet format (`DB_BTREEVERSION` 9), so a wallet built against
-one opens fine with the other. Homebrew has removed the `berkeley-db@4`
-formula from homebrew-core; `brew install berkeley-db@5` is the
-validated baseline for a Homebrew-based build (`berkeley-db@4` still
-works if you have it installed some other way). If you have to build
-4.8 yourself, you can use [the installation script included in contrib/](/contrib/install_db4.sh)
+`wallet.dat` file format (`DB_BTREEVERSION` 9), but not the BDB
+environment: once a wallet directory has been opened by 5.3, its
+transaction log is a version 4.8 cannot read, and it will not reopen
+under a 4.8-linked build (remove the wallet's `database/` subdirectory,
+or run the old binary with `-salvagewallet`, to go back). Homebrew has
+removed the `berkeley-db@4` formula from homebrew-core; `brew install
+berkeley-db@5` is the validated baseline for a Homebrew-based build
+(`berkeley-db@4` still works if you have it installed some other way).
+If you have to build 4.8 yourself, you can use
+[the installation script included in contrib/](/contrib/install_db4.sh)
 like so
 
 ```shell

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -91,20 +91,21 @@ Building the GUI (Qt) through `depends` on Linux additionally requires `gperf`
 and Meson >= 1.4.0 — newer than the `meson` apt package on Ubuntu 24.04. See
 [depends/README.md](/depends/README.md) for the exact packages.
 
-BerkeleyDB is required for the wallet.
+BerkeleyDB is required for the wallet. Berkeley DB 4.8 and 5.3 are both
+validated (they share the same on-disk wallet format, `DB_BTREEVERSION` 9,
+so a wallet built against one opens fine with the other) — 5.3 is the
+recommended version going forward.
 
-**For Ubuntu only:** db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
-You can add the repository and install using the following commands:
+**For Ubuntu:** a `libdb5.3++-dev` package is available directly from the
+standard repositories, no extra PPA needed:
 
-    sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:bitcoin/bitcoin
-    sudo apt-get update
-    sudo apt-get install libdb4.8-dev libdb4.8++-dev
+    sudo apt-get install libdb5.3-dev libdb5.3++-dev
 
-Ubuntu and Debian have their own libdb-dev and libdb++-dev packages, but these will install
-BerkeleyDB 5.1 or later, which break binary wallet compatibility with the distributed executables which
-are based on BerkeleyDB 4.8. If you do not care about wallet compatibility,
-use `-DWITH_INCOMPATIBLE_BDB=ON` when configuring CMake.
+Plain `libdb-dev`/`libdb++-dev` (no version suffix) install whatever BDB
+major version Ubuntu currently ships as its default, which may be newer
+than 5.3 and break binary wallet compatibility. If you do not care about
+wallet compatibility, use `-DWITH_INCOMPATIBLE_BDB=ON` when configuring
+CMake — see [build-cmake.md](build-cmake.md)'s CMake options table.
 
 See the section "Disable-wallet mode" to build Tapyrus Core without wallet.
 
@@ -149,9 +150,11 @@ Optional:
 
     sudo dnf install libevent-devel boost-devel
 
-Berkeley DB is required for the legacy wallet:
+Berkeley DB is required for the wallet. Fedora's `libdb-devel` package
+ships Berkeley DB 5.3.28 directly (unlike Ubuntu/Debian's version-suffixed
+package names) -- no compat package needed:
 
-    sudo dnf install libdb4-devel libdb4-cxx-devel
+    sudo dnf install libdb-devel
 
 User-Space, Statically Defined Tracing (USDT) dependencies:
 
@@ -196,8 +199,11 @@ turned off by default.  See the CMake options for upnp behavior desired:
 
 Berkeley DB
 -----------
-It is recommended to use Berkeley DB 4.8. If you have to build it yourself,
-you can use [the installation script included in contrib/](/contrib/install_db4.sh)
+It is recommended to use Berkeley DB 5.3, which Fedora's `libdb-devel`
+package provides directly (see above). Berkeley DB 4.8 is also validated
+(both share the same on-disk wallet format, `DB_BTREEVERSION` 9) if you
+specifically need it -- if you have to build it yourself, you can use
+[the installation script included in contrib/](/contrib/install_db4.sh)
 like so
 
 ```shell
@@ -273,7 +279,7 @@ disable-wallet mode with:
 
     cmake -S . -B build -DENABLE_WALLET=OFF
 
-In this case there is no dependency on Berkeley DB 4.8.
+In this case there is no dependency on Berkeley DB.
 
 Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
 call not `getwork`.
@@ -297,11 +303,12 @@ This example lists the steps necessary to setup and build a command line only, n
     ctest --test-dir build
 
 Note:
-Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `-DWITH_INCOMPATIBLE_BDB=ON`,
-or building and depending on a local version of Berkeley DB 4.8. The readily available Arch Linux packages are currently built using
+Enabling wallet support requires either compiling against a Berkeley DB newer than 5.3 (package `db`) using `-DWITH_INCOMPATIBLE_BDB=ON`,
+or building and depending on a local version of Berkeley DB 4.8 or 5.3 (both share the same on-disk wallet format, `DB_BTREEVERSION` 9).
+The readily available Arch Linux packages are currently built using
 `-DWITH_INCOMPATIBLE_BDB=ON` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/tapyrus/trunk/PKGBUILD).
 As mentioned above, when maintaining portability of the wallet between the standard Tapyrus Core distributions and independently built
-node software is desired, Berkeley DB 4.8 must be used.
+node software is desired, Berkeley DB 4.8 or 5.3 must be used.
 
 
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -92,9 +92,14 @@ and Meson >= 1.4.0 — newer than the `meson` apt package on Ubuntu 24.04. See
 [depends/README.md](/depends/README.md) for the exact packages.
 
 BerkeleyDB is required for the wallet. Berkeley DB 4.8 and 5.3 are both
-validated (they share the same on-disk wallet format, `DB_BTREEVERSION` 9,
-so a wallet built against one opens fine with the other) — 5.3 is the
-recommended version going forward.
+validated and share the same on-disk `wallet.dat` file format
+(`DB_BTREEVERSION` 9) — 5.3 is the recommended version going forward.
+This does not extend to the BDB environment: once a wallet directory has
+been opened by 5.3, its transaction log is a version 4.8 cannot read, and
+reopening it with a 4.8-linked build will fail
+(`PANIC: ... unsupported log version`). If you need to go back to a
+4.8-linked build, remove the wallet's `database/` subdirectory first (or
+run the old binary with `-salvagewallet`).
 
 **For Ubuntu:** a `libdb5.3++-dev` package is available directly from the
 standard repositories, no extra PPA needed:
@@ -201,9 +206,10 @@ Berkeley DB
 -----------
 It is recommended to use Berkeley DB 5.3, which Fedora's `libdb-devel`
 package provides directly (see above). Berkeley DB 4.8 is also validated
-(both share the same on-disk wallet format, `DB_BTREEVERSION` 9) if you
-specifically need it -- if you have to build it yourself, you can use
-[the installation script included in contrib/](/contrib/install_db4.sh)
+and shares the same `wallet.dat` file format (`DB_BTREEVERSION` 9) if you
+specifically need it -- but a wallet directory once opened by 5.3 will not
+reopen under 4.8 (see the note above) -- if you have to build it yourself,
+you can use [the installation script included in contrib/](/contrib/install_db4.sh)
 like so
 
 ```shell
@@ -304,11 +310,12 @@ This example lists the steps necessary to setup and build a command line only, n
 
 Note:
 Enabling wallet support requires either compiling against a Berkeley DB newer than 5.3 (package `db`) using `-DWITH_INCOMPATIBLE_BDB=ON`,
-or building and depending on a local version of Berkeley DB 4.8 or 5.3 (both share the same on-disk wallet format, `DB_BTREEVERSION` 9).
+or building and depending on a local version of Berkeley DB 4.8 or 5.3 (both share the same `wallet.dat` file format, `DB_BTREEVERSION` 9 --
+though a wallet directory once opened by 5.3 will not reopen under 4.8; see the note above).
 The readily available Arch Linux packages are currently built using
 `-DWITH_INCOMPATIBLE_BDB=ON` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/tapyrus/trunk/PKGBUILD).
 As mentioned above, when maintaining portability of the wallet between the standard Tapyrus Core distributions and independently built
-node software is desired, Berkeley DB 4.8 or 5.3 must be used.
+node software is desired, Berkeley DB 4.8 or 5.3 must be used, and a wallet already opened by 5.3 can no longer be moved back to 4.8.
 
 
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -91,15 +91,16 @@ Building the GUI (Qt) through `depends` on Linux additionally requires `gperf`
 and Meson >= 1.4.0 — newer than the `meson` apt package on Ubuntu 24.04. See
 [depends/README.md](/depends/README.md) for the exact packages.
 
-BerkeleyDB is required for the wallet. Berkeley DB 4.8 and 5.3 are both
-validated and share the same on-disk `wallet.dat` file format
-(`DB_BTREEVERSION` 9) — 5.3 is the recommended version going forward.
-This does not extend to the BDB environment: once a wallet directory has
-been opened by 5.3, its transaction log is a version 4.8 cannot read, and
-reopening it with a 4.8-linked build will fail
-(`PANIC: ... unsupported log version`). If you need to go back to a
-4.8-linked build, remove the wallet's `database/` subdirectory first (or
-run the old binary with `-salvagewallet`).
+BerkeleyDB is required for the wallet. 5.3 is the recommended version —
+a wallet written by an older, 4.8-linked build opens and upgrades
+cleanly under 5.3, since both read the same on-disk `wallet.dat` file
+format (`DB_BTREEVERSION` 9). This is a one-way upgrade, not general
+compatibility between the two BDB versions: once a wallet directory has
+been opened by 5.3, its transaction log is a version 4.8 cannot read,
+and that wallet directory can no longer be opened by a 4.8-linked build
+afterwards (`PANIC: ... unsupported log version`). If you need to go
+back to a 4.8-linked build, remove the wallet's `database/` subdirectory
+first (or run the old binary with `-salvagewallet`).
 
 **For Ubuntu:** a `libdb5.3++-dev` package is available directly from the
 standard repositories, no extra PPA needed:
@@ -206,9 +207,10 @@ Berkeley DB
 -----------
 It is recommended to use Berkeley DB 5.3, which Fedora's `libdb-devel`
 package provides directly (see above). Berkeley DB 4.8 is also validated
-and shares the same `wallet.dat` file format (`DB_BTREEVERSION` 9) if you
-specifically need it -- but a wallet directory once opened by 5.3 will not
-reopen under 4.8 (see the note above) -- if you have to build it yourself,
+if you specifically need it, e.g. to keep running an older, 4.8-linked
+build -- a wallet last written by 4.8 opens fine under 5.3 (see the note
+above), but not the reverse: a wallet directory once opened by 5.3 will
+not reopen under 4.8 -- if you have to build 4.8 yourself,
 you can use [the installation script included in contrib/](/contrib/install_db4.sh)
 like so
 
@@ -310,12 +312,12 @@ This example lists the steps necessary to setup and build a command line only, n
 
 Note:
 Enabling wallet support requires either compiling against a Berkeley DB newer than 5.3 (package `db`) using `-DWITH_INCOMPATIBLE_BDB=ON`,
-or building and depending on a local version of Berkeley DB 4.8 or 5.3 (both share the same `wallet.dat` file format, `DB_BTREEVERSION` 9 --
-though a wallet directory once opened by 5.3 will not reopen under 4.8; see the note above).
+or building and depending on a local version of Berkeley DB 4.8 or 5.3 -- a 4.8-written wallet opens fine under 5.3 (see the note above),
+but not the reverse: a wallet directory once opened by 5.3 will no longer reopen under 4.8.
 The readily available Arch Linux packages are currently built using
 `-DWITH_INCOMPATIBLE_BDB=ON` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/tapyrus/trunk/PKGBUILD).
-As mentioned above, when maintaining portability of the wallet between the standard Tapyrus Core distributions and independently built
-node software is desired, Berkeley DB 4.8 or 5.3 must be used, and a wallet already opened by 5.3 can no longer be moved back to 4.8.
+As mentioned above, when sharing a wallet between the standard Tapyrus Core distributions and independently built
+node software is desired, Berkeley DB 4.8 or 5.3 must be used -- keeping in mind that this only works one-way, from a 4.8-linked build to a 5.3-linked one.
 
 
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -44,6 +44,15 @@ These are the dependencies currently used by Tapyrus Core. You can find instruct
 | ZeroMQ | | 4.3.5 | 4.3.5 | `zeromq-4.3.5.tar.gz` | `6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43` | [github.com](https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz) |
 | macOS SDK | macOS only | Xcode 26.2 (17C52) | Xcode 26.2 (17C52) | `Xcode-26.2-17C52-extracted-SDK-with-libcxx-headers.tar.gz` | *(not checked; see below)* | [bitcoincore.org](https://bitcoincore.org/depends-sources/sdks/Xcode-26.2-17C52-extracted-SDK-with-libcxx-headers.tar.gz) |
 
+**Berkeley DB downgrade warning:**
+
+| Tapyrus Core version | Berkeley DB version |
+| --- | --- |
+| v0.7.1 and earlier | 4.8 |
+| v0.7.2 and later | 5.3 |
+
+A wallet written by Tapyrus Core v0.7.1 or earlier can be opened and upgraded by v0.7.2 or later. This only works in that one direction, not both: once a wallet has been opened by v0.7.2 or later, it can no longer be opened by v0.7.1 or earlier -- that older version will refuse to start against it, even after a clean shutdown of the newer version. To move a wallet back to v0.7.1 or earlier after it has been opened by a newer version, back up the wallet directory first, then either remove its `database` subdirectory before starting the older version, or start the older version with `-salvagewallet`.
+
 Package/version/hash/URL data above is copied from `depends/packages/*.mk` and `depends/hosts/darwin.mk` for convenience — it will drift if those files change without this table being updated too. Treat the `.mk` files as the source of truth.
 
 Building Qt also requires three small CMake scaffolding files (`depends/packages/qt_details.mk`) fetched directly from the `qt/qt5` GitHub repository rather than a release archive. They're part of that repo, not a standalone release artifact, so they aren't listed in the table above and don't need S3 mirroring.

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -18,7 +18,7 @@ These are the dependencies currently used by Tapyrus Core. You can find instruct
 
 | Package | Platform | Minimum tested | Version | File name | SHA256 | Download URL |
 | --- | --- | --- | --- | --- | --- | --- |
-| Berkeley DB | Wallet only | 4.8 | 4.8.30 | `db-4.8.30.NC.tar.gz` | `12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef` | [download.oracle.com](https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz) |
+| Berkeley DB | Wallet only | 5.3.28 | 5.3.28 | `db-5.3.28.NC.tar.gz` | `76a25560d9e52a198d37a31440fd07632b5f1f8f9f2b6d5438f4bc3e7c9013ef` | [download.oracle.com](https://download.oracle.com/berkeley-db/db-5.3.28.NC.tar.gz) |
 | Boost | | 1.81.0 | 1.92.0 | `boost_1_92_0.tar.gz` | `c4a3b310ddd2472416e091067166b0713be97c63f38c212c484ada022fd296ce` | [archives.boost.io](https://archives.boost.io/release/1.92.0/source/boost_1_92_0.tar.gz) |
 | Expat | Linux + GUI only | 2.4.8 | 2.8.3 | `expat-2.8.3.tar.xz` | `f6256df90c906773d344da084402b7d3e4f22ed41b1a59c989098a83d3ea0c85` | [github.com](https://github.com/libexpat/libexpat/releases/download/R_2_8_3/expat-2.8.3.tar.xz) |
 | fontconfig | Linux + GUI only | 2.16.0 | 2.16.0 | `fontconfig-2.16.0.tar.xz` | `6a33dc555cc9ba8b10caf7695878ef134eeb36d0af366041f639b1da9b6ed220` | [freedesktop.org](https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.16.0.tar.xz) |


### PR DESCRIPTION
Upgrade the wallet's Berkeley DB dependency from 4.8.30 to 5.3.28 across the depends build system, CI, and docs. The CMake version gate upgrade in in PR #459.  This PR moves what depends/ actually builds to 5.3, while keeping 4.8 usable for anyone with an existing system install (-DWITH_INCOMPATIBLE_BDB=ON remains the escape hatch for anything outside that range).

- depends/packages/bdb.mk: version, download URL, and sha256 bumped to 5.3.28; build target names updated to libdb_cxx-5.3.a/libdb-5.3.a (BDB's own LIBVERSION convention).
- depends/patches/bdb/5.3.28/clang_cxx_11.patch: regenerated against real 5.3.28 source — 5.3 nests everything under a new top-level src/ directory that 4.8 didn't have, so the patch's file paths needed updating (same atomic_init→atomic_init_db rename as before, just repathed).
- CI (daily-test.yml, weekly-heavy-tests.yml): updated libdb_cxx-4.8.a/libdb-4.8.a references to -5.3.a.
- Docs (dependencies.md, build-cmake.md, build-unix.md): 5.3 is now the recommended version; Ubuntu gets a direct libdb5.3-dev/libdb5.3++-dev package instead of the old bitcoin PPA; Fedora's unsuffixed libdb-devel already ships 5.3.28; 4.8 stays documented as supported (both share DB_BTREEVERSION 9. SO the same wallet file can be opened using a tapyrus_wallet using any version. However after a wallet is opened using bdb5.3, it can no longer be opened using bdb4.8) 
- contrib/install_db4.sh: kept as a 4.8-specific legacy helper (matches the docs' framing); fixed its trailing usage note, which still referenced pre-CMake ./configure flags, to the current cmake -DBerkeleyDB_ROOT=... invocation.
- Real native depends + CMake builds confirmed on both Linux (aarch64) and macOS (arm64): BDB 5.3.28 compiles, patches apply cleanly, tapyrusd links against it statically.