### PR TITLE
Fix rpc_pstt.py failures in the CI 

### DIFF
--- a/test/functional/rpc_pstt.py
+++ b/test/functional/rpc_pstt.py
@@ -159,6 +159,7 @@ class PSTTTest(BitcoinTestFramework):
         colorId = create_colored_transaction(2, 100, self.nodes[0])['color']
         self.sync_all()
         self.nodes[2].generate(1, self.signblockprivkey_wif)
+        self.sync_all()
 
         # Create and fund a raw tx for sending 10 TPC
         psttx1 = self.nodes[0].walletcreatefundedpstt([], {self.nodes[2].getnewaddress():10})['pstt']


### PR DESCRIPTION
cause: node2 mines without syncing, causing a chain fork and later on test failure while waiting for all nodes to synch the chain tip.
nodes[2].generate(1, ...) at line 161 had no sync_all()/sync_blocks() before nodes[0] mined again later in the test. 